### PR TITLE
close the 'start of game' window whenever you start your turn

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1691,7 +1691,9 @@
        [:button {:on-click #(send-command "end-turn")}
         (tr [:game.end-turn "End Turn"])])
      (when @end-turn
-       [:button {:on-click #(send-command "start-turn")}
+       [:button {:on-click #(do
+                              (swap! app-state assoc :start-shown true)
+                              (send-command "start-turn"))}
         (tr [:game.start-turn "Start Turn"])]))
    (when (and (= (keyword @active-player) side)
               (or @runner-phase-12 @corp-phase-12))


### PR DESCRIPTION
This is a bit frivolous, because there's a little X in the corner you can close the window with anyway, but it is what it is.

Whenever you click 'start turn', the window will be closed if it was open.

Closes #4216