### PR TITLE
Runner install msg cleanup

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -559,8 +559,9 @@
                                          (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                    [(->c :credit (install-cost state side target))])))}
                 :cost [(->c :trash-can)]
-                :msg (msg "install " (:title target))
-                :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]})
+                :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                         :display-origin true
+                                                                                                                         :include-cost-from-eid eid}}))}]})
 
 (defcard "Comet"
   {:static-abilities [(mu+ 1)]
@@ -1005,7 +1006,7 @@
                   :waiting-prompt true
                   :effect (req (set-aside state side eid (take 6 (:deck runner)))
                                (let [set-aside-cards (sort-by :title (get-set-aside state side eid))]
-                                 (system-msg state side (str "uses " (get-title card)
+                                 (system-msg state side (str (:latest-payment-str eid) "to use " (get-title card)
                                                              " to set aside "
                                                              (enumerate-str (map get-title set-aside-cards))
                                                              " from the top of the stack"))
@@ -1033,7 +1034,9 @@
                                                              (continue-ability state side (shuffle-next set-aside-cards nil nil) card nil)
                                                              (let [set-aside-cards (remove-once #(= % target) set-aside-cards)
                                                                    new-eid (assoc eid :source card :source-type :runner-install)]
-                                                               (wait-for (runner-install state side new-eid target {:cost-bonus -2})
+                                                               (wait-for (runner-install state side new-eid target {:cost-bonus -2
+                                                                                                                    :msg-keys {:install-source card
+                                                                                                                               :display-origin true}})
                                                                          (continue-ability state side (shuffle-next set-aside-cards nil nil) card nil)))))}
                                              card nil))))}]}))
 
@@ -1188,10 +1191,10 @@
                             {:optional
                              {:prompt "Install this hardware from the heap?"
                               :yes-ability {:cost [(->c :lose-click 1)]
-                                            :msg (msg "install " (get-title card) " from the heap")
                                             :async true
                                             :effect (req (let [target-card (first (filter #(= (:printed-title %) (:printed-title card)) (:discard runner)))]
-                                                           (runner-install state side (assoc eid :source card :source-type :runner-install) target-card nil)))}}}
+                                                           (runner-install state side (assoc eid :source card :source-type :runner-install) target-card {:msg-keys {:display-origin true
+                                                                                                                                                                    :install-source card}})))}}}
                             card nil))}
             {:event :runner-turn-ends
              :req (req (and
@@ -1362,8 +1365,9 @@
                                             (hardware? target)
                                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                       [(->c :credit (install-cost state side target {:cost-bonus 1}))])))}
-                            :msg (msg "install " (:title target) " from the grip, paying 1 [Credit] more")
-                            :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus 1}))}}}
+                            :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus 1
+                                                                                                                          :msg-keys {:display-origin true
+                                                                                                                                     :install-source card}}))}}}
             {:event :runner-install
              :async true
              :interactive (req true)
@@ -1447,7 +1451,9 @@
                                     (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                               [(->c :credit (install-cost state side target {:cost-bonus -4}))])))}
            :async true
-           :effect (req (wait-for (runner-install state side target {:cost-bonus -4})
+           :effect (req (wait-for (runner-install state side target {:cost-bonus -4
+                                                                     :msg-keys {:install-source card
+                                                                                :display-origin true}})
                                   (continue-ability state side (when (< n 3) (mh (inc n))) card nil)))})]
     {:interactions {:prevent [{:type #{:net :brain}
                                :req (req true)}]}
@@ -1586,10 +1592,10 @@
                                   (in-hand? target)
                                   (not (event? target))
                                   (runner-can-pay-and-install? state side eid target {:no-toast true})))}
-         :msg (msg "install " (:title target))
          :effect (effect (runner-install
                           (assoc eid :source card :source-type :runner-install)
-                          target nil))
+                          target {:msg-keys {:install-source card
+                                             :display-origin true}}))
          :cancel-effect (effect (system-msg :runner (str "declines to use " (:title card) " to install a card"))
                                 (effect-completed eid))}
         gain-credit-ability
@@ -1771,7 +1777,9 @@
                           :prompt (msg "Install " (:title top-card) "?")
                           :yes-ability
                           {:async true
-                           :effect (effect (runner-install (assoc eid :source-type :runner-install) top-card nil))}}})
+                           :effect (effect (runner-install (assoc eid :source-type :runner-install) top-card {:msg-keys {:display-origin true
+                                                                                                                         :origin-index 0
+                                                                                                                         :install-source card}}))}}})
                       card nil)))}]})
 
 (defcard "Public Terminal"
@@ -1821,12 +1829,12 @@
     {:req (req (some #(when (= (:title %) (:title card)) %) (:deck runner)))
      :prompt (msg "Install another copy of " (:title card) "?")
      :yes-ability {:async true
-                   :msg "install another copy of itself"
                    :effect (req (trigger-event state side :searched-stack)
                                 (shuffle! state :runner :deck)
                                 (when-let [c (some #(when (= (:title %) (:title card)) %)
                                                    (:deck runner))]
-                                  (runner-install state side eid c nil)))}}}})
+                                  (runner-install state side eid c {:msg-keys {:install-source card
+                                                                               :display-origin true}})))}}}})
 
 (defcard "Ramujan-reliant 550 BMI"
   {:interactions {:prevent [{:type #{:net :brain}
@@ -2114,7 +2122,6 @@
                                         % {:cost-bonus -3}))
                                 (:discard runner)))
                 :cost [(->c :trash-can)]
-                :msg "install a program"
                 :effect
                 (effect
                   (continue-ability
@@ -2123,7 +2130,10 @@
                                               (program? target)
                                               (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                         [(->c :credit (install-cost state side target {:cost-bonus -3}))])))}
