### PR TITLE
mark freshly revealed archives cards as new

### DIFF
--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -1296,7 +1296,10 @@
   [state side server]
   (when (= :archives (get-server-type (first server)))
     (doseq [card (get-in @state [:corp :discard])]
-      (update! state side (assoc card :seen true)))))
+      ;; this lets us distinguish the most freshly revealed cards from archives
+      (if (:seen card)
+        (update! state side (dissoc card :new))
+        (update! state side (assoc card :seen true :new true))))))
 
 (defn clean-access-args
   [{:keys [access-first] :as args}]

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -64,7 +64,7 @@
   (when (= side :corp)
     (swap! state update-in [:turn] inc))
 
-  (doseq [c (filter :new (all-installed-and-scored state side))]
+  (doseq [c (filter :new (concat (all-installed-and-scored state side) (get-in @state [side :discard])))]
     (update! state side (dissoc c :new)))
 
   (swap! state assoc :active-player side :per-turn nil :end-turn false)


### PR DESCRIPTION
Whenever you breach archives and flip cards faceup, the newly flipped cards will be marked as new, and the already flipped cards will be marked as no-longer new.

We also have to clear the newness from them between turns.

[fresh chives.webm](https://github.com/user-attachments/assets/1a442017-6fa6-42df-91a0-ef4886229c6c)

Closes #4537