### PR TITLE
remove tournament hash functionality

### DIFF
--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -8,7 +8,7 @@
    [monger.db]
    [monger.operators :refer :all]
    [tasks.setup :refer [connect disconnect]]
-   [web.decks :refer [hash-deck prepare-deck-for-db update-deck]]
+   [web.decks :refer [prepare-deck-for-db update-deck]]
    [web.mongodb :refer [->object-id]]
    [web.nrdb :refer [download-public-decklist]]
    [web.user :refer [create-user]]
@@ -89,11 +89,9 @@
                        :date (inst/now)
                        :format "standard")
            updated-deck (update-deck deck)
-           status (calculate-deck-status updated-deck)
-           deck-hash (hash-deck updated-deck)]
+           status (calculate-deck-status updated-deck)]
        (if-not (empty? (:cards deck))
          {:deck deck
-          :deck-hash deck-hash
           :status status}
          (throw (Exception. "A deck contains no cards. Did you forget to run `lein fetch`?")))))))
 
@@ -108,8 +106,8 @@
 
 (defn- create-sample-deck
   [username decks]
-  (let [{deck :deck, deck-hash :deck-hash, status :status} (rand-nth decks)]
-    (prepare-deck-for-db deck username status deck-hash)))
+  (let [{deck :deck, status :status} (rand-nth decks)]
+    (prepare-deck-for-db deck username status)))
 
 (defn- create-sample-game-log
   [username]

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -32,12 +32,11 @@
       (update :identity #(@all-cards (:title %)))))
 
 (defn prepare-deck-for-db
-  [deck username status deck-hash]
+  [deck username status]
   (-> deck
       (update :cards (fn [cards] (mapv #(select-keys % [:qty :card :id :art]) cards)))
       (assoc :username username
-             :status status
-             :hash deck-hash)))
+             :status status)))
 
 (defn- deck-locked?
   [db deck-id]
@@ -50,19 +49,6 @@
   (let [salt (byte-array (map byte (slugify deck-name)))]
     (if (empty? salt) (byte-array (map byte "default-salt")) salt)))
 
-(defn hash-deck
-  [deck]
-  (let [check-deck (-> deck
-                       (update :cards #(map update-card %))
-                       (update :identity #(get @all-cards (:title %))))
-        id (-> deck :identity :title)
-        sorted-cards (sort-by #(:code (:card %)) (:cards check-deck))
-        decklist (str/join (for [entry sorted-cards]
-                           (str (:qty entry) (:code (:card entry)))))
-        deckstr (str id decklist)
-        salt (make-salt (:name deck))]
-    (last (str/split (pbkdf2/encrypt deckstr 100000 "HMAC-SHA1" salt) #"\$"))))
-
 (defn decks-create-handler
   [{db :system/db
     {username :username} :user
@@ -70,8 +56,7 @@
   (if (and username deck)
     (let [updated-deck (update-deck deck)
           status (calculate-deck-status updated-deck)
-          deck-hash (hash-deck updated-deck)
-          deck (prepare-deck-for-db deck username status deck-hash)]
+          deck (prepare-deck-for-db deck username status)]
       (response 200 (mc/insert-and-return db "decks" deck)))
     (response 401 {:message "Unauthorized"})))
 
@@ -82,8 +67,7 @@
   (if (and username deck)
     (let [updated-deck (update-deck deck)
           status (calculate-deck-status updated-deck)
-          deck-hash (hash-deck updated-deck)
-          deck (prepare-deck-for-db deck username status deck-hash)]
+          deck (prepare-deck-for-db deck username status)]
       (if-let [deck-id (:_id deck)]
         (if-not (deck-locked? db deck-id)
           (if (:identity deck)
@@ -126,8 +110,7 @@
                              :format "standard")
               updated-deck (update-deck db-deck)
               status (calculate-deck-status updated-deck)
-              deck-hash (hash-deck updated-deck)
-              deck (prepare-deck-for-db db-deck username status deck-hash)]
+              deck (prepare-deck-for-db db-deck username status)]
           (mc/insert db "decks" deck)
           (ws/broadcast-to! [uid] :decks/import-success "Imported"))
         (ws/broadcast-to! [uid] :decks/import-failure "Failed to parse imported deck.")))

--- a/src/clj/web/diffs.clj
+++ b/src/clj/web/diffs.clj
@@ -21,7 +21,7 @@
             deck (-> deck
                      (select-keys
                        (if started
-                         [:name :date :identity :hash]
+                         [:name :date :identity]
                          [:name :date]))
                      (assoc :_id (str _id) :status status))]
         (assoc p :deck deck))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -86,7 +86,7 @@
 
 (defn strip-deck [player]
   (-> player
-      (update :deck select-keys [:_id :identity :name :hash])
+      (update :deck select-keys [:_id :identity :name])
       (update-in [:deck :_id] str)
       (update-in [:deck :identity] select-keys [:title :faction])))
 

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -80,7 +80,7 @@
           deck (-> deck
                    (select-keys
                      (if (:started lobby)
-                       [:name :date :identity :hash]
+                       [:name :date :identity]
                        [:name :date]))
                    (assoc :_id (str _id) :status status))]
       (assoc player :deck deck))

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -768,8 +768,7 @@
              [:span.invalid " (" (tr [:deck-builder.max "maximum"]) " " (inc min-point) ")"])]))
       (when (validator/format-point-limit (:format deck))
         [:div [deck-points-span deck]])
-      [:div [deck-status-span deck true true false]]
-      (when (:hash deck) [:div (tr [:deck-builder.hash "Tournament hash"]) ": " (:hash deck)])]]))
+      [:div [deck-status-span deck true true false]]]]))
 
 (defn decklist-contents
   [s deck cards]


### PR DESCRIPTION
As per the discussions on slack, this feature isn't used for anything, since we ended up abandoning the tournament scheduling feature. It also seems to be eating up a bunch of CPU time (7.5% load) on the laggy CPU samples.