-                     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))}
+                     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3
+                                                                                                                   :msg-keys {:display-origin true
+                                                                                                                              :install-source card
+                                                                                                                              :include-cost-from-eid eid}}))}
                     card nil))}]})
 
 (defcard "Skulljack"
@@ -2277,16 +2287,16 @@
                :choices [(str "Install " (:title first-card))
                          (when second-card (str "Install " (:title second-card)))
                          "No install"]
-               :msg (msg "reveal " rev-str " from the top of the stack"
-                         (when-not (= target "No install")
-                           (str " and " (decapitalize target) ", ignoring all costs")))
+               :msg (msg "reveal " rev-str " from the top of the stack")
                :effect (req (if-not (= target "No install")
                               (wait-for (runner-install
                                           state side
                                           (make-eid state {:source card :source-type :runner-install})
                                           (if (= target (str "Install " (:title first-card)))
                                             first-card second-card)
-                                          {:ignore-all-cost true})
+                                          {:ignore-all-cost true
+                                           :msg-keys {:display-origin true
+                                                      :install-source card}})
                                         (shuffle! state side :deck)
                                         (system-msg state side "shuffles the Stack")
                                         (effect-completed state side eid))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -296,12 +296,12 @@
                  :req (req (and (pos? (count (:hand runner)))
                                 (:runner-phase-12 @state)))
                  :async true
-                 :msg "install a card facedown"
                  :effect (effect
                            (runner-install
                              (assoc eid :source card :source-type :runner-install)
                              target
-                             {:facedown true :no-msg true}))}]
+                             {:facedown true
+                              :msg-keys {:install-source card}}))}]
     {:implementation "Install restriction not enforced"
      :events [(assoc ability :event :runner-turn-begins)]
      :flags {:runner-phase-12 (req true)}
@@ -344,10 +344,10 @@
                                                      state side
                                                      (assoc eid :source-type :runner-install) % false))
                                              (:hand runner))))
-                     :msg (msg "install " (:title target) " from the grip")
                      :effect (req (wait-for (runner-install state :runner
                                                             (assoc (make-eid state eid) :source card :source-type :runner-install)
-                                                            (assoc-in target [:special :street-artist] true) nil)
+                                                            (assoc-in target [:special :street-artist] true) {:msg-keys {:install-source card
+                                                                                                                         :display-origin true}})
                                             (register-once state side {:once :per-turn} card)
                                             (register-events
                                               state side card
@@ -858,9 +858,9 @@
                              {:prompt (str "Choose a " card-type " to install")
                               :choices {:card #(and (is-type? % card-type)
                                                     (in-hand? %))}
-                              :msg (msg "install " (:title target))
                               :async true
-                              :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}}}
+                              :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                                       :display-origin true}}))}}}
                            {:prompt (str "You have no " card-type " to install")
                             :choices ["Carry on!"]
                             :prompt-type :bogus}))
@@ -1114,7 +1114,6 @@
                                               (can-pay? state :runner (assoc eid :source card :source-type :runner-install) % nil
                                                         [(->c :credit (install-cost state side % {:cost-bonus -1}))]))
                                         (:deck runner))))
-                :msg (msg "install " (:title target) " from the stack, lowering the cost by 1 [Credit]")
                 :async true
                 :effect (effect (trigger-event :searched-stack)
                                 (shuffle! :deck)
@@ -1129,7 +1128,10 @@
                                                    (move state side program :rfg)))}])
                                 (runner-install (assoc eid :source card :source-type :runner-install)
                                                 (assoc-in target [:special :kabonesa] true)
-                                                {:cost-bonus -1}))}]})
+                                                {:cost-bonus -1
+                                                 :msg-keys {:display-origin true
+                                                            :include-cost-from-eid eid
+                                                            :install-source card}}))}]})
 
 (defcard "Kate \"Mac\" McCaffrey: Digital Tinker"
   ;; Effect marks Kate's ability as "used" if it has already met it's trigger condition this turn
@@ -1172,8 +1174,9 @@
                                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                       [(->c :credit (install-cost state side target {:cost-bonus -1}))])))}
                             :async true
-                            :msg (msg "install " (:title target) " from the grip, lowering the cost by 1 [Credits]")
-                            :effect (effect (runner-install eid target {:cost-bonus -1}))})
+                            :effect (effect (runner-install eid target {:cost-bonus -1
+                                                                        :msg-keys {:display-origin true
+                                                                                   :install-source card}}))})
                          card nil))}]})
 
 (defcard "Laramy Fisk: Savvy Investor"
@@ -1874,8 +1877,9 @@
                              (in-hand? target)
                              (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                        [(->c :credit (install-cost state side target {:cost-bonus -2}))])))}
