### PR TITLE
Fix missing 4 nbsp before the set name in cardbrowser

### DIFF
--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -14,11 +14,11 @@
     (tr [kw "Unknown"])))
 
 (defn tr-string-s [prefix s]
-  (let [s (-> (or s "")
-              (str/replace "&nbsp;" ""))
-        side (slugify s)
+  (let [s-trim (-> (or s "")
+              (str/replace "&nbsp;&nbsp;&nbsp;&nbsp;" ""))
+        side (slugify s-trim)
         kw (keyword (str prefix "." side))]
-    (tr [kw s])))
+    (str/replace (or s "") s-trim (tr [kw s-trim]))))
 
 (defn tr-type [s] (tr-string "card-type" s))
 (defn tr-side [s] (tr-string "side" s))


### PR DESCRIPTION
After translation, 4 spaces were lost.
now
![current](https://github.com/user-attachments/assets/089d6c16-099c-460f-bd8e-237297703bc8)
should be
![fix](https://github.com/user-attachments/assets/51d52f37-0591-4a73-87c8-303b7bb59981)

Perhaps there is a better way  to fix, here is the solution I come up with.