### PR TITLE
don't share stats until the game is over

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -452,6 +452,7 @@
   (-> @state
       (update-in [:corp :user] user-summary)
       (update-in [:runner :user] user-summary)
+      (assoc :stats (when (:winner @state) (:stats @state)))
       (assoc :run (run-summary state))
       (assoc :encounters (encounters-summary state))
       (select-non-nil-keys state-keys)))


### PR DESCRIPTION
This one seems like a trivial change, but it means there's one more data structure that doesn't need to get diff'd constantly