-             :msg (msg "install " (:title target) " from the grip, paying 2 [Credit] less")
-             :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -2}))}]})
+             :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -2
+                                                                                                           :msg-keys {:display-origin true
+                                                                                                                      :install-source card}}))}]})
 
 (defcard "Seidr Laboratories: Destiny Defined"
   {:implementation "Manually triggered"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -128,7 +128,7 @@
                                       state side
                                       (cond
                                         (= target "Yes") {:async true
-                                                          :effect (effect (runner-install :runner (assoc eid :source card :source-type :runner-install) card nil))}
+                                                          :effect (effect (runner-install :runner (assoc eid :source card :source-type :runner-install) card {:msg-keys {:install-source card :display-origin true}}))}
                                         ;; Add a register to note that the player was already asked about installing,
                                         ;; to prevent multiple copies from prompting multiple times.
                                         (= target "No") {:effect (req (swap! state assoc-in [:run :register (keyword (str "conspiracy-" title)) (:cid current-ice)] true))}
@@ -1109,9 +1109,10 @@
                   :choices (req (cancellable (filter #(can-pay? state side (assoc eid :source card :source-type :runner-install)
                                                                 % nil [(->c :credit (install-cost state side %))])
                                                      (:hosted card))))
-                  :msg (msg "install " (:title target))
                   :async true
-                  :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]}))
+                  :effect (req
+                            (runner-install state side (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                                :include-cost-from-eid eid}}))}]}))
 
 (defcard "Cyber-Cypher"
   (auto-icebreaker
@@ -1184,7 +1185,6 @@
                           (continue-ability
                             {:waiting-prompt true
                              :prompt "Choose a card to install"
-                             :msg (msg "install " (:title target) " from the grip at no cost")
                              :choices {:req (req (and (in-hand? target)
                                                       (or (hardware? target)
                                                           (program? target)
@@ -1192,8 +1192,12 @@
                                                       (<= (install-cost state side target)
                                                           (get-counters (cost-target eid :trash-can) :power))))}
                              :async true
-                             :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
-                                                             target {:ignore-install-cost true}))}
+                             :effect (effect
+                                       (runner-install (assoc eid :source card :source-type :runner-install)
+                                                       target {:ignore-install-cost true
+                                                               :msg-keys {:install-source card
+                                                                          :include-cost-from-eid eid
+                                                                          :display-origin true}}))}
                             card nil))}]})
 
 (defcard "Deep Thought"
@@ -2249,9 +2253,6 @@
                      (= (:title card) "Ika"))))
           (muse-abi [where]
             {:prompt "Choose a non-daemon program"
-             :msg (msg (if (= target "Done")
-                         "shuffle the stack"
-                         (str "install " (:title target))))
              :choices (req (concat
                              (->> (where runner)
                                   (filter
@@ -2266,27 +2267,30 @@
              :async true
              :effect (req (when (= :deck where)
                             (trigger-event state side :searched-stack)
+                            (system-msg state side (str "uses " (:title card) " to shuffle the stack"))
                             (shuffle! state side :deck))
-                          (if (not= target "Done")
-                            ;; does the card need to be installed on muse?
-                            (if-not (has-subtype? target "Trojan")
-                              (runner-install state side (assoc eid :source card :source-type :runner-install) target {:host-card (get-card state card)})
-                              ;;otherwise, pick a target card to host the trojan on
-                              (if (trojan-auto-hosts? target)
-                                ;; if the trojan does it for free, so be it
-                                (runner-install state side (assoc eid :source card :source-type :runner-install) target nil)
-                                ;; do it the hard way
-                                (let [target-card target]
-                                  (continue-ability
-                                    state side
-                                    {:prompt (msg "Choose a piece of ice to host " (:title target-card))
-                                     :choices {:card #(and (installed? %)
-                                                           (ice? %))}
-                                     :async true
-                                     :effect (req (runner-install state side (assoc eid :source card :source-type :runner-install) target-card {:host-card (get-card state target)}))}
-                                    card nil))))
-                            ;; declined to install
-                            (effect-completed state side eid)))})]
+                          (let [msg-keys {:install-source card
+                                          :display-origin true}]
+                            (if (not= target "Done")
+                              ;; does the card need to be installed on muse?
+                              (if-not (has-subtype? target "Trojan")
+                                (runner-install state side (assoc eid :source card :source-type :runner-install) target {:host-card (get-card state card) :msg-keys msg-keys})
+                                ;;otherwise, pick a target card to host the trojan on
+                                (if (trojan-auto-hosts? target)
+                                  ;; if the trojan does it for free, so be it
+                                  (runner-install state side (assoc eid :source card :source-type :runner-install) target {:msg-keys msg-keys})
+                                  ;; do it the hard way
+                                  (let [target-card target]
+                                    (continue-ability
+                                      state side
+                                      {:prompt (msg "Choose a piece of ice to host " (:title target-card))
+                                       :choices {:card #(and (installed? %)
+                                                             (ice? %))}
+                                       :async true
+                                       :effect (req (runner-install state side (assoc eid :source card :source-type :runner-install) target-card {:host-card (get-card state target) :msg-keys msg-keys}))}
+                                      card nil))))
+                              ;; declined to install
+                              (effect-completed state side eid))))})]
     {:on-install {:async true
                   :interactive (req true)
                   :prompt "Choose where to install from"
@@ -2569,7 +2573,9 @@
                                  :effect (req (wait-for
                                                 (trash state side card {:cause-card card
                                                                         :unpreventable true})
-                                                (runner-install state side eid target {:ignore-all-cost true})))
+                                                (runner-install state side eid target {:ignore-all-cost true
+                                                                                       :msg-keys {:display-origin true
+                                                                                                  :install-source card}})))
                                  :cancel-effect (req (system-msg state side (str "uses Pawn to trash itself"))
                                                      (trash state side eid card {:cause-card card
                                                                                  :unpreventable true}))}
@@ -2937,12 +2943,13 @@
                 :label "Install a program"
                 :once :per-turn
                 :req (req (not (install-locked? state side)))
-                :msg (msg "install " (:title target) " from the grip")
                 :prompt "Choose a program to install"
                 :choices {:card #(and (program? %)
                                       (in-hand? %))}
                 :async true
-                :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]})
+                :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                         :display-origin true
+                                                                                                                         :include-cost-from-eid eid}}))}]})
 
 (defcard "Scheherazade"
   {:static-abilities [{:type :can-host
@@ -2958,28 +2965,31 @@
                 :label "Install a program from the stack"
                 :cost [(->c :trash-can) (->c :credit 2)]
                 :async true
-                :effect (effect (continue-ability
-                                  {:prompt "Choose a program to install"
-                                   :msg (msg (if (= target "Done")
-                                               "shuffle the stack"
-                                               (str "install " (:title target) " from the stack")))
-                                   :choices (req (concat
-                                                   (->> (:deck runner)
-                                                        (filter
-                                                          #(and (program? %)
-                                                                (can-pay? state side
-                                                                          (assoc eid :source card :source-type :runner-install)
-                                                                          % nil [(->c :credit (install-cost state side %))])))
-                                                        (sort-by :title)
-                                                        (seq))
-                                                  ["Done"]))
-                                   :async true
-                                   :effect (req (trigger-event state side :searched-stack)
-                                                (shuffle! state side :deck)
-                                                (if (= target "Done")
-                                                  (effect-completed state side eid)
-                                                  (runner-install state side (assoc eid :source card :source-type :runner-install) target nil)))}
-                                  card nil))}]})
+                :effect (effect
+                          (continue-ability
+                            {:prompt "Choose a program to install"
+                             :msg (msg (if (= target "Done")
+                                         "shuffle the stack"
+                                         (str "install " (:title target) " from the stack")))
+                             :choices (req (concat
+                                             (->> (:deck runner)
+                                                  (filter
+                                                    #(and (program? %)
+                                                          (can-pay? state side
+                                                                    (assoc eid :source card :source-type :runner-install)
+                                                                    % nil [(->c :credit (install-cost state side %))])))
+                                                  (sort-by :title)
+                                                  (seq))
+                                             ["Done"]))
+                             :async true
+                             :effect (req (trigger-event state side :searched-stack)
+                                          (shuffle! state side :deck)
+                                          (if (= target "Done")
+                                            (effect-completed state side eid)
+                                            (runner-install state side (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                                                :display-origin true
+                                                                                                                                                :include-cost-from-eid eid}})))}
+                            card nil))}]})
 
 (defcard "Sharpshooter"
   (auto-icebreaker {:abilities [(break-sub [(->c :trash-can)] 0 "Destroyer")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2968,9 +2968,6 @@
                 :effect (effect
                           (continue-ability
                             {:prompt "Choose a program to install"
-                             :msg (msg (if (= target "Done")
-                                         "shuffle the stack"
-                                         (str "install " (:title target) " from the stack")))
                              :choices (req (concat
                                              (->> (:deck runner)
                                                   (filter
@@ -2985,7 +2982,8 @@
                              :effect (req (trigger-event state side :searched-stack)
                                           (shuffle! state side :deck)
                                           (if (= target "Done")
-                                            (effect-completed state side eid)
+                                            (do (system-msg state side (str (:latest-payment-str eid) " to shuffle the Stack"))
+                                                (effect-completed state side eid))
                                             (runner-install state side (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
                                                                                                                                                 :display-origin true
                                                                                                                                                 :include-cost-from-eid eid}})))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -101,8 +101,9 @@
                 {:target-server target-server
                  :ability
                  {:async true
-                  :msg (str "install " title ", ignoring all costs")
-                  :effect (effect (runner-install eid card {:ignore-all-cost true}))}})
+                  :effect (effect (runner-install eid card {:ignore-all-cost true
+                                                            :msg-keys {:display-origin true
+                                                                       :install-source card}}))}})
               :location :hand)]
    :abilities [{:async true
                 :cost [(->c :trash-can)]
@@ -305,14 +306,15 @@
 (defcard "Artist Colony"
   {:abilities [{:prompt "Choose a card to install"
                 :label "install a card"
-                :msg (msg "install " (:title target))
                 :req (req (not (install-locked? state side)))
                 :cost [(->c :forfeit)]
                 :choices (req (cancellable (filter #(not (event? %)) (:deck runner)) :sorted))
                 :async true
                 :effect (effect (trigger-event :searched-stack)
                                 (shuffle! :deck)
-                                (runner-install eid target nil))}]})
+                                (runner-install eid target {:msg-keys {:install-source card
+                                                                       :include-cost-from-eid eid
+                                                                       :display-origin true}}))}]})
 
 (defcard "Arruaceiras Crew"
   {:abilities [{:req (req (active-encounter? state))
@@ -479,9 +481,9 @@
                                      :prompt (msg "Install another copy of " hw "?")
                                      :yes-ability
                                      {:async true
-                                      :msg (msg "install another copy of " hw)
                                       :effect (req (if-let [c (some #(when (= (:title %) hw) %) (:hand runner))]
-                                                     (runner-install state side eid c nil)
+                                                     (runner-install state side eid c {:msg-keys {:display-origin true
+                                                                                                  :install-source card}})
                                                      (effect-completed state side eid)))}}})
                                  card nil))}]}))
 
