### PR TITLE
unregister keydown listener when leaving replay

### DIFF
--- a/src/cljs/nr/gameboard/replay.cljs
+++ b/src/cljs/nr/gameboard/replay.cljs
@@ -291,6 +291,10 @@
      (fn [this]
        (-> js/document (.addEventListener "keydown" handle-keydown)))
 
+     :component-will-unmount
+     (fn [this]
+       (-> js/document (.removeEventListener "keydown" handle-keydown)))
+
      :reagent-render
      (fn []
        [:div.replay.panel.blue-shade


### PR DESCRIPTION
Turns out this was the piece of the puzzle for getting pushed back into replays after joining a game.

Closes #6386
Closes #7290
Closes #5800