### PR TITLE
Fix Mitosis black screen when scoring/rezzing

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -3140,7 +3140,7 @@
                                     card :can-score
                                     (fn [state _ card]
                                       (if (same-card? card installed-card)
-                                        ((constantly false) (toast state :corp "Cannot score due to Warm Reception." "Warning"))
+                                        ((constantly false) (toast state :corp "Cannot score due to Warm Reception." "warning"))
                                         true)))
                                   (effect-completed state side eid))))}
         derez {:label "Derez another card (start of turn)"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1713,14 +1713,14 @@
                           card :can-rez
                           (fn [state _ card]
                             (if (same-card? card installed-card)
-                              ((constantly false) (toast state :corp "Cannot rez due to Mitosis." "Warning"))
+                              ((constantly false) (toast state :corp "Cannot rez due to Mitosis." "warning"))
                               true)))
                         (register-turn-flag!
                           state side
                           card :can-score
                           (fn [state _ card]
                             (if (same-card? card installed-card)
-                              ((constantly false) (toast state :corp "Cannot score due to Mitosis." "Warning"))
+                              ((constantly false) (toast state :corp "Cannot score due to Mitosis." "warning"))
                               true)))
                         (if (seq (rest target-cards))
                           (mitosis-ability state side card eid (rest target-cards))


### PR DESCRIPTION
We were sending prompts with type `"Warning"` when we actually wanted type `"warning"` :joy:.

Turns out we were also doing it with warm reception. We also fixed it at some point so it just bricks all future prompts instead of causing a black screen, which is I guess slightly more useful.

Anyway, both those issues are solved.

Closes #7184