@@ -687,8 +689,9 @@
                                 (can-pay? state :runner (assoc eid :source card :source-type :runner-install) target nil
                                           [(->c :credit (install-cost state side target
                                                                       {:cost-bonus (- (get-counters card :power))}))])))}
-                :msg (msg "install " (:title target) " from the grip")
-                :effect (req (wait-for (runner-install state side target {:cost-bonus (- (get-counters card :power))})
+                :effect (req (wait-for (runner-install state side target {:msg-keys {:install-source card
+                                                                                     :display-origin true}
+                                                                          :cost-bonus (- (get-counters card :power))})
                                        (when (pos? (get-counters card :power))
                                          (add-counter state side card :power -1))
                                        (effect-completed state side eid)))}]})
@@ -912,7 +915,9 @@
                              :player :runner
                              :prompt "Install Crowdfunding from the Heap?"
                              :yes-ability {:async true
-                                           :effect (effect (runner-install :runner eid card {:ignore-all-cost true}))}
+                                           :effect (effect (runner-install :runner eid card {:ignore-all-cost true
+                                                                                             :msg-keys {:install-source card
+                                                                                                        :display-origin true}}))}
                              ;; Add a register to note that the player was already asked about installing,
                              ;; to prevent multiple copies from prompting multiple times.
                              :no-ability {:effect (req (swap! state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
@@ -930,14 +935,14 @@
                 :async true
                 :label "Install a virus program from the stack"
                 :prompt "Choose a virus"
-                :msg (msg "install " (:title target) " from the stack")
                 :choices (req (cancellable (filter #(and (program? %)
                                                          (has-subtype? % "Virus"))
                                                    (:deck runner)) :sorted))
                 :cost [(->c :click 1) (->c :virus 3) (->c :trash-can)]
                 :effect (effect (trigger-event :searched-stack)
                                 (shuffle! :deck)
-                                (runner-install (assoc eid :source card :source-type :runner-install) target nil))}
+                                (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                         :display-origin true}}))}
                (set-autoresolve :auto-place-counter "Crypt placing virus counters on itself")]})
 
 (defcard "Cybertrooper Talut"
@@ -1675,7 +1680,9 @@
    :abilities [(letfn [(ri [cards]
                          (when (seq cards)
                            {:async true
-                            :effect (req (wait-for (runner-install state side (first cards) {:facedown true})
+                            :effect (req (wait-for (runner-install state side (first cards) {:facedown true
+                                                                                             :msg-keys {:install-source card
+                                                                                                        :display-origin true}})
                                                    (continue-ability state side (ri (rest cards)) card nil)))}))]
                  {:async true
                   :label "Install the top 3 cards of the stack facedown"
@@ -2065,8 +2072,10 @@
                 :choices {:card #(and (program? %)
                                       (not (has-subtype? % "Virus"))
                                       (in-hand? %))}
-                :msg (msg "install and host " (:title target))
-                :effect (effect (runner-install eid target {:host-card card :ignore-install-cost true}))}
+                :effect (effect (runner-install eid target {:host-card card :ignore-install-cost true
+                                                            :msg-keys {:install-source card
+                                                                       :include-cost-from-eid eid
+                                                                       :display-origin true}}))}
                {:action true
                 :label "Add a hosted program to the grip"
                 :cost [(->c :click 1)]
@@ -2516,7 +2525,6 @@
                            0))]
                  {:async true
                   :label "Install hosted card"
-                  :msg "install hosted card"
                   :cost [(->c :credit 1)]
                   :req (req (and (seq (:hosted card))
                                  (some #(can-pay? state :runner (assoc eid :source card :source-type :runner-install)
@@ -2532,7 +2540,9 @@
                                  (assoc eid :source card :source-type :runner-install)
                                  target
                                  {:cost-bonus (discount state card)
-                                  :custom-message #(str (build-spend-msg % "install") (:title target) " using " (:title card))})
+                                  :msg-keys {:install-source card
+                                             :display-origin true
+                                             :include-cost-from-eid eid}})
                             (swap! state assoc-in [:per-turn (:cid card)] true))})]})
 
 (defcard "Penumbral Toolkit"
@@ -2557,7 +2567,9 @@
          :effect (req (do (add-counter state side target :power -1)
                           (if (pos? (get-counters (get-card state target) :power))
                             (effect-completed state side eid)
-                            (runner-install state side eid (dissoc target :counter) {:ignore-all-cost true}))))}]
+                            (runner-install state side eid (dissoc target :counter) {:ignore-all-cost true
+                                                                                     :msg-keys {:display-origin true
+                                                                                                :install-source card}}))))}]
     {:flags {:drip-economy true}
      :abilities [{:action true
                   :async true
@@ -2570,7 +2582,9 @@
                                         (in-hand? %)
                                         (runner? %))}
                   :effect (req (if (not (pos? (:cost target)))
-                                 (runner-install state side (assoc eid :source card :source-type :runner-install) target nil)
+                                 (runner-install state side (assoc eid :source card :source-type :runner-install) target {:ignore-all-cost true
+                                                                                                                          :msg-keys {:display-origin true
+                                                                                                                                     :install-source card}})
                                  (do (host state side card
                                            (assoc target :counter {:power (:cost target)}))
                                      (effect-completed state side eid))))
@@ -2598,7 +2612,9 @@
                                                                        " to remove " (quantify target "power counter")
                                                                        " from " (:title paydowntarget)))
                                                       (if (= num-counters target)
-                                                        (runner-install state side (assoc eid :source card :source-type :runner-install) (dissoc paydowntarget :counter) {:ignore-all-cost true})
+                                                        (runner-install state side (assoc eid :source card :source-type :runner-install) (dissoc paydowntarget :counter) {:ignore-all-cost true
+                                                                                                                                                                          :msg-keys {:display-origin true
+                                                                                                                                                                                     :install-source card}})
                                                         (do (add-counter state side paydowntarget :power (- target))
                                                             (effect-completed state side eid))))
                                                   (effect-completed state side eid))))})
