### PR TITLE
Paying advancements or power counters no longer duplicates hosted trash can cards

### DIFF
--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -55,7 +55,7 @@
                (:cost/args acc)
                (:cost/args cur)))))
 
-(defn- cost-ranks
+(defn- display-cost-ranks
   [cost]
   (case (:cost/type cost)
     :click 1
@@ -64,6 +64,17 @@
     (:trash-can :remove-from-game) 4
     ; :else
     5))
+
+(defn- impl-cost-ranks
+  [cost]
+  (case (:cost/type cost)
+    :click 1
+    :lose-click 2
+    :credit 3
+    (:advancement :power :virus) 4
+    (:trash-can :remove-from-game) 5
+    ; :else
+    6))
 
 (defn merge-costs
   "Combines disparate costs into a single cost per type."
@@ -79,7 +90,7 @@
                      (and (= :credit (:cost/type %))
                           (zero? (:cost/amount %)))
                      false))
-          (sort-by cost-ranks)
+          (sort-by impl-cost-ranks)
           (into [])))))
 
 (comment
@@ -129,6 +140,7 @@
   [costs]
   (let [cost-string
         (->> (merge-costs costs)
+             (sort-by display-cost-ranks)
              (map label)
              (interpose ", ")
              (apply str))]

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2236,6 +2236,22 @@
         (click-advance state :corp (last (:hosted (refresh fir))))
         (is (= 11 (:credit (get-corp))) "Gained 1cr from advancing Oaktown"))))
 
+(deftest full-immersion-rec-vs-ngo-front-issue-#5617
+  (do-game
+    (new-game {:corp {:hand ["Full Immersion RecStudio" "NGO Front"]}})
+    (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
+    (let [rec (get-content state :remote1 0)]
+      (rez state :corp rec)
+      (card-ability state :corp (refresh rec) 0)
+      (click-card state :corp "NGO Front")
+      (let [ngo (first (:hosted (refresh rec)))]
+        (core/add-counter state :corp ngo :advancement 1)
+        (rez state :corp (refresh ngo))
+        (card-ability state :corp (refresh ngo) 0)
+        (is (not (refresh ngo)) "NGO gone"))
+      (is (not (seq (:hosted (refresh rec)))) "Rec Studio empty"))
+    (is (= ["NGO Front"] (map :title (:discard (get-corp)))) "Ngo Front is trashed")))
+
 (deftest fumiko-yamamori
   ;; Fumiko Yamamori
   (do-game


### PR DESCRIPTION
Because of our cost ranking system, we were paying the trash cost for a card, removing it from the host card, then paying the counter cost for the card, then updating it back onto the hosted card with update!.

This never really came up because, surprisingly, not a single runner card has been printed that has both:
* A trash cost
* A counter cost

We can't just rearrange the cost ranks because it looks ugly, so I separated them into one for implementation and one for display.

This is how long it took me to narrow the issue down:

![ngo](https://github.com/user-attachments/assets/1ba26e7c-dbb4-4ac6-883d-a5a373acd9aa)

Closes #5617