### PR TITLE
muse doesnt pretend to shuffle

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2250,7 +2250,9 @@
           (muse-abi [where]
             {:prompt "Choose a non-daemon program"
              :msg (msg (if (= target "Done")
-                         "shuffle the stack"
+                         (if (= :deck where)
+                           "shuffle the stack"
+                           "do nothing")
                          (str "install " (:title target))))
              :choices (req (concat
                              (->> (where runner)


### PR DESCRIPTION
Turns out I was wrong, it was just an error with the `msg` for the card, and not the behaviour.

Closes #7629