@@ -2688,7 +2704,6 @@
                              (assoc eid :source card :source-type :runner-install) % nil))
                      (:discard runner)))
      :cost [(->c :click 1) (->c :trash-can) (->c :trash-from-hand 1)]
-     :msg "install a program, piece of hardware, or Virtual resource from the heap"
      :effect
      (effect
        (continue-ability
@@ -2703,8 +2718,9 @@
                                             (can-pay? state :runner (assoc eid :source card :source-type :runner-install) % nil
                                                       [(->c :credit (install-cost state side %))]))
                                       (:discard runner)))))
-          :msg (msg "install " (:title target) " from the heap")
-          :effect (req (runner-install state :runner (assoc eid :source card :source-type :runner-install) target nil))}
+          :effect (req (runner-install state :runner (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
+                                                                                                                              :display-origin true
+                                                                                                                              :include-cost-from-eid eid}}))}
          card nil))}]})
 
 (defcard "Red Team"
@@ -2793,17 +2809,16 @@
                                             (sort-by :title)
                                             (seq))
                                        ["Done"]))
-                       :msg (msg (if (= target "Done")
-                                   "shuffle the stack"
-                                   (str "install " (:title target)
-                                        " from the stack, lowering its cost by "
-                                        (:cost (find-rfg state card)))))
                        :effect (req (trigger-event state side :searched-stack)
                                     (shuffle! state side :deck)
                                     (if (= target "Done")
-                                      (effect-completed state side eid)
+                                      (do (system-msg state side (str (:latest-payment-str eid) " to use " (:title card) " to shuffle the Stack"))
+                                          (effect-completed state side eid))
                                       (runner-install state side (assoc eid :source card :source-type :runner-install)
-                                                      target {:cost-bonus (- (:cost (find-rfg state card)))})))}
+                                                      target {:msg-keys {:display-origin true
+                                                                         :include-cost-from-eid eid
+                                                                         :install-source card}
+                                                              :cost-bonus (- (:cost (find-rfg state card)))})))}
                       card nil))}]}))
 
 (defcard "Sacrificial Clone"
@@ -3223,9 +3238,9 @@
                 :once-key :artist-install
                 :async true
                 :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
-                                                target {:no-msg true
-                                                        :cost-bonus -1}))
-                :msg (msg "install " (:title target) " from the grip, lowering its cost by 1 [Credits]")}]})
+                                                target {:msg-keys {:install-source card
+                                                                   :display-source true}
+                                                        :cost-bonus -1}))}]})
 
 (defcard "The Back"
   {:implementation "Placing power counters is manual"
@@ -3418,8 +3433,6 @@
                                  (can-pay? state side (assoc eid :source card :source-type :runner-install)
                                            target nil [(->c :credit (install-cost state side target {:cost-bonus -2}))])))}
                  :once :per-turn
-                 :msg (msg "install " (:title target)
-                           ", lowering its install cost by 2 [Credits]")
                  :async true
                  :effect
                  (req (if-not (runner-can-install? state side target nil)
@@ -3431,7 +3444,9 @@
                                                     (fn [coll]
                                                       (remove-once #(same-card? % target) coll)))))
                             (runner-install state side (assoc eid :source card :source-type :runner-install)
-                                            target {:cost-bonus -2}))))}]
+                                            target {:cost-bonus -2
+                                                    :msg-keys {:display-origin true
+                                                               :install-source card}}))))}]
     {:flags {:drip-economy true}  ; not technically drip economy, but has an interaction with Drug Dealer
      :abilities [{:action true
                   :label "Host a resource or piece of hardware"
@@ -3536,11 +3551,12 @@
                                  (not (event? target))
                                  (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                            [(->c :credit (install-cost state side target {:cost-bonus -1}))])))}
