### PR TITLE
ice strength moved away from ice art

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -875,6 +875,12 @@
                         transform(rotate(90deg))
                         cursor: pointer
 
+                        .strength
+                            bottom: unset
+                            left: unset
+                            right: 3px
+                            top: 3px
+
                         &.host
                             margin-bottom: 15px
                             margin-top: 5px;

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -161,6 +161,7 @@
         line-height: 1.5rem
         text-align: center
         margin: 2px
+        pointer-events: none
 
     .advance-counter
         background-color: alpha(blue-core, o-80)


### PR DESCRIPTION
I moved the ice strength off the art, and made it so whatever perspective you are, it tends towards the center of the page (where your view is most likely to be concentrated).

See:
![ice-str-positioning_000](https://github.com/user-attachments/assets/e71e9701-55cf-4d42-87b5-5747fb9d841c)
![ice-str-positioning](https://github.com/user-attachments/assets/57461982-3f86-4c0d-8d38-3bd42e9b1ebe)

Closes #4462

I also added a `pointer-events: none` into the css for `.counter`, which should (I think) stop some browsers (don't know which ones) turning the mouse into an I-bar when hovering counters.

Closes #7652