### PR TITLE
default options on new accounts

### DIFF
--- a/src/clj/web/user.clj
+++ b/src/clj/web/user.clj
@@ -36,7 +36,8 @@
      :lastConnection   registration-date
      :password         (password/encrypt password)
      :isadmin          (or isadmin false)
-     :options          {}}))
+     :options          {:default-format "standard"
+                        :pronouns "none"}}))
 
 (defn active-user?
   "Returns the given user if it exists and is not banned"


### PR DESCRIPTION
Since updating either or both of these in the account page has been touted as a solution for the problems in #7352, #7341, #6949, and possible another one or two I couldn't track down.

I figure it's worth trying this, and if the issue persists, then we know it's some other key that's borked and not these ones.