### PR TITLE
Some minor wording updates

### DIFF
--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -14,7 +14,9 @@
 (defn- change-msg
   "Send a system message indicating the property change"
   [state side kw new-val delta]
-  (let [key (name kw)]
+  (let [key (cond
+              (= kw :brain-damage) "core damage"
+              :else (name kw))]
     (system-msg state side
                 (str "sets " (.replace key "-" " ") " to " new-val
                      " (" (if (pos? delta) (str "+" delta) delta) ")"))))

--- a/src/cljs/nr/landing.cljs
+++ b/src/cljs/nr/landing.cljs
@@ -3,7 +3,7 @@
 (def landing-content
   [:div.landing.panel.content-page.blue-shade
    [:h2 "Welcome!"]
-   [:p "This website is for the facilitation of Netrunner games online. Please note that jinteki.net does not provide an accurate representation of the " [:u "rules"] " of the game."]
+   [:p "This website is for the facilitation of Netrunner games online. Please note that jinteki.net does not provide a complete implementation of the " [:u "rules"] " of the game."]
    [:h4 "The use of Jinteki.net:"]
    [:ul.list.compact
     [:li "Please be respectful. Any disrespectful conduct will not be tolerated regardless of the circumstance or rationale."]


### PR DESCRIPTION
I changed two bits of wording here.

First, I changed the landing page a little, because (at least to me) it sounded overly demeaning to our work (I understand that probably wasn't the intent):
From: `Please note that jinteki.net does not provide an accurate representation of the " [:u "rules"] " of the game.`
To: `Please note that jinteki.net does not provide a complete representation of the " [:u "rules"] " of the game.`
I believe our implementations are, for the most part, extremely accurate *(correct)* - just not *complete*.

Second, since we're doing key->name in `change-vals`, I added a fallback to present the changed value as core damage when the runner changes how much brain damage they have (see @Larrea-Mon's comment in #6435).