### PR TITLE
Added ffg's unreleased identities

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -3047,13 +3047,16 @@
 
 (defcard "Wage Workers"
   (let [payoff {:msg "gain [Click]"
-                :effect (effect (gain-clicks 1))}]
+                :effect (effect (gain-clicks 1))}
+        relevant-keys (fn [context] {:cid (get-in context [:card :cid])
+                                     :idx (:ability-idx context)})]
     {:events [{:event :action-resolved
                :req (req (= :corp side))
                :async true
                :effect (req (let [similar-actions
                                   (event-count state side :action-resolved
-                                               (fn [[ctx]] (= ctx context)))]
+                                               (fn [[ctx]] (= (relevant-keys ctx)
+                                                              (relevant-keys context))))]
                               (continue-ability
                                 state side
                                 (when (= 3 similar-actions) payoff)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -3047,18 +3047,17 @@
 
 (defcard "Wage Workers"
   (let [payoff {:msg "gain [Click]"
-                :effect (effect (gain-clicks 1))}
-        three-of (fn [state side cid idx]
-                   (= 3 (event-count state side :corp-spent-click
-                                     (fn [[context]]
-                                       (and (= cid (:action context))
-                                            (= idx (:ability-idx context)))))))]
-    {:events [{:event :corp-spent-click
+                :effect (effect (gain-clicks 1))}]
+    {:events [{:event :action-resolved
+               :req (req (= :corp side))
                :async true
-               :effect (req (let [{:keys [action ability-idx]} context]
-                              (if (three-of state side action ability-idx)
-                                (continue-ability state side payoff card nil)
-                                (effect-completed state side eid))))}]}))
+               :effect (req (let [similar-actions
+                                  (event-count state side :action-resolved
+                                               (fn [[ctx]] (= ctx context)))]
+                              (continue-ability
+                                state side
+                                (when (= 3 similar-actions) payoff)
+                                card nil)))}]}))
 
 (defcard "Wall to Wall"
   (let [all [{:msg "gain 1 [Credits]"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -491,7 +491,7 @@
 (defcard "Chaos Theory: Wünderkind"
   {:static-abilities [(mu+ 1)]})
 
-(defcard "Chronos Protocol: Haas Bioroid"
+(defcard "Chronos Protocol: Haas-Bioroid"
   {:events [{:event :damage
              :req (req (= (:damage-type context) :brain))
              :msg (msg "remove all copies of " (enumerate-str (map :title (:cards-trashed context))) ", everywhere, from the game")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -4,7 +4,7 @@
    [game.core.access :refer [access-bonus access-cost-bonus access-non-agenda]]
    [game.core.bad-publicity :refer [gain-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed card->server
-                            get-remote-names get-remotes server->zone]]
+                            get-all-cards get-remote-names get-remotes server->zone]]
    [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? faceup? get-advancement-requirement
                            get-agenda-points get-card get-counters get-title get-zone hardware? has-subtype?
@@ -490,6 +490,18 @@
 
 (defcard "Chaos Theory: Wünderkind"
   {:static-abilities [(mu+ 1)]})
+
+(defcard "Chronos Protocol: Haas Bioroid"
+  {:events [{:event :damage
+             :req (req (= (:damage-type context) :brain))
+             :msg (msg "remove all copies of " (enumerate-str (map :title (:cards-trashed context))) ", everywhere, from the game")
+             :effect (req (doseq [c (:cards-trashed context)]
+                            (let [all-candidates (filter #(and (not= (:zone %) [:rfg])
+                                                               (runner? %)
+                                                               (= (:title %) (:title c)))
+                                                         (get-all-cards state))]
+                              (doseq [candidate all-candidates]
+                                (move state :runner candidate :rfg)))))}]})
 
 (defcard "Chronos Protocol: Selective Mind-mapping"
   {:req (req (empty? (filter #(= :net (:damage-type (first %))) (turn-events state :runner :damage))))
@@ -2108,6 +2120,27 @@
 (defcard "The Catalyst: Convention Breaker"
   ;; No special implementation
   {})
+
+(defcard "The Collective: Williams, Wu, et al."
+  (let [gain-click-abi {:label "Manually gain [Click]"
+                        :once :per-turn
+                        :msg (msg "gain [Click]")
+                        :effect (req (gain-clicks state side 1))}]
+    {:events [{:event :action-resolved
+               :req (req (= :runner side))
+               :silent (req true)
+               :effect (req (let [current-queue (get-in card [:special :previous-actions])]
+                              (if (and (seq current-queue)
+                                       (= (first current-queue) context))
+                                (let [new-queue (concat current-queue [context])]
+                                  (update! state side (assoc-in card [:special :previous-actions] new-queue))
+                                  (if (= 3 (count new-queue))
+                                    (continue-ability state side gain-click-abi card nil)
+                                    (effect-completed state side eid)))
+                                (update! state side (assoc-in card [:special :previous-actions] [context])))))}
+              {:event :runner-turn-begins
+               :silent (req true)
+               :effect (req (update! state side (assoc-in card [:special :previous-actions] nil)))}]}))
 
 (defcard "The Foundry: Refining the Process"
   {:events [{:event :rez

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -63,7 +63,13 @@
     (when (or (nil? cost)
               (can-pay? state side eid card (:title card) cost))
       (update-click-state state ability)
-      (resolve-ability state side eid ability card targets))))
+      (if (:action ability)
+        (let [stripped-card (select-keys card [:cid :type :title])]
+        (wait-for
+          (trigger-event-simult state side :action-played nil {:ability-idx ability-idx :card stripped-card})
+          (wait-for
+            (resolve-ability state side ability card targets)
+            (trigger-event-simult state side eid :action-resolved nil {:ability-idx ability-idx :card stripped-card}))))))))
 
 (defn play-ability
   "Triggers a card's ability using its zero-based index into the card's card-def :abilities vector."

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -65,11 +65,12 @@
       (update-click-state state ability)
       (if (:action ability)
         (let [stripped-card (select-keys card [:cid :type :title])]
-        (wait-for
-          (trigger-event-simult state side :action-played nil {:ability-idx ability-idx :card stripped-card})
           (wait-for
-            (resolve-ability state side ability card targets)
-            (trigger-event-simult state side eid :action-resolved nil {:ability-idx ability-idx :card stripped-card}))))))))
+            (trigger-event-simult state side :action-played nil {:ability-idx ability-idx :card stripped-card})
+            (wait-for
+              (resolve-ability state side ability card targets)
+              (trigger-event-simult state side eid :action-resolved nil {:ability-idx ability-idx :card stripped-card}))))
+        (resolve-ability state side eid ability card targets)))))
 
 (defn play-ability
   "Triggers a card's ability using its zero-based index into the card's card-def :abilities vector."

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -6416,6 +6416,23 @@
           (click-credit state :corp)))
         "Corp spent 2 clicks instead of 3")))
 
