### PR TITLE
Name derez source

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -703,7 +703,7 @@
     :choices {:card #(rezzed? %)}
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (effect (derez target))}})
+    :effect (effect (derez target {:source-card card}))}})
 
 (defcard "Eden Fragment"
   {:static-abilities [{:type :ignore-install-cost
@@ -1216,7 +1216,7 @@
                                          :min derez-count}
                                :msg (msg "derez " (enumerate-str (map #(card-str state %) targets)))
                                :effect (req (doseq [t targets]
-                                              (derez state side t)))}
+                                              (derez state side t {:no-msg true})))}
                               card nil)))})
           (ice-free-rez [state side targets card zone eid]
             (if (zero? (count targets))
@@ -1955,7 +1955,7 @@
                                            [{:event (if (= side :corp) :corp-turn-ends :runner-turn-ends)
                                              :unregister-once-resolved true
                                              :duration :end-of-turn
-                                             :effect (effect (derez c))}])
+                                             :effect (effect (derez c {:source-card card}))}])
                                          (effect-completed state side eid))))}]})
 
 (defcard "Sentinel Defense Program"
@@ -2078,7 +2078,7 @@
                          :once :per-turn
                          :msg (msg "derez " (card-str state target) " to gain 1 [Credits]")
                          :async true
-                         :effect (effect (derez target)
+                         :effect (effect (derez target {:no-msg true})
                                          (gain-credits eid 1))})
                       card nil)))}
             {:event :derez

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2844,7 +2844,7 @@
                :prompt "Derez a card"
                :choices {:card #(and (installed? %)
                                      (rezzed? %))}
-               :effect (req (derez state side target)
+               :effect (req (derez state side target {:source-card card})
                             (continue-ability state side (derez-card (dec advancements)) card nil))}))]
     {:advanceable :always
      :abilities [{:label "Derez 1 card for each advancement token"
@@ -3143,20 +3143,20 @@
                                         ((constantly false) (toast state :corp "Cannot score due to Warm Reception." "Warning"))
                                         true)))
                                   (effect-completed state side eid))))}
-        derez {:label "Derez another card (start of turn)"
-               :req (req unprotected)
-               :prompt "Choose another card to derez"
-               :choices {:not-self true
-                         :card #(rezzed? %)}
-               :msg (msg "derez itself to derez " (card-str state target))
-               :effect (effect (derez card)
-                               (derez target))}]
+        derez-abi {:label "Derez another card (start of turn)"
+                   :req (req unprotected)
+                   :prompt "Choose another card to derez"
+                   :choices {:not-self true
+                             :card #(rezzed? %)}
+                   :msg (msg "derez itself to derez " (card-str state target))
+                   :effect (effect (derez card {:source-card card})
+                                   (derez target {:source-card card}))}]
     {:derezzed-events [corp-rez-toast]
      :events [{:event :corp-turn-begins
                :interactive (req true)
                :async true
                :effect (req (wait-for (resolve-ability state side install card nil)
-                                      (continue-ability state side derez card nil)))}]}))
+                                      (continue-ability state side derez-abi card nil)))}]}))
 
 (defcard "Watchdog"
   (letfn [(not-triggered? [state]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -423,8 +423,7 @@
                                                                              (:cid %))
                                                                           (<= (second c) target)))
                                                              affordable-ice))}
-                                 :msg (msg "derez " (card-str state target))
-                                 :effect (effect (derez target))}
+                                 :effect (effect (derez target {:source-card card}))}
                                 card nil))}
              card nil)))}})
 
@@ -1265,10 +1264,9 @@
   {:on-play
    {:req (req (some #{:hq} (:successful-run runner-reg)))
     :change-in-game-state (req (some (every-pred ice? rezzed?) (all-installed state :corp)))
-    :msg (msg "derez " (:title target))
     :choices {:card #(and (ice? %)
                           (rezzed? %))}
-    :effect (effect (derez target))}})
+    :effect (effect (derez target {:source-card card}))}})
 
 (defcard "Emergent Creativity"
   (letfn [(ec [trash-cost to-trash]
@@ -1413,7 +1411,7 @@
                           (ice? %))}
     :msg (msg "derez " (enumerate-str (map :title targets)))
     :effect (req (doseq [c targets]
-                   (derez state side c)))}})
+                   (derez state side c {:no-msg true})))}})
 
 (defcard "Exploratory Romp"
   {:makes-run true
@@ -2347,7 +2345,7 @@
                                                           (get-card state card))))
                                                 (filter rezzed?))]
                             (doseq [ice rezzed-ice]
-                              (derez state :runner ice))
+                              (derez state :runner ice {:no-msg true}))
                             (when (seq rezzed-ice)
                               (system-msg state :runner (str "uses " (:title card) " to derez " (enumerate-str (map :title rezzed-ice)))))))}]})
 