-                 :msg (msg "install " (:title target))
                  :effect (effect (runner-install (assoc eid
                                                         :source card
                                                         :source-type :runner-install)
-                                                 target {:cost-bonus -1}))
+                                                 target {:cost-bonus -1
+                                                         :msg-keys {:install-source card
+                                                                    :display-origin true}}))
                  :cancel-effect (effect (effect-completed eid))}]
     {:events [(assoc ability
                      :event :runner-lose-tag

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -2,6 +2,7 @@
   (:require
     [clj-uuid :as uuid]
     [clojure.stacktrace :refer [print-stack-trace]]
+    [clojure.string :as string]
     [cond-plus.core :refer [cond+]]
     [game.core.board :refer [clear-empty-remotes get-all-cards all-installed all-installed-runner
                              all-installed-runner-type all-active-installed]]
@@ -357,6 +358,10 @@
   (let [payment-str (:msg async-result)
         cost-paid (merge-costs-paid (:cost-paid eid) (:cost-paid async-result))
         ability (assoc-in ability [:eid :cost-paid] cost-paid)
+        ;; this lets nested abilities access payment strs from outside the nesting
+        ;; which is admittedly a little cursed
+        last-payment-str (get-in ability [:eid :latest-payment-str])
+        ability (assoc-in ability [:eid :latest-payment-str] (if-not (string/blank? payment-str) payment-str last-payment-str))
         ;; After paying costs, counters will be removed, so fetch the latest version.
         ;; We still want the card if the card is trashed, so default to given
         ;; when the latest is gone.

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -424,7 +424,7 @@
                       (str (:title card) " as a facedown card")
                       "a card facedown")
                     (:title card))
-        origin (if display-origin
+        origin (if (and display-origin (not= (:previous-zone card) [:onhost]))
                  (str " from "
                       (when origin-index (str " position " (inc origin-index) " of "))
                       (cond
@@ -435,6 +435,8 @@
                  "")
         pre-lhs (when (every? (complement string/blank?) [cost-str prepend-cost-str])
                   (str prepend-cost-str ", and then "))
+        from-host? (when (and display-origin (= (:previous-zone card) [:onhost]))
+                     "hosted ")
         modified-cost-str (if (string/blank? cost-str)
                             prepend-cost-str
                             (if (string/blank? pre-lhs)
@@ -447,7 +449,7 @@
       (if custom-message
         (system-msg state side (custom-message cost-str))
         (system-msg state side
-                    (str pre-lhs lhs card-name origin discount-str
+                    (str pre-lhs lhs from-host? card-name origin discount-str
                          (when host-card (str " on " (card-str state host-card)))
                          (when no-cost " at no cost")))))))
 

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -410,7 +410,7 @@
   [state side card cost-str
    {:keys [no-cost host-card facedown custom-message msg-keys ignore-install-cost ignore-all-cost cost-bonus] :as args}]
   (let [{:keys [display-origin install-source origin-index known]} msg-keys
-        hide-zero-cost (:hide-zero-cost msg-keys true)
+        hide-zero-cost (:hide-zero-cost msg-keys facedown)
         cost-str (if (and hide-zero-cost (= cost-str "pays 0 [Credits]")) nil cost-str)
         prepend-cost-str (get-in msg-keys [:include-cost-from-eid :latest-payment-str])
         discount-str (cond

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -410,6 +410,8 @@
   [state side card cost-str
    {:keys [no-cost host-card facedown custom-message msg-keys ignore-install-cost] :as args}]
   (let [{:keys [display-origin install-source origin-index known]} msg-keys
+        hide-zero-cost (:hide-zero-cost msg-keys true)
+        cost-str (if (and hide-zero-cost (= cost-str "pays 0 [Credits]")) nil cost-str)
         prepend-cost-str (get-in msg-keys [:include-cost-from-eid :latest-payment-str])
         card-name (if facedown
                     (if known

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -1,6 +1,7 @@
 (ns game.core.installing
   (:require
     [cond-plus.core :refer [cond+]]
+    [clojure.string :as string]
     [game.core.agendas :refer [update-advancement-requirement]]
     [game.core.board :refer [all-installed get-remotes installable-servers server->zone all-installed-runner-type]]
     [game.core.card :refer [agenda? asset? condition-counter? convert-to-condition-counter  corp? event? get-card get-zone has-subtype? ice? installed? operation? program? resource? rezzed? upgrade?]]
@@ -142,33 +143,33 @@
 (defn- corp-install-message
   "Prints the correct install message."
   [state side card server install-state cost-str {:keys [counters msg-keys] :as args}]
-  (let [{:keys [display-origin install-source origin-index known]} msg-keys]
-    (when (:display-message args true)
-      (let [card-name (if (or (#{:rezzed :rezzed-no-cost :face-up} install-state)
-                              ;; note that cards which the corp is instructed to rez, but cannot
-                              ;; (or chooses not to rez) are revealed, so they're safe to name here
-                              known
-                              (:seen card)
-                              (rezzed? card))
-                        (:title card)
-                        (if (ice? card) "ice" "a card"))
-            server-name (if (= server "New remote")
-                          (str (remote-num->name (dec (:rid @state))) " (new remote)")
-                          server)
-            origin (if display-origin
-                     (str " from "
-                          (when origin-index (str " position " (inc origin-index) " of "))
-                          (name-zone :corp (:zone card)))
-                     "")
-            lhs (if install-source
-                  (str (build-spend-msg cost-str "use") (:title install-source) " to install ")
-                  (build-spend-msg cost-str "install"))]
-        (system-msg state side (str lhs card-name origin
-                                    (if (ice? card) " protecting " " in ") server-name
-                                    (format-counters-msg counters)))
-        (when (and (= :face-up install-state)
-                   (agenda? card))
-          (implementation-msg state card))))))
+  (when (:display-message args true)
+    (let [{:keys [display-origin install-source origin-index known]} msg-keys
+          card-name (if (or (#{:rezzed :rezzed-no-cost :face-up} install-state)
+                            ;; note that cards which the corp is instructed to rez, but cannot
+                            ;; (or chooses not to rez) are revealed, so they're safe to name here
+                            known
+                            (:seen card)
+                            (rezzed? card))
+                      (:title card)
+                      (if (ice? card) "ice" "a card"))
+          server-name (if (= server "New remote")
+                        (str (remote-num->name (dec (:rid @state))) " (new remote)")
+                        server)
+          origin (if display-origin
+                   (str " from "
+                        (when origin-index (str " position " (inc origin-index) " of "))
+                        (name-zone :corp (:zone card)))
+                   "")
+          lhs (if install-source
+                (str (build-spend-msg cost-str "use") (:title install-source) " to install ")
+                (build-spend-msg cost-str "install"))]
+      (system-msg state side (str lhs card-name origin
+                                  (if (ice? card) " protecting " " in ") server-name
+                                  (format-counters-msg counters)))
+      (when (and (= :face-up install-state)
+                 (agenda? card))
+        (implementation-msg state card)))))
 
 ;; Unused in the corp install system, necessary for card definitions
 (defn corp-install-msg
@@ -406,16 +407,42 @@
 
 (defn- runner-install-message
   "Prints the correct msg for the card install"
-  [state side card-title cost-str
-   {:keys [no-cost host-card facedown custom-message]}]
-  (if facedown
-    (system-msg state side "installs a card facedown")
-    (if custom-message
-      (system-msg state side (custom-message cost-str))
-      (system-msg state side
-                  (str (build-spend-msg cost-str "install") card-title
-                       (when host-card (str " on " (card-str state host-card)))
-                       (when no-cost " at no cost"))))))
+  [state side card cost-str
+   {:keys [no-cost host-card facedown custom-message msg-keys ignore-install-cost] :as args}]
+  (let [{:keys [display-origin install-source origin-index known]} msg-keys
+        prepend-cost-str (get-in msg-keys [:include-cost-from-eid :latest-payment-str])
+        card-name (if facedown
+                    (if known
+                      (str (:title card) " as a facedown card")
+                      "a card facedown")
+                    (:title card))
+        origin (if display-origin
+                 (str " from "
+                      (when origin-index (str " position " (inc origin-index) " of "))
+                      (cond
+                        (= (:previous-zone card) [:set-aside])
+                        "among the set-aside cards"
+                        :else
+                        (str "the " (name-zone :runner (:previous-zone card)))))
+                 "")
+        pre-lhs (when (every? (complement string/blank?) [cost-str prepend-cost-str])
+                  (str prepend-cost-str ", and then "))
+        modified-cost-str (if (string/blank? cost-str)
+                            prepend-cost-str
+                            (if (string/blank? pre-lhs)
+                              cost-str
+                              (str cost-str ",")))
+        lhs (if install-source
+              (str (build-spend-msg modified-cost-str "use") (:title install-source) " to install ")
+              (build-spend-msg modified-cost-str "install"))
+        ignore-cost-str (when ignore-install-cost " (ignoring it's install cost)")]
+    (when (:display-message args true)
+      (if custom-message
+        (system-msg state side (custom-message cost-str))
+        (system-msg state side
+                    (str pre-lhs lhs card-name origin ignore-cost-str
+                         (when host-card (str " on " (card-str state host-card)))
+                         (when no-cost " at no cost")))))))
 
 (defn runner-install-continue
   [state side eid card
@@ -435,7 +462,7 @@
                                                   :init-data true
                                                   :no-mu no-mu}))]
     (when-not no-msg
-      (runner-install-message state side (:title installed-card) payment-str args))
+      (runner-install-message state side installed-card payment-str args))
     (when-not facedown
       (implementation-msg state card))
     (play-sfx state side "install-runner")

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -5201,8 +5201,7 @@
           "Install at no cost")
       (is (= "Femme Fatale" (:title (get-program state 0))) "Femme Fatale is installed")
       (is (second-last-log-contains? state (str "Runner uses The Wizard's Chest"
-                                                " to reveal Legwork, Corroder, Ice Carver, Prepaid VoicePAD, Femme Fatale from the top of the stack"
-                                                " and install Femme Fatale, ignoring all costs."))))))
+                                                " to reveal Legwork, Corroder, Ice Carver, Prepaid VoicePAD, Femme Fatale from the top of the stack."))))))
 
 (deftest the-wizards-chest-single-card-selection
   (do-game
@@ -5228,8 +5227,7 @@
           "Install at no cost")
       (is (= "Femme Fatale" (:title (get-program state 0))) "Femme Fatale is installed")
       (is (second-last-log-contains? state (str "Runner uses The Wizard's Chest"
-                                                " to reveal Legwork, Ice Carver, Prepaid VoicePAD, Femme Fatale, Earthrise Hotel from the top of the stack"
-                                                " and install Femme Fatale, ignoring all costs."))))))
+                                                " to reveal Legwork, Ice Carver, Prepaid VoicePAD, Femme Fatale, Earthrise Hotel from the top of the stack."))))))
 
 (deftest time-bomb
   (do-game

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -269,7 +269,7 @@
     (card-ability state :runner (get-resource state 0) 0)
     (click-prompt state :runner "Chatterjee University")
     (click-card state :runner "Vanity Project")
-    (is (last-n-log-contains? state 1 "forfeits 1 agenda .* to use Artist Colony to install Chatterjee University"))
+    (is (last-log-contains? state "forfeits 1 agenda .* to use Artist Colony to install Chatterjee University"))
     (is (= "Chatterjee University" (:title (get-resource state 1))))
     (is (empty? (:scored (get-runner))))))
 
