### PR TITLE
tori hanzo no longer triggers PU mill

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1084,10 +1084,10 @@
 
 (defcard "Jinteki: Potential Unleashed"
   {:events [{:async true
-             :event :pre-resolve-damage
+             :event :damage
              :req (req (and
-                         (= target :net)
-                         (pos? (last targets))))
+                         (= (:damage-type context) :net)
+                         (pos? (:amount context))))
              :effect (req (let [c (first (get-in @state [:runner :deck]))]
                             (system-msg state :corp (str "uses " (:title card) " to trash " (:title c)
                                                          " from the top of the stack"))

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -2642,6 +2642,25 @@
     (play-from-hand state :corp "Neural EMP")
     (is (= 5 (count (:discard (get-runner)))))))
 
+(deftest jinteki-potential-unleashed-vs-tori-hanzo
+  ;; Potential Unleashed - when the runner takes at least one net damage, mill 1 from their deck
+  (do-game
+    (new-game {:corp {:id "Jinteki: Potential Unleashed"
+                      :deck ["Kakugo" "Tori Hanzō"]
+                      :credits 15}
+               :runner {:hand ["Sure Gamble"]
+                        :deck ["Easy Mark"]}})
+    (play-from-hand state :corp "Kakugo" "New remote")
+    (play-from-hand state :corp "Tori Hanzō" "Server 1")
+    (rez state :corp (get-ice state :remote1 0))
+    (rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (run-on state :remote1)
+    (run-continue-until state :movement)
+    (click-prompt state :corp "Yes")
+    (is (= ["Sure Gamble"] (map :title (:discard (get-runner)))) "Gamble trashed, easy mark not milled")
+    (is (= 1 (:brain-damage (get-runner))))))
+
 (deftest jinteki-replicating-perfection
   ;; Replicating Perfection - Prevent runner from running on remotes unless they first run on a central
   (do-game


### PR DESCRIPTION
Not sure why we made PU `pre-resolve-damage` in the first place, but rules says that damage is atomic and the mill happens after, so this fix is nice and easy.

Closes #6179