### PR TITLE
Gateway precon automation

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -23,7 +23,7 @@
     user :user
     {:keys [gameid now
             allow-spectator api-access format mute-spectators password room save-replay
-            side singleton spectatorhands timer title]
+            gateway-type side singleton spectatorhands timer title]
      :or {gameid (random-uuid)
           now (inst/now)}} :options}]
   (let [player {:user user
@@ -38,6 +38,7 @@
      :runner-spectators []
      :messages []
      ;; options
+     :gateway-type (when (= (str format) "system-gateway") gateway-type)
      :allow-spectator allow-spectator
      :api-access api-access
      :format format
@@ -113,6 +114,7 @@
    :date
    :format
    :gameid
+   :gateway-type
    :messages
    :mute-spectators
    :original-players

--- a/src/clj/web/preconstructed.clj
+++ b/src/clj/web/preconstructed.clj
@@ -1,0 +1,96 @@
+(ns web.preconstructed)
+
+(def gateway-beginner-corp
+  {:format "system-gateway"
+   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code 30077}
+   :name "System Gateway Starter Corp"
+   :cards [{:qty 3 :card "Offworld Office"}
+           {:qty 2 :card "Send a Message"}
+           {:qty 2 :card "Superconducting Hub"}
+           {:qty 2 :card "Nico Campaign"}
+           {:qty 2 :card "Regolith Mining License"}
+           {:qty 2 :card "Urtica Cipher"}
+           {:qty 2 :card "Government Subsidy"}
+           {:qty 3 :card "Hedge Fund"}
+           {:qty 2 :card "Seamless Launch"}
+           {:qty 1 :card "Manegarm Skunkworks"}
+           {:qty 2 :card "Brân 1.0"}
+           {:qty 3 :card "Palisade"}
+           {:qty 2 :card "Diviner"}
+           {:qty 2 :card "Whitespace"}
+           {:qty 2 :card "Karunā"}
+           {:qty 2 :card "Tithe"}]})
+
+(def gateway-intermediate-corp
+  {:format "system-gateway"
+   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code 30077}
+   :name "System Gateway Starter Corp"
+   :cards [{:qty 3 :card "Offworld Office"}
+           {:qty 2 :card "Send a Message"}
+           {:qty 2 :card "Orbital Superiority"}
+           {:qty 2 :card "Predictive Planogram"}
+           {:qty 2 :card "Public Trail"}
+           {:qty 1 :card "Retribution"}
+           {:qty 1 :card "AMAZE Amusements"}
+           {:qty 2 :card "Funhouse"}
+           {:qty 2 :card "Superconducting Hub"}
+           {:qty 2 :card "Nico Campaign"}
+           {:qty 2 :card "Regolith Mining License"}
+           {:qty 2 :card "Urtica Cipher"}
+           {:qty 2 :card "Government Subsidy"}
+           {:qty 3 :card "Hedge Fund"}
+           {:qty 2 :card "Seamless Launch"}
+           {:qty 1 :card "Manegarm Skunkworks"}
+           {:qty 2 :card "Brân 1.0"}
+           {:qty 3 :card "Palisade"}
+           {:qty 2 :card "Diviner"}
+           {:qty 2 :card "Whitespace"}
+           {:qty 2 :card "Karunā"}
+           {:qty 2 :card "Tithe"}]})
+
+(def gateway-beginner-runner
+  {:format "system-gateway"
+   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code 30076}
+   :name "System Gateway Starter Runner"
+   :cards [{:qty 2 :card "Creative Commission"}
+           {:qty 3 :card "Jailbreak"}
+           {:qty 2 :card "Overclock"}
+           {:qty 3 :card "Sure Gamble"}
+           {:qty 2 :card "Tread Lightly"}
+           {:qty 2 :card "VRcation"}
+           {:qty 1 :card "Docklands Pass"}
+           {:qty 1 :card "Pennyshaver"}
+           {:qty 1 :card "Red Team"}
+           {:qty 2 :card "Smartware Distributor"}
+           {:qty 2 :card "Telework Contract"}
+           {:qty 1 :card "Verbal Plasticity"}
+           {:qty 2 :card "Carmen"}
+           {:qty 2 :card "Cleaver"}
+           {:qty 2 :card "Mayfly"}
+           {:qty 2 :card "Unity"}]})
+
+(def gateway-intermediate-runner
+  {:format "system-gateway"
+   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code 30076}
+   :name "System Gateway Starter Runner"
+   :cards [{:qty 2 :card "Creative Commission"}
+           {:qty 3 :card "Jailbreak"}
+           {:qty 2 :card "Overclock"}
+           {:qty 2 :card "Mutual Favor"}
+           {:qty 2 :card "Wildcat Strike"}
+           {:qty 2 :card "DZMZ Optimizer"}
+           {:qty 2 :card "Conduit"}
+           {:qty 2 :card "Leech"}
+           {:qty 3 :card "Sure Gamble"}
+           {:qty 2 :card "Tread Lightly"}
+           {:qty 2 :card "VRcation"}
+           {:qty 1 :card "Docklands Pass"}
+           {:qty 1 :card "Pennyshaver"}
+           {:qty 1 :card "Red Team"}
+           {:qty 2 :card "Smartware Distributor"}
+           {:qty 2 :card "Telework Contract"}
+           {:qty 1 :card "Verbal Plasticity"}
+           {:qty 2 :card "Carmen"}
+           {:qty 2 :card "Cleaver"}
+           {:qty 2 :card "Mayfly"}
+           {:qty 2 :card "Unity"}]})