@@ -4870,21 +4870,18 @@
           (is (changed? [(:credit (get-runner)) -4]
                 (click-card state :runner mo))
               "Pay 4 for MOpus install (1+5-2)")
-          (is (second-last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted card\\.") "Correct message for Paule usage")
-          (is (last-log-contains? state "Runner pays 3 [Credits] to install Magnum Opus using Paule's Café\\.") "Correct message for MOpus install")
+          (is (last-log-contains? state "Runner pays 1 [Credits], and then pays 3 [Credits], to use Paule's Café to install hosted Magnum Opus.") "Correct message for Mopus install")
           (card-ability state :runner pau 1)
           (is (changed? [(:credit (get-runner)) -4]
                 (click-card state :runner des))
               "Pay 4 for Desperado install (1+3)")
-          (is (second-last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted card\\.") "Correct message for Paule usage")
-          (is (last-log-contains? state "Runner pays 3 [Credits] to install Desperado using Paule's Café\\.") "Correct message for Desperado install")
+          (is (last-log-contains? state "Runner pays 1 [Credits], and then pays 3 [Credits], to use Paule's Café to install hosted Desperado.") "Correct message for Desperado install")
           (take-credits state :runner)
           (card-ability state :runner pau 1)
           (is (changed? [(:credit (get-runner)) -3]
                 (click-card state :runner cor))
               "Pay 3 for Corroder install in Corp turn (1+2)")
-          (is (second-last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted card\\.") "Correct message for Paule usage")
-          (is (last-log-contains? state "Runner pays 2 [Credits] to install Corroder using Paule's Café\\.") "Correct message for Corroder install")))))
+          (is (last-log-contains? state "pays 1 [Credits], and then pays 2 [Credits], to use Paule's Café to install hosted Corroder") "Correct message for Corroder install")))))
 
 (deftest paule-s-cafe-can-t-lower-cost-below-1-issue-4816
     ;; Can't lower cost below 1. Issue #4816
@@ -4906,8 +4903,7 @@
                 (card-ability state :runner pau 1)
                 (click-card state :runner cor))
               "Pay 1 credit for Corroder (2 - 4 + 1 base)")
-          (is (second-last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted card\\.") "Correct message for Paule usage")
-          (is (last-log-contains? state "Runner pays 0 [Credits] to install Corroder using Paule's Café\\.") "Correct message for Corroder install")))))
+          (is (last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted Corroder ") "Correct message for Corroder install")))))
 
 (deftest penumbral-toolkit-install-cost-reduction-after-hq-run
     ;; install cost reduction after HQ run
@@ -5152,8 +5148,8 @@
       (click-prompt state :runner (find-card "Mimic" (:discard (get-runner))))
       (is (= 1 (count (get-program state))) "1 Program installed")
       (is (= 2 (:credit (get-runner))) "Runner paid install cost")
-      (is (last-n-log-contains? state 2 "Clone Chip"))
-      (is (second-last-log-contains? state "uses Reclaim to install Mimic"))))
+      (is (last-log-contains? state "Clone Chip"))
+      (is (last-log-contains? state "Reclaim to install Mimic"))))
 
 (deftest reclaim-no-cards-in-hand
     ;; No cards in hand

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -4903,7 +4903,7 @@
                 (card-ability state :runner pau 1)
                 (click-card state :runner cor))
               "Pay 1 credit for Corroder (2 - 4 + 1 base)")
