### PR TITLE
Slee vs Ankusa return to hand test

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -531,7 +531,7 @@
   {:events [{:event :end-of-encounter
              :req (req (pos? (count (remove :broken (:subroutines (:ice context))))))
              :msg (req (let [unbroken-count (count (remove :broken (:subroutines (:ice context))))]
-                        (str "place " (quantify unbroken-count "power counter") " on itself")))
+                         (str "place " (quantify unbroken-count "power counter") " on itself")))
              :effect (effect (add-counter :corp card :power (count (remove :broken (:subroutines (:ice context))))))}]
    :abilities [{:action true
                 :cost [(->c :click 1) (->c :power 5)]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -493,8 +493,9 @@
                                              (all-subs-broken-by-card? (:ice context) card)))
                               :msg (msg "add " (:title (:ice context))
                                         " to HQ after breaking all its subroutines")
-                              :effect (effect (move :corp (:ice context) :hand nil)
-                                              (continue :runner nil))}]}))
+                              :effect (req (set-current-ice state (:ice context))
+                                           (move state :corp (:ice context) :hand nil)
+                                           (continue state :runner nil))}]}))
 
 (defcard "Atman"
   {:on-install {:cost [(->c :x-credits)]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -493,8 +493,7 @@
                                              (all-subs-broken-by-card? (:ice context) card)))
                               :msg (msg "add " (:title (:ice context))
                                         " to HQ after breaking all its subroutines")
-                              :effect (req (set-current-ice state (:ice context))
-                                           (move state :corp (:ice context) :hand nil)
+                              :effect (req (move state :corp (:ice context) :hand nil)
                                            (continue state :runner nil))}]}))
 
 (defcard "Atman"

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -577,6 +577,8 @@
                                        (let [ice (get-card state ice)
                                              on-break-subs (when ice (:on-break-subs (card-def ice)))
                                              event-args (when on-break-subs {:card-abilities (ability-as-handler ice on-break-subs)})]
+                                         (when (same-card? ice (get-current-ice state))
+                                           (set-current-ice state ice))
                                          (wait-for
                                            (trigger-event-simult state side :subroutines-broken event-args (break-subs-event-context state ice broken-subs breaker))
                                            (let [ice (get-card state ice)

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -773,7 +773,8 @@
             (card-ability state :runner (refresh ankusa) 0)
             (click-prompt state :runner "End the run")
             (click-prompt state :runner "End the run")
-            (is (find-card "Battlement" (:hand (get-corp))) "Battlement should be back in hand"))
+            (is (find-card "Battlement" (:hand (get-corp))) "Battlement should be back in hand")
+            (run-continue state))
           "Slee did not gain counters for ankusa bounce"))))
 
 (deftest battering-ram-automated-test

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -753,6 +753,29 @@
         (click-prompt state :runner "End the run")
         (is (find-card "Battlement" (:hand (get-corp))) "Battlement should be back in hand"))))
 
+(deftest ankusa-vs-chief-slee
+  (do-game
+    (new-game {:corp {:hand ["Battlement" "Chief Slee"]}
+               :runner {:hand ["Ankusa"] :credits 16}})
+    (play-from-hand state :corp "Battlement" "HQ")
+    (play-from-hand state :corp "Chief Slee" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Ankusa")
+    (let [slee (get-content state :remote1 0)
+          ankusa (get-program state 0)]
+      (rez state :corp slee)
+      (run-on state "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state :encounter-ice)
+      (is (changed? [(get-counters (refresh slee) :power) 0]
+            (card-ability state :runner (refresh ankusa) 1)
+            (card-ability state :runner (refresh ankusa) 1)
+            (card-ability state :runner (refresh ankusa) 0)
+            (click-prompt state :runner "End the run")
+            (click-prompt state :runner "End the run")
+            (is (find-card "Battlement" (:hand (get-corp))) "Battlement should be back in hand"))
+          "Slee did not gain counters for ankusa bounce"))))
+
 (deftest battering-ram-automated-test
   (basic-program-test {:name "Atman"
                        :click-prompt-on-install "0"


### PR DESCRIPTION
Essentially, we need to update the current encounter before we end it (by bouncing the card), because slee looks at what the current encounter was when the encounter ends.

Closes #5834