### PR TITLE
don't prompt when checking card reqs for installability status

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -552,7 +552,8 @@
                 :req (req (some #(and (program? %)
                                       (runner-can-pay-and-install?
                                         state side
-                                        (assoc eid :source card :source-type :runner-install) % nil))
+                                        (assoc eid :source card :source-type :runner-install) %
+                                        {:no-toast true}))
                                 (:discard runner)))
                 :choices {:req (req (and (program? target)
                                          (in-discard? target)
@@ -1026,7 +1027,8 @@
                                                                             (runner-can-pay-and-install?
                                                                               state side
                                                                               (assoc eid :source card :source-type :runner-install)
-                                                                              % {:cost-bonus -2}))
+                                                                              % {:cost-bonus -2
+                                                                                 :no-toast true}))
                                                                       set-aside-cards)
                                                               ["Done"]))
                                               :effect (req (if (= "Done" target)
@@ -2111,7 +2113,8 @@
                                       (runner-can-pay-and-install?
                                         state side
                                         (assoc eid :source card :source-type :runner-install)
-                                        % {:cost-bonus -3}))
+                                        % {:cost-bonus -3
+                                           :no-toast true}))
                                 (:discard runner)))
                 :cost [(->c :trash-can)]
                 :msg "install a program"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -342,7 +342,7 @@
                                      (filter #(and (program? %)
                                                    (runner-can-pay-and-install?
                                                      state side
-                                                     (assoc eid :source-type :runner-install) % false))
+                                                     (assoc eid :source-type :runner-install) % {:no-toast true}))
                                              (:hand runner))))
                      :msg (msg "install " (:title target) " from the grip")
                      :effect (req (wait-for (runner-install state :runner

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -110,7 +110,7 @@
                             (runner-can-pay-and-install?
                               state :runner
                               (assoc eid :source card :source-type :runner-install)
-                              card nil)))
+                              card {:no-toast true})))
              :effect (effect
                        (continue-ability
                          {:req (req (and (not-any? #(and (= title (:title %))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2685,7 +2685,7 @@
                                     (has-subtype? % "Virtual")))
                            (runner-can-pay-and-install?
                              state side
-                             (assoc eid :source card :source-type :runner-install) % nil))
+                             (assoc eid :source card :source-type :runner-install) % {:no-toast true}))
                      (:discard runner)))
      :cost [(->c :click 1) (->c :trash-can) (->c :trash-from-hand 1)]
      :msg "install a program, piece of hardware, or Virtual resource from the heap"
@@ -3066,7 +3066,8 @@
                                              state side
                                              (assoc eid :source card :source-type :runner-install)
                                              (get-card state %)
-                                             {:cost-bonus -1}))
+                                             {:cost-bonus -1
+                                              :no-toast true}))
                                 (seq (:hosted card))))
                 :effect (req (set-aside state side eid (:hosted card))
                              (let [set-aside-cards (get-set-aside state side eid)]


### PR DESCRIPTION
Closes #7433
Closes #7608

Essentially, simulchip was checking the req for every single program in the discard, and queuing up prompts for them, on every frame, and then the queue was getting pushed when another prompt was pushed in a regular (non-req) game function (ie public trail).

And I guess getting 100+ prompts at once is too much for our frontend.

Anyway, I don't have a clue how to unit test this one, but I'm 99% sure this fixes it.