### PR TITLE
Fix being unable to play cards after one side closes a run prompt

### DIFF
--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -205,10 +205,10 @@
 
 (defn clear-run-prompts
   [state]
-  (when-let* [runner-prompt (find-first #(= :run (:prompt-type %)) (-> @state :runner :prompt))
-              corp-prompt (find-first #(= :run (:prompt-type %)) (-> @state :corp :prompt))]
-             (remove-from-prompt-queue state :runner runner-prompt)
-             (remove-from-prompt-queue state :corp corp-prompt)))
+  (when-let* [runner-prompt (find-first #(= :run (:prompt-type %)) (-> @state :runner :prompt))]
+    (remove-from-prompt-queue state :runner runner-prompt))
+  (when-let* [corp-prompt (find-first #(= :run (:prompt-type %)) (-> @state :corp :prompt))]
+    (remove-from-prompt-queue state :corp corp-prompt)))
 
 (defn cancellable
   "Wraps a vector of prompt choices with a final 'Cancel' option. Optionally sorts the vector alphabetically,

--- a/test/clj/game/core/actions_test.clj
+++ b/test/clj/game/core/actions_test.clj
@@ -17,7 +17,7 @@
     (is (not (:run @state)) "Run ended")
     (take-credits state :runner)
     (is (nil? (get-in @state [:corp :prompt-state])) "Cleared the dummy run prompt at the end of the run")
-    (is (changed? [(:credits (get-corp)) 4]
+    (is (changed? [(:credit (get-corp)) 4]
                   (play-from-hand state :corp "Hedge Fund"))
         "Was able to play hedge fund")))
 

--- a/test/clj/game/core/actions_test.clj
+++ b/test/clj/game/core/actions_test.clj
@@ -5,6 +5,22 @@
    [game.core.card :refer :all]
    [game.test-framework :refer :all]))
 
+(deftest clearing-run-prompt-doesnt-brick-actions-later
+  (do-game
+    (new-game {:corp {:deck [] :hand [(qty "Hedge Fund" 5)]}})
+    (take-credits state :corp)
+    (run-on state :hq)
+    (core/command-parser state :runner {:user {:username "Runner"} :text "/close-prompt"})
+    (is (nil? (get-in @state [:runner :prompt-state])) "Cleared the dummy run prompt")
+    (is (get-in @state [:corp :prompt-state]) "The corp still has a dummy prompt though")
+    (run-jack-out state)
+    (is (not (:run @state)) "Run ended")
+    (take-credits state :runner)
+    (is (nil? (get-in @state [:corp :prompt-state])) "Cleared the dummy run prompt at the end of the run")
+    (is (changed? [(:credits (get-corp)) 4]
+                  (play-from-hand state :corp "Hedge Fund"))
+        "Was able to play hedge fund")))
+
 (deftest undo-turn
   (do-game
     (new-game)


### PR DESCRIPTION
So basically, when a run is made we add these dummy prompts of type `:run` into the prompt state, which are invisible and (basically) inert.

Then, when the run ends, we were calling 
```
(when-let* [runner-prompt ...
                     corp-prompt ...]
   (close-prompt runner-prompt ...)
   (close-prompt corp-prompt ...))
```

Which looks cool, but also means that if:
1) the corp closed the run prompt
or
2) the runner closed the run prompt
the prompts weren't getting cleared for the other side.

Until this is applied, the remedy is just for the affected player to shoot out a `/close-prompt` (or multiple, if the runner did this multiple runs in the same turn).

Closes #7593