@@ -4239,7 +4237,6 @@
                           {:prompt "Choose a piece of ice protecting this server to derez"
                            :waiting-prompt true
                            :choices {:req (req (some #{target} rezzed-targets))}
-                           :msg (msg "derez " (card-str state target))
                            :async true
                            :effect
                            (req (let [chosen-ice target]
@@ -4258,7 +4255,7 @@
                                                      (req 
                                                        (system-msg state :corp (str "rezzes " (card-str state chosen-ice) ", ignoring all costs"))
                                                        (rez state :corp eid chosen-ice {:ignore-cost :all-costs}))}}}])
-                                  (derez state side target)
+                                  (derez state side target {:source-card card})
                                   (effect-completed state side eid)))}
                           card nil)
                         (effect-completed state side eid))))}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -467,8 +467,7 @@
               :yes-ability
               {:async true
                :cost [(->c :remove-from-game)]
-               :msg (msg "derez " (card-str state target))
-               :effect (effect (derez target)
+               :effect (effect (derez target {:source-card card})
                                (effect-completed eid))}}}]})
 
 (defcard "Carnivore"
@@ -1960,11 +1959,11 @@
                 :effect (effect (continue-ability
                                   (let [spent-credits target]
                                     {:choices {:card #(and (ice? %)
-                                                          (= :this-turn (:rezzed %))
-                                                          (<= (:cost %) target))}
-                                    :effect (effect (derez target))
-                                    :msg (msg "spend " spent-credits "[Credits] and derez " (:title target))})
-                                    card nil))}]})
+                                                           (= :this-turn (:rezzed %))
+                                                           (<= (:cost %) target))}
+                                     :effect (effect (derez target {:source-card card}))
+                                     :msg (msg "spend " spent-credits "[Credits] and derez " (:title target))})
+                                  card nil))}]})
 
 (defcard "Security Chip"
   {:abilities [{:label "Add [Link] strength to a non-Cloud icebreaker until the end of the run"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1139,7 +1139,7 @@
                                  (wait-for (resolve-ability state :runner
                                                             (make-eid state eid)
                                                             (offer-jack-out) card nil)
-                                           (derez state side card)
+                                           (derez state side card {:source-card card})
                                            (encounter-ends state side eid))))}]})
 
 (defcard "Changeling"
@@ -1176,10 +1176,10 @@
                        :value (req (:subtype-target card))}]
    :events [{:event :runner-turn-ends
              :req (req (rezzed? card))
-             :effect (effect (derez :corp card))}
+             :effect (effect (derez :corp card {:source-card card}))}
             {:event :corp-turn-ends
              :req (req (rezzed? card))
-             :effect (effect (derez :corp card))}]
+             :effect (effect (derez :corp card {:source-card card}))}]
    :subroutines [end-the-run]})
 
 (defcard "Chiyashi"
@@ -2005,7 +2005,7 @@
             :waiting-prompt true
             :cancel-effect (effect (system-msg :corp (str "declines to use " (:title card)))
                                    (effect-completed eid))
-            :effect (effect (derez target)
+            :effect (effect (derez target {:source-card card})
                             (system-msg (str "prevents the runner from using printed abilities on bioroid ice for the rest of the turn"))
                             (register-lingering-effect
                              card
@@ -2285,7 +2285,7 @@
                                   :duration :end-of-run
                                   :async true
                                   :msg (req (msg "derez " (:title new-ice) " and trash itself"))
-                                  :effect (effect (derez new-ice)
+                                  :effect (effect (derez new-ice {:no-msg true})
                                                   (trash eid card {:cause :subroutine}))}]))))}]})
 
 (defcard "Hudson 1.0"
@@ -2765,10 +2765,10 @@
                          :value (req (:subtype-target card))}]
      :events [{:event :runner-turn-ends
                :req (req (rezzed? card))
-               :effect (effect (derez :corp card))}
+               :effect (effect (derez :corp card {:source-card card}))}
               {:event :corp-turn-ends
                :req (req (rezzed? card))
-               :effect (effect (derez :corp card))}]
+               :effect (effect (derez :corp card {:source-card card}))}]
      :subroutines [{:label "(Code Gate) Force the Runner to lose [Click] and 1 [Credit]"
                     :msg "force the Runner to lose [Click] and 1 [Credit]"
                     :req (req (has-subtype? card "Code Gate"))
@@ -3072,7 +3072,7 @@
              :async true
              :req (req (and (same-card? card (:ice context))
                             (:broken (first (filter :printed (:subroutines (:ice context)))))))
-             :msg "make the Runner continue the run on Archives. Mirāju is derezzed"
+             :msg "make the Runner continue the run on Archives"
              :effect (req (when (and (:run @state)
                                      (= 1 (count (:encounters @state)))
                                      (not= :success (:phase (:run @state))))
@@ -3081,7 +3081,7 @@
                                                      (make-eid state eid)
                                                      (offer-jack-out)
                                                      card nil)
-                                    (derez state side card)
+                                    (derez state side card {:source-card card})
                                     (effect-completed state side eid)))}]
    :subroutines [{:async true
                   :label "Draw 1 card, then shuffle 1 card from HQ into R&D"
@@ -4120,7 +4120,7 @@
   {:on-rez {:trace {:base 2
                     :msg "keep TMI rezzed"
                     :label "Keep TMI rezzed"
-                    :unsuccessful {:effect (effect (derez card))}}}
+                    :unsuccessful {:effect (effect (derez card {:source-card card}))}}}
    :subroutines [end-the-run]})
 
 (defcard "Tollbooth"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -437,7 +437,7 @@
              :effect (effect (system-msg :corp
                                          (str "derezzes " (:title (:ice context))
                                               " and trashes Bioroid Efficiency Research"))
-                             (derez :corp (:ice context))
+                             (derez :corp (:ice context) {:source-card card})
                              (trash :corp eid card {:unpreventable true :cause-card card}))}]})
 
 (defcard "Biotic Labor"
@@ -815,7 +815,7 @@
     :change-in-game-state (req (seq (all-installed state :corp)))
     :async true
     :effect (req (doseq [c targets]
-                   (derez state side c))
+                   (derez state side c {:source-card card}))
                  (let [discount (* -3 (count targets))]
                    (continue-ability
                      state side

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -320,8 +320,7 @@
                                    (rezzed? current-ice)
                                    (has-subtype? current-ice ice-type)
                                    (all-subs-broken-by-card? current-ice card)))
-                    :msg (msg "derez " (:title current-ice))
-                    :effect (effect (derez current-ice))}]})))
+                    :effect (effect (derez current-ice {:source-card card}))}]})))
 
 (defn- trash-to-bypass
   "Trash to bypass current ice
@@ -996,8 +995,7 @@
                                (all-subs-broken? current-ice)))
                 :label "derez an ice"
                 :cost [(->c :trash-can)]