-          (is (last-log-contains? state "Runner pays 1 [Credits] to use Paule's Café to install hosted Corroder ") "Correct message for Corroder install")))))
+          (is (last-log-contains? state "Runner pays 1 [Credits], and then pays 0 [Credits], to use Paule's Café to install hosted Corroder ") "Correct message for Corroder install")))))
 
 (deftest penumbral-toolkit-install-cost-reduction-after-hq-run
     ;; install cost reduction after HQ run

--- a/test/clj/game/core/costs_test.clj
+++ b/test/clj/game/core/costs_test.clj
@@ -78,7 +78,7 @@
       (play-from-hand state :runner "Career Fair")
       (is (last-log-contains? state "Runner spends [Click] and pays 0 [Credits] to play Career Fair.") "Play Career Fair, zero cost")
       (click-card state :runner (find-card "Daily Casts" (:hand (get-runner))))
-      (is (last-log-contains? state "Runner pays 0 [Credits] to install Daily Casts.") "Choose Daily cast, zero cost install")
+      (is (last-log-contains? state "Runner uses Career Fair to install Daily Casts from the Grip") "Choose Daily cast, zero cost install")
       (play-from-hand state :runner "Daily Casts")
       (is (last-log-contains? state "Runner spends [Click] and pays 3 [Credits] to install Daily Casts.") "Install resource, three cost")
       (run-on state :archives)

--- a/test/clj/game/core/costs_test.clj
+++ b/test/clj/game/core/costs_test.clj
@@ -78,7 +78,7 @@
       (play-from-hand state :runner "Career Fair")
       (is (last-log-contains? state "Runner spends [Click] and pays 0 [Credits] to play Career Fair.") "Play Career Fair, zero cost")
       (click-card state :runner (find-card "Daily Casts" (:hand (get-runner))))
-      (is (last-log-contains? state "Runner uses Career Fair to install Daily Casts from the Grip") "Choose Daily cast, zero cost install")
+      (is (last-log-contains? state "Runner pays 0 [Credits] to use Career Fair to install Daily Casts from the Grip") "Choose Daily cast, zero cost install")
       (play-from-hand state :runner "Daily Casts")
       (is (last-log-contains? state "Runner spends [Click] and pays 3 [Credits] to install Daily Casts.") "Install resource, three cost")
       (run-on state :archives)


### PR DESCRIPTION
My attempt to make the install messages (marginally) nicer, and make it so we don't have to write these `:msg` keys ourselves.

I updated `engine` to keep track of the last relevant payment-str on an eid, so we can use it when cards have nested costs, instead of needing to hotwire stuff down the line.

Here's a sample of the changed cards, because I know it's really hard to guage what's changed just from reading that runner-install-msg fn:

## Programs ##

Conspiracy breakers all share the same code.

![paperclip](https://github.com/user-attachments/assets/b4fe755b-00f5-401f-982e-74238252d866)

Customized Secretary
![customized-secretary](https://github.com/user-attachments/assets/2b415abb-f467-4f1b-932f-e838458b471a)

DaVinci
![davinci](https://github.com/user-attachments/assets/15659a42-e322-4cb5-a3f6-1dfafba9992d)

Muse demostrates origins in the text:
![muse_000](https://github.com/user-attachments/assets/d03b894a-25aa-4bea-822d-f544dd660399)
![muse](https://github.com/user-attachments/assets/c8e6b3c6-995c-4d5e-b240-7dce4dea8bf7)
![muse_001](https://github.com/user-attachments/assets/abd50f87-0028-4894-b496-c26f88fe2b68)
Also Closes #7629

I realized when I did SMC that the listing of costs was kind of ambiguous with nested costs, so I changed it to look like this. I'm not 100% on if this is the best presentation, but it makes sense to me.

![smc](https://github.com/user-attachments/assets/80725681-0ccd-4541-bdaf-3db592051b55)

## Identities ##

![arissana](https://github.com/user-attachments/assets/14964de5-78b2-429e-99bb-4fcdce201d41)
![hayley](https://github.com/user-attachments/assets/35d06261-69e2-4bd3-b8fc-92ac2e26b7c5)
![wu_000](https://github.com/user-attachments/assets/f886f9f3-6a85-4db1-a14c-9e847c51d97c)
![seb](https://github.com/user-attachments/assets/96567fff-b389-4c35-8868-fbf307dce83c)

Here I have to decide if it's worth including the discount in the install message. I think players are responsible enough to glance at the source card if they're confused.

I also added an option to hide if the credit cost happens to be 0. I feel like the cost being 0 is junk information, but I can make this default to false instead of true if desired.

## Hardware ##
So many of these apply discounts or modify costs that I had to add it to the install messages (I did this pretty late, so I've only got pictures of it for simulchip and wizard's chest).

Clone Chip
![cc](https://github.com/user-attachments/assets/1ce9caac-8808-4c1a-96bd-6d51e8d62d63)

Gachapon (note that it now displays the trash cost, I can do this because of the eid change)
![gachapon_000](https://github.com/user-attachments/assets/24968b8d-fece-4ab8-b3f3-6ad9812dd02b)
Pantograph
![pantograph](https://github.com/user-attachments/assets/c8d48f7b-8737-4eed-b103-2604a9045793)
One too many rabbit holes
![rabbit-hole](https://github.com/user-attachments/assets/095ebed9-3d5f-4eab-9f53-4266998f0871)
Wizard's Chest
![wiz](https://github.com/user-attachments/assets/ace48263-ddae-4dc6-a796-4385e38fa77a)
Simulchip
![simulchip_002](https://github.com/user-attachments/assets/4faffafd-1ee5-4462-8bee-6a60f6f16c45)

## Events ##

![cf](https://github.com/user-attachments/assets/8faa9fb1-38e5-4f80-95cf-b1a0f7b08d9d)

![compile](https://github.com/user-attachments/assets/c6b1c58b-191e-44d4-bdca-e2718f8c252f)

![praxis](https://github.com/user-attachments/assets/1c395348-d509-4705-b248-ddaf6a8d4583)

![spark](https://github.com/user-attachments/assets/63f46958-9bc9-42b2-b617-9ae31b59c460)

![price](https://github.com/user-attachments/assets/ca0139eb-798a-4ace-90cb-d9a543afdb3f)

## Resources ##

![crowd](https://github.com/user-attachments/assets/533307ea-dbb3-4a25-8155-f3e6f5d60a4d)
![hg](https://github.com/user-attachments/assets/60ed95d9-a44b-4272-b357-eb724380cf28)
![paule](https://github.com/user-attachments/assets/da34a0da-a6a3-4c2d-a77f-192aeed9fc99)


Closes #7630