+(deftest wage-workers-vs-ob-interaction
+  (do-game
+    (new-game {:corp {:deck ["Wage Workers"]
+                      :id "Ob Superheavy Logistics: Extract. Export. Excel."
+                      :hand ["Hedge Fund" "Subliminal Messaging" "Extract" "Mavirus"]}})
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Mavirus" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (is (changed? [(:click (get-corp)) 0]
+          (play-from-hand state :corp "Extract")
+          (click-card state :corp "Mavirus")
+          (click-prompt state :corp "Yes")
+          (click-prompt state :corp "Wage Workers")
+          (click-prompt state :corp "New remote"))
+        "Gained click from wage workers once the action finished resolving!")))
+
 (deftest wage-workers-multiple-triggers
   (do-game
     (new-game {:corp {:hand ["Wage Workers" (qty "Biotic Labor" 3)]

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -944,6 +944,15 @@
     (new-game {:runner {:id "Chaos Theory: Wünderkind"}})
     (is (= 5 (core/available-mu state)) "Chaos Theory starts the game with +1 MU")))
 
+(deftest chronos-protocol-haas-bioroid
+  (do-game
+    (new-game {:corp {:id "Chronos Protocol: Haas Bioroid" :hand []}
+               :runner {:hand ["Ika" "Street Peddler"] :deck [(qty "Ika" 5)] :discard ["Ika"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Street Peddler")
+    (damage state :corp :brain 1)
+    (is (= 7 (count (get-in @state [:runner :rfg]))) "7 Ikas rfg'd")))
+
 (deftest chronos-protocol-selective-mind-mapping
   ;; Chronos Protocol - Choose Runner discard for first net damage of a turn
   (do-game
@@ -4973,6 +4982,14 @@
             (click-card state :runner (refresh palisade))
             (click-card state :runner (refresh iw)))
           "Available MU should not change"))))
+
+(deftest the-collective-williams-wu-et-al
+  (do-game
+    (new-game {:runner {:id "The Collective: Williams, Wu, et al."}})
+    (take-credits state :corp)
+    (dotimes [_ 3]
+      (click-credit state :runner))
+    (is (= 2 (:click (get-runner))) "gained [click]")))
 
 (deftest the-foundry-refining-the-process-interaction-with-accelerated-beta-test
     ;; interaction with Accelerated Beta Test

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -946,7 +946,7 @@
 
 (deftest chronos-protocol-haas-bioroid
   (do-game
-    (new-game {:corp {:id "Chronos Protocol: Haas Bioroid" :hand []}
+    (new-game {:corp {:id "Chronos Protocol: Haas-Bioroid" :hand []}
                :runner {:hand ["Ika" "Street Peddler"] :deck [(qty "Ika" 5)] :discard ["Ika"]}})
     (take-credits state :corp)
     (play-from-hand state :runner "Street Peddler")


### PR DESCRIPTION
I thought it would be fun.

Note that these tests are gonna fail until netrunner-data is updated.

I added a PR in netrunner-data that inserts these, and they aren't legal for any formats except casual.
See: https://github.com/NoahTheDuke/netrunner-data/pull/54

Closes #4476

Additionally, I changed `play-ability` to be more aware of actions, and when an action is taken, it fires an event for pre-resolution and post-resolution (this was part of the collective).

Having done that, making wage workers behave right was pretty easy too, so I fixed that: Closes #7660