--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -299,6 +299,11 @@
            :side "Side"
            :format "Format"
            :default-game-format "Default game format"
+           :gateway-format {:beginner "Beginner"
+                            :beginner-info "This lobby is using the System Gateway beginner decks for the Corporation and Runner. These decks are recommended for your first games. Games are played to 6 agenda points."
+                            :intermediate "Intermediate"
+                            :intermediate-info "This lobby is using the System Gateway intermediate decks for the Corporation and Runner. These decks have slightly more range than the beginner decks. Games are played to 7 agenda points."
+                            :constructed "Constructed"}
            :singleton "Singleton"
            :singleton-b "(singleton)"
            :singleton-details "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -325,7 +325,7 @@
                      :disabled (not (or (:sounds @s) (:lobby-sounds @s)))}]]]
 
         [:section
-         [:h3 (tr [:lobby.format "Format"])]
+         [:h3 (tr [:lobby.default-game-format "Default game format"])]
          [:select.format
           {:value (or (:default-format @s) "standard")
            :on-change #(swap! s assoc-in [:default-format] (.. % -target -value))}

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -176,10 +176,20 @@
         (let [c (count (:spectators game))]
           (when (pos? c) (str " (" (tr [:lobby.spectator-count] c) ")"))))])
 
-(defn game-format [{fmt :format singleton? :singleton}]
+(defn- gateway-type-span [gateway-type]
+  (cond
+    (= gateway-type "Beginner")
+    [:span.format-precon (str " (" (tr [:lobby.gateway-format.beginner "Beginner"]) ")")]
+    (= gateway-type "Intermediate")
+    [:span.format-precon (str " (" (tr [:lobby.gateway-format.intermediate "Intermediate"]) ")")]
+    (= gateway-type "Constructed")
+    [:span.format-precon (str " (" (tr [:lobby.gateway-format.constructed "Constructed"]) ")")]))
+
+(defn game-format [{fmt :format singleton? :singleton gateway-type :gateway-type}]
   [:div {:class "game-format"}
-   [:span.format-label (tr [:lobby.default-game-format "Default game format"]) ":  "]
+   [:span.format-label (tr [:lobby.format "Format"]) ":  "]
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
+   [gateway-type-span gateway-type]
    [:span.format-singleton (str (when singleton? (str " " (tr [:lobby.singleton-b "(singleton)"]))))]])
 
 (defn- time-since

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -3,7 +3,7 @@
    [jinteki.utils :refer [str->int]]
    [nr.appstate :refer [app-state]]
    [nr.auth :refer [authenticated] :as auth]
-   [nr.translations :refer [tr tr-format tr-side]]
+   [nr.translations :refer [tr tr-string tr-format tr-side]]
    [nr.utils :refer [slug->format]]
    [nr.ws :as ws]
    [reagent.core :as r]))
