### PR TITLE
cloud eater logs the runner choice now

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1270,7 +1270,7 @@
                                               (= target "Suffer 3 net damage")
                                               {:msg (msg "force the Runner to " (decapitalize target))
                                                :effect (req (pay state :runner eid card [(->c :net 3)]))})
-                                            card nil))}
+                                            card targets))}
                                card nil))}]})
 
 (defcard "Cobra"

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1669,6 +1669,7 @@
       (is (changed? [(count-tags state) 2]
                     (click-prompt state :runner "Take 2 tags"))
           "Runner got 2 tags")
+      (is (last-log-contains? state "Cloud Eater to force the Runner to take 2 tag") "Correctly logs choice")
       (run-jack-out state)
       (take-credits state :runner)
       (take-credits state :corp)


### PR DESCRIPTION
Just needed to pass the targets through (or redef the target).

Closes #7653