### PR TITLE
dont duplicate cards trashed during checkpoints

### DIFF
--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -57,6 +57,7 @@
                                     :trash
                                     (update h :zone #(map to-keyword %))
                                     {:unpreventable true
+                                     :suppress-checkpoint true
                                      :host-trashed true
                                      :game-trash true})
                        nil)

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -300,6 +300,19 @@
       (is (= 2 (count (:hand (get-runner)))) "Card was added to grip")
       (is (= 1 (count (:discard (get-runner)))) "Asmund Pudlat was trashed"))))
 
+(deftest asmund-pudlat-doesnt-duplicate-self
+  ;; Asmund Pudlat
+  (do-game
+    (new-game {:runner {:hand [(qty "Asmund Pudlat" 2)]
+                        :deck ["Unregistered S&W '35" (qty "Fermenter" 2)]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Asmund Pudlat")
+    (click-prompt state :runner "Fermenter")
+    (click-prompt state :runner "Unregistered S&W '35")
+    (play-from-hand state :runner "Asmund Pudlat")
+    (is (is-discard? state :runner ["Fermenter" "Unregistered S&W '35" "Asmund Pudlat"])
+        "Didn't duplicate asmund")))
+
 (deftest amelia-earhart
   (do-game
     (new-game {:runner {:hand ["Amelia Earhart" "The Maker's Eye" (qty "Legwork" 2)]


### PR DESCRIPTION
Uniques and consoles are trashed by the game during checkpoints.
* When they host cards, we first trash those cards
* When those cards get trashed, they each have a checkpoint
* Uniques and consoles are trashed by the game during those checkpoints
* We end up with X+1 copies of the host in the trash

So I'm suppressing the trash-events for the hosted cards until the same time as the host dies. I think under the CR, hosted cards get trashed *after* the host does (this is literally only relevant for the draft anarch id, you can't instantly recur your parasites), so we're at least a step closer to that.