@@ -18,6 +18,7 @@
    :side
    :singleton
    :spectatorhands
+   :gateway-type
    :timer
    :title])
 
@@ -75,7 +76,21 @@
             :on-change #(swap! options assoc :singleton (.. % -target -checked))}]
    (tr [:lobby.singleton "Singleton"])])
 
-(defn format-section [fmt-state options]
+(defn gateway-constructed-choice [fmt-state gateway-type]
+  [:div
+   {:style {:display (if (= @fmt-state "system-gateway") "block" "none")}}
+   (doall
+     (for [option ["Beginner" "Intermediate" "Constructed"]]
+       ^{:key option}
+       [:span [:label [:input
+                       {:type "radio"
+                        :name "gateway-type"
+                        :value option
+                        :on-change #(reset! gateway-type (.. % -target -value))
+                        :checked (= @gateway-type option)}]
+              (str (tr-string "lobby.gateway-format" option) "    ")]]))])
+
+(defn format-section [fmt-state options gateway-type]
   [:section
    [:h3 (tr [:lobby.default-game-format "Default game format"])]
    [:select.format
@@ -86,6 +101,7 @@
         ^{:key k}
         [:option {:value k} (tr-format v)]))]
    [singleton-only options fmt-state]
+   [gateway-constructed-choice fmt-state gateway-type]
    [:div.infobox.blue-shade
     {:style {:display (if (:singleton @options) "block" "none")}}
     [:p (tr [:lobby.singleton-details "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."])]
@@ -196,6 +212,7 @@
                               :format (or (get-in @app-state [:options :default-format]) "standard")
                               :room (:room @lobby-state)
                               :side "Any Side"
+                              :gateway-type "Beginner"
                               :title (str (:username @user) "'s game")})
                options (r/atom {:allow-spectator true
                                 :api-access false
@@ -208,6 +225,7 @@
                                 :timer nil})
                title (r/cursor state [:title])
                side (r/cursor state [:side])
+               gateway-type (r/cursor state [:gateway-type])
                fmt (r/cursor state [:format])
                flash-message (r/cursor state [:flash-message])]
     (fn [lobby-state user]
@@ -218,5 +236,5 @@
        [:div.content
         [title-section title]
         [side-section side]
-        [format-section fmt options]
+        [format-section fmt options gateway-type]
         [options-section options user]]])))


### PR DESCRIPTION
I made it so you can start games with the gateway precon decks (beginner/intermediate), or in constructed, when choosing the gateway format.

Closes #5720
Closes #7681

Here's a video (this is before I finished everything, so the text still has some typos):

[2024-08-31 19-36-09.webm](https://github.com/user-attachments/assets/03e641c2-6f10-475f-a38e-632a79a4a08d)

* When creating a gateway game, there's a pop-up radio-menu that lets you choose beginner, intermediate or constructed
* Constructed is what we already have
* Beginner and intermediate will remove the deck-picking functionality from the lobby. Instead, when a game is started, the players will load in with the starter deck for the selected side and complexity (beginner/intermediate)

Additionally, because it was bugging me:
* The format in the game-row (the thing you see in the lobby) now says "format", instead of default format. That's the one you're selecting.
* The one in your options page now says "default format", instead of format.
idk why these keys got mixed up, but it looks ugly to see "Default game format" take up half the game-row box on 15 different games. It makes the actual format chosen more difficult to spot in comparison.