### PR TITLE
tied actions to clicks being spend, and the card type, so juli can be correct

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1847,7 +1847,7 @@
              :req (req (let [all-cards (get-all-cards state)
                              pred (fn [context]
                                     (and (:is-game-action? context)
-                                         (= "Resource" (:source-type context))))]
+                                         (resource? (:stripped-source-card context))))]
                          (and pred
                               (first-event? state side :runner-spent-click
                                             #(pred (first %))))))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1844,15 +1844,13 @@
    :events [(trash-on-empty :power)
             {:event :runner-spent-click
              :once :per-turn
-             :req (req (let [all-cards (get-all-cards state)]
-                         ;; TODO - assert this works when (e.g.) using the last click on lib-acc
-                         ;; and having it trashed (all-cards wont find it)
-                         ;; also asset that the first-event? fn actually works right...
-                         ;; -nbk, mar '24
-                         (and (resource? (find-cid (:action target) all-cards))
+             :req (req (let [all-cards (get-all-cards state)
+                             pred (fn [context]
+                                    (and (:is-game-action? context)
+                                         (= "Resource" (:source-type context))))]
+                         (and pred
                               (first-event? state side :runner-spent-click
-                                            #(resource?
-                                               (find-cid (:action (first %)) all-cards))))))
+                                            #(pred (first %))))))
              :cost [(->c :power 1)]
              :msg "gain [Click]"
              :effect (effect (gain-clicks 1))}]})

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -36,8 +36,11 @@
   [cost state side eid _card]
   (let [a (:action eid)
         idx (get-in eid [:source-info :ability-idx])
-        is-game-action? (when (= :ability (:source-type eid))
-                          (:action (nth (get-in eid [:source :abilities]) idx nil)))
+        source-abilities (get-in eid [:source :abilities])
+        is-game-action? (when (and (= :ability (:source-type eid))
+                                   (number? idx)
+                                   (seq source-abilities))
+                          (:action (nth source-abilities idx {})))
         source-type (get-in eid [:source :type])]
     (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
     (deduct state side [:click (value cost)])

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -41,14 +41,14 @@
                                    (number? idx)
                                    (seq source-abilities))
                           (:action (nth source-abilities idx {})))
-        source-type (get-in eid [:source :type])]
+        source (get-in eid [:source])]
     (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
     (deduct state side [:click (value cost)])
     (wait-for (trigger-event-sync state side (make-eid state eid)
                                   (if (= side :corp) :corp-spent-click :runner-spent-click)
                                   {:action a
                                    :is-game-action? is-game-action?
-                                   :source-type source-type
+                                   :stripped-source-card (select-keys source [:cid :title :type])
                                    :value (value cost)
                                    :ability-idx (:ability-idx (:source-info eid))})
               ;; sending the idx is mandatory to make wage workers functional

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -34,12 +34,18 @@
   (<= 0 (- (get-in @state [side :click]) (value cost))))
 (defmethod handler :click
   [cost state side eid _card]
-  (let [a (:action eid)]
+  (let [a (:action eid)
+        idx (get-in eid [:source-info :ability-idx])
+        is-game-action? (when (= :ability (:source-type eid))
+                          (:action (nth (get-in eid [:source :abilities]) idx nil)))
+        source-type (get-in eid [:source :type])]
     (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
     (deduct state side [:click (value cost)])
     (wait-for (trigger-event-sync state side (make-eid state eid)
                                   (if (= side :corp) :corp-spent-click :runner-spent-click)
                                   {:action a
+                                   :is-game-action? is-game-action?
+                                   :source-type source-type
                                    :value (value cost)
                                    :ability-idx (:ability-idx (:source-info eid))})
               ;; sending the idx is mandatory to make wage workers functional

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3472,16 +3472,36 @@
           juli (get-resource state 1)]
       (is (changed? [(get-counters (refresh juli) :power) -1
                      (:click (get-runner)) 0]
-                    (card-ability state :runner artist 0))
+            (card-ability state :runner artist 0))
           "Runner gained 1 click from Juli Moreira Lee")
       (is (changed? [(get-counters (refresh juli) :power) 0]
-                    (card-ability state :runner artist 1))
+            (card-ability state :runner artist 1))
           "No further Juli Moreira Lee trigger")
       (take-credits state :runner)
       (take-credits state :corp)
       (core/add-counter state :runner (refresh juli) :power -2)
       (card-ability state :runner artist 0)
       (is (= 1 (count (:discard (get-runner)))) "Juli Moreira Lee trashed"))))
+
+(deftest juli-when-resource-trashed
+  (do-game
+    (new-game {:runner {:hand [(qty "Juli Moreira Lee" 2) (qty "Telework Contract" 2)]
+                        :credits 10}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Juli Moreira Lee")
+    (play-from-hand state :runner "Telework Contract")
+    (is (changed? [(get-counters (get-resource state 0) :power) -1
+                   (:click (get-runner)) 0]
+          (card-ability state :runner (get-resource state 1) 0))
+        "Runner gained 1 click from Juli Moreira Lee")
+    (trash state :runner (get-resource state 1))
+    (trash state :runner (get-resource state 0))
+    (play-from-hand state :runner "Juli Moreira Lee")
+    (play-from-hand state :runner "Telework Contract")
+    (is (changed? [(get-counters (get-resource state 0) :power) 0
+                   (:click (get-runner)) -1]
+          (card-ability state :runner (get-resource state 1) 0))
+        "Runner did NOT gain 1 click from Juli Moreira Lee")))
 
 (deftest kasi-string
   ;; Kasi String


### PR DESCRIPTION
Since we can't look back in time at the game state, we need to add a little bit of information. It is what it is.

Closes #7330
And I'm not sure what the exact issue was here, but this impl change should make it impossible as well, so this Closes #7387 too
