### PR TITLE
Score only during your turn

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2122,7 +2122,7 @@
                               (in-hand? target)))}
      :msg (msg "score " (:title target))
      :async true
-     :effect (effect (score eid target {:no-req true}))}))
+     :effect (effect (score eid target {:no-req true :ignore-turn true}))}))
 
 (defcard "Political Dealings"
   (letfn [(pdhelper [agendas]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -634,8 +634,8 @@
 (defn score
   "Score an agenda."
   ([state side eid card] (score state side eid card nil))
-  ([state side eid card {:keys [no-req]}]
-   (if-not (can-score? state side card {:no-req no-req})
+  ([state side eid card {:keys [no-req ignore-turn]}]
+   (if-not (can-score? state side card {:no-req no-req :ignore-turn ignore-turn})
      (effect-completed state side eid)
      (let [cost (score-additional-cost-bonus state side card)
            cost-strs (build-cost-string cost)

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -1,6 +1,7 @@
 (ns game.core.commands
   (:require
    [clojure.string :as string]
+   [game.core.actions :refer [score]]
    [game.core.board :refer [all-installed server->zone]]
    [game.core.card :refer [agenda? can-be-advanced? corp? get-card
                            has-subtype? ice? in-hand? installed? rezzed? runner?]]
@@ -293,6 +294,19 @@
     ["Done"]
     identity))
 
+(defn command-score
+  [state side]
+  (when (= :corp side)
+    (resolve-ability
+     state side
+     {:prompt "Choose an agenda to score"
+      :choices {:req (req (and (agenda? target)
+                               (or (installed? target)
+                                   (in-hand? target))))}
+      :msg (msg "score " (card-str state target {:visible true}) ", ignoring all restrictions")
+      :effect (effect (score eid target {:no-req true :ignore-turn true}))}
+     (make-card {:title "the '/score' command"}) nil)))
+
 (defn command-summon
   [state side args]
   (let [card-name (string/join " " args)]
@@ -499,6 +513,7 @@
         "/sabotage"   #(when (= %2 :runner) (resolve-ability %1 %2 (sabotage-ability (constrain-value value 0 1000)) nil nil))
         "/save-replay" command-save-replay
         "/set-mark"   #(command-set-mark %1 %2 args)
+        "/score"      command-score
         "/show-hand" #(resolve-ability %1 %2
                                          {:effect (effect (system-msg (str
                                                                        (if (= :corp %2)

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -275,8 +275,10 @@
 (defn can-score?
   "Checks if the corp can score a given card"
   ([state side card] (can-score? state side card nil))
-  ([state side card {:keys [no-req]}]
+  ([state side card {:keys [no-req ignore-turn]}]
    (and
+     (or (= (:active-player @state) :corp) ignore-turn)
+     ;; Cannot (normally) score agendas outside of your turn
      (agenda? card)
      ;; The Agenda is not already scored
      (not (in-scored? card))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -72,8 +72,8 @@
 (defn action-list
   [{:keys [type zone rezzed advanceable
            advancementcost current-advancement-requirement] :as card}]
-  (let [active-player (r/cursor game-state [:active-player])
-        side (r/cursor game-state [:side])]
+  (r/with-let [active-player (r/cursor game-state [:active-player])
+               side (r/cursor game-state [:side])]
     (cond->> []
       ;; advance
       (or (and (= type "Agenda")

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -72,33 +72,36 @@
 (defn action-list
   [{:keys [type zone rezzed advanceable
            advancementcost current-advancement-requirement] :as card}]
-  (cond->> []
-    ;; advance
-    (or (and (= type "Agenda")
-             (#{"servers" "onhost"} (first zone)))
-        (= advanceable "always")
-        (and rezzed
-             (= advanceable "while-rezzed"))
-        (and (not rezzed)
-             (= advanceable "while-unrezzed")))
-    (cons "advance")
-    ;; score
-    (and (= type "Agenda")
-         (#{"servers" "onhost"} (first zone))
-         (>= (get-counters card :advancement)
-             (or current-advancement-requirement advancementcost)))
-    (cons "score")
-    ;; trash
-    (#{"ICE" "Program"} type)
-    (cons "trash")
-    ;; rez
-    (and (#{"Asset" "ICE" "Upgrade"} type)
-         (not rezzed))
-    (cons "rez")
-    ;; derez
-    (and (#{"Asset" "ICE" "Upgrade"} type)
-         rezzed)
-    (cons "derez")))
+  (let [active-player (r/cursor game-state [:active-player])
+        side (r/cursor game-state [:side])]
+    (cond->> []
+      ;; advance
+      (or (and (= type "Agenda")
+               (#{"servers" "onhost"} (first zone)))
+          (= advanceable "always")
+          (and rezzed
+               (= advanceable "while-rezzed"))
+          (and (not rezzed)
+               (= advanceable "while-unrezzed")))
+      (cons "advance")
+      ;; score
+      (and (= type "Agenda")
+           (#{"servers" "onhost"} (first zone))
+           (= (keyword @active-player) @side)
+           (>= (get-counters card :advancement)
+               (or current-advancement-requirement advancementcost)))
+      (cons "score")
+      ;; trash
+      (#{"ICE" "Program"} type)
+      (cons "trash")
+      ;; rez
+      (and (#{"Asset" "ICE" "Upgrade"} type)
+           (not rezzed))
+      (cons "rez")
+      ;; derez
+      (and (#{"Asset" "ICE" "Upgrade"} type)
+           rezzed)
+      (cons "derez"))))
 
 (def click-card-keys
   [:cid :side :host :type :zone :ghost])


### PR DESCRIPTION
Closes #6888

I also added a command to manually score agendas so players have a way to fix mistakes or repair the gamestate without needing to rewind the turn.