### PR TITLE
deregister thunderbolt on run start too

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -2188,14 +2188,16 @@
                                                 (str payment-str
                                                      " due to " (:title card)
                                                      " subroutine")))
-                                  (effect-completed state side eid))))}]
-    {:events [{:event :run-ends
-               :effect (req (let [cid (:cid card)
-                                  ices (get-in card [:special :thunderbolt-armaments])]
-                              (doseq [i ices]
-                                (when-let [ice (get-card state i)]
-                                  (remove-sub! state side ice #(= cid (:from-cid %))))))
-                            (update! state side (dissoc-in card [:special :thunderbolt-armaments])))}
+                                  (effect-completed state side eid))))}
+        unregister-sub-event
+        {:effect (req (let [cid (:cid card)
+                            ices (get-in card [:special :thunderbolt-armaments])]
+                        (doseq [i ices]
+                          (when-let [ice (get-card state i)]
+                            (remove-sub! state side ice #(= cid (:from-cid %))))))
+                      (update! state side (dissoc-in card [:special :thunderbolt-armaments])))}]
+    {:events [(assoc unregister-sub-event :event :run-ends)
+              (assoc unregister-sub-event :event :run) ;; protection for trick shot...
               {:event :rez
                :req (req (and run
                               (ice? (:card context))

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -5146,6 +5146,23 @@
       (click-card state :runner "Smartware Distributor")
       (is (:run @state) "Run continues"))))
 
+(deftest thunderbolt-vs-trick-shot
+  (do-game
+    (new-game {:corp {:id "Thunderbolt Armaments: Peace Through Power"
+                      :deck ["Tithe"]}
+               :runner {:hand ["Trick Shot"]}})
+    (play-from-hand state :corp "Tithe" "New remote")
+    (let [tithe (get-ice state :remote1 0)]
+      (take-credits state :corp)
+      (play-from-hand state :runner "Trick Shot")
+      (rez state :corp tithe)
+      (is (= 2 (get-strength (refresh tithe))) "Tithe strength is buffed")
+      (is (= 3 (count (:subroutines (refresh tithe)))) "Tithe has 3 subroutines")
+      (run-continue state)
+      (click-prompt state :runner "Server 1")
+      (is (= 1 (get-strength (refresh tithe))) "Tithe strength is not buffed")
+      (is (= 2 (count (:subroutines (refresh tithe)))) "Tithe has 2 subroutines again"))))
+
 (deftest weyland-consortium-because-we-built-it-pay-credits-prompt
     ;; Pay-credits prompt
     (do-game


### PR DESCRIPTION
Until we find a better way to handle magic subroutines (like thunderbolt, or warden fatuma), I'm not sure there's a better way to do this.

Closes #7674