### PR TITLE
Remove nested state histories being stored in click-states and turn-state

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -33,8 +33,8 @@
   "Update :click-states to hold latest 4 moments before performing actions."
   [state ability]
   (when (:action ability)
-    (let [state' (dissoc @state :log :history)
-          click-states (vec (take-last 4 (conj (:click-states state') state')))]
+    (let [state' (dissoc @state :log :history :click-states :turn-state)
+          click-states (vec (take-last 4 (conj (:click-states @state) state')))]
       (swap! state assoc :click-states click-states))))
 
 ;;; Neutral actions

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -59,7 +59,7 @@
   ; Functions to set up state for undo-turn functionality
   (doseq [s [:runner :corp]] (swap! state dissoc-in [s :undo-turn]))
   (swap! state assoc :click-states [])
-  (swap! state assoc :turn-state (dissoc @state :log :turn-state))
+  (swap! state assoc :turn-state (dissoc @state :log :history :turn-state))
 
   (when (= side :corp)
     (swap! state update-in [:turn] inc))


### PR DESCRIPTION
This updates the mechanisms for storing and undoing clicks / turns so that the stored click/turn state does not also include other snapshots of previous states

This should hopefully reduce the worst case for the state tree (usually click 4 or 5) from storing up to like 16 (maybe even 32?) copies of the state across all saved state snapshots to max ever 6 states (current, start of turn, 4 clicks of history).