-                :msg (msg "derez " (:title current-ice))
-                :effect (effect (derez current-ice))}]})
+                :effect (effect (derez current-ice {:source-card card}))}]})
 
 (defcard "Crowbar"
   (break-and-enter "Code Gate"))
@@ -1461,8 +1459,7 @@
                                  :cost [(->c :credit 6)]
                                  :req (req (and (get-current-encounter state)
                                                 (has-subtype? current-ice "Sentry")))
-                                 :msg (msg "derez " (:title current-ice))
-                                 :effect (effect (derez current-ice))}
+                                 :effect (effect (derez current-ice {:source-card card}))}
                                 (strength-pump 1 1)]}))
 
 (defcard "Flux Capacitor"
@@ -3240,7 +3237,7 @@
   (let [action (req (add-counter state side card :virus 1)
                     (when (and (rezzed? (get-card state (:host card)))
                                (<= 3 (get-virus-counters state (get-card state card))))
-                      (derez state side (get-card state (:host card)))))]
+                      (derez state side (get-card state (:host card)) {:source-card card})))]
     {:implementation "[Erratum] Program: Virus - Trojan"
      :hosting {:req (req (and (ice? target)
                               (installed? target)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -434,7 +434,7 @@
                                (<= (get-strength current-ice) (get-counters (get-card state card) :power))))
                 :cost [(->c :trash-can)]
                 :async true
-                :effect (effect (derez current-ice)
+                :effect (effect (derez current-ice {:source-card card})
                                 (gain-tags eid 1))}]})
 
 (defcard "Bank Job"
@@ -816,7 +816,7 @@
                     :async true
                     :effect (req (wait-for (trash state side card {:cause-card card})
                                            (when-not (get-card state card)
-                                             (derez state :runner (:card context))
+                                             (derez state :runner (:card context) {:no-msg true})
                                              (register-turn-flag!
                                                state side card :can-rez
                                                (fn [state _ card]
@@ -2117,9 +2117,10 @@
                 :choices {:card #(and (ice? %)
                                       (rezzed? %)
                                       (is-remote? (second (get-zone %))))}
-                :msg "derez a piece of ice protecting a remote server"
+                :label "Derez a piece of ice protecting a remote server"
+                :msg (msg "derez " (card-str state target))
                 :cost [(->c :trash-can)]
-                :effect (effect (derez target))}]})
+                :effect (effect (derez target {:no-msg true}))}]})
 
 (defcard "Miss Bones"
   {:data {:counter {:credit 12}}
@@ -2183,7 +2184,7 @@
                 :choices {:card #(and (corp? %)
                                       (not (agenda? %))
                                       (rezzed? %))}
-                :effect (effect (derez target))}
+                :effect (effect (derez target {:source-card card}))}
    :uninstall
    (effect
      (continue-ability

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -345,7 +345,7 @@
                                                                  (not (same-card? % rezzed-card)))}
                                            :async true
                                            :msg (msg "derez " (card-str state target) " to give " (card-str state rezzed-card) " +3 strength for the remainder of the run")
-                                           :effect (req (derez state side (get-card state target))
+                                           :effect (req (derez state side (get-card state target) {:no-msg true})
                                                         (pump-ice state side rezzed-card 3 :end-of-run)
                                                         (effect-completed state side eid))}}}
                            card nil)))}]})

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -131,16 +131,21 @@
 ;; TODO: make async
 (defn derez
   "Derez a corp card."
-  [state side card]
-  (let [card (get-card state card)]
-    (system-msg state side (str "derezzes " (:title card)))
-    (unregister-events state side card)
-    (update! state :corp (deactivate state :corp card true))
-    (let [cdef (card-def card)]
-      (when-let [derez-effect (:derez-effect cdef)]
-        (resolve-ability state side derez-effect (get-card state card) nil))
-      (when-let [derezzed-events (:derezzed-events cdef)]
-        (register-events state side card (map #(assoc % :condition :derezzed) derezzed-events))))
-    (unregister-static-abilities state side card)
-    (update-disabled-cards state)
-    (trigger-event state side :derez {:card card :side side})))
+  ([state side card] (derez state side card nil))
+  ([state side card {:keys [source-card no-msg] :as args}]
+   (let [card (get-card state card)]
+     (when-not no-msg
+       (system-msg state side (str (if source-card
+                                     (str "uses " (:title source-card) " to derez ")
+                                     "derezzes ")
+                                   (:title card))))
+     (unregister-events state side card)
+     (update! state :corp (deactivate state :corp card true))
+     (let [cdef (card-def card)]
+       (when-let [derez-effect (:derez-effect cdef)]
+         (resolve-ability state side derez-effect (get-card state card) nil))
+       (when-let [derezzed-events (:derezzed-events cdef)]
+         (register-events state side card (map #(assoc % :condition :derezzed) derezzed-events))))
+     (unregister-static-abilities state side card)
+     (update-disabled-cards state)
+     (trigger-event state side :derez {:card card :side side}))))


### PR DESCRIPTION
I adjusted the derez function to optionally take a source card, or a request to not display a log message.

I cleaned up a lot of the derez messages so they don't double print (once from the function, once from the card msg), and so they refer to the source cards where appropriate.

Closes #7609

![context-aware-derez](https://github.com/user-attachments/assets/56b6b717-9b3e-4ef2-8070-b871e43f59c4)