### PR TITLE
undo-turn resets the 'started-turn' flag

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -210,6 +210,7 @@
                                   :turn-state turn-state)]
         (reset! state original-turn-state))
       (doseq [s [:runner :corp]]
+        (swap! state dissoc-in [s :turn-started])
         (toast state s "Game reset to start of turn")))))
 
 (defn command-unique

--- a/test/clj/game/core/actions_test.clj
+++ b/test/clj/game/core/actions_test.clj
@@ -33,7 +33,13 @@
     (core/command-undo-turn state :corp)
     (is (= 3 (count (:hand (get-corp)))) "Corp has 3 cards in HQ")
     (is (zero? (:click (get-corp))) "Corp has no clicks - turn not yet started")
-    (is (= 5 (:credit (get-corp))) "Corp has 5 credits")))
+    (is (= 5 (:credit (get-corp))) "Corp has 5 credits")
+    (start-turn state :corp)
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Hedge Fund")
+    (is (= 1 (:click (get-corp))) "Corp spent 2 clicks")
+    (is (= 13 (:credit (get-corp))) "Corp has 13 credits")
+    (is (= 1 (count (:hand (get-corp)))) "Corp has 1 card in HQ")))
 
 (deftest undo-click
   (do-game

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -303,6 +303,47 @@
         (core/command-parser state :corp {:user user :text "/trace 99999999999999999999999999999999999999999999"})
         (is (= 1000 (:base (prompt-map :corp))) "Base trace should now be 1000"))))
 
+  (testing "/undo-click"
+    (let [r {:username "Runner"}
+          c {:username "Corp"}]
+      (do-game
+        (new-game {:corp {:hand ["Hedge Fund"]}})
+        (dotimes [n 3]
+          (click-credit state :corp))
+        (end-turn state :corp)
+        (start-turn state :runner)
+        (is (changed? [(:click (get-runner)) -1
+                       (:credit (get-runner)) +1]
+              (click-credit state :runner))
+            "Clicked for a cred")
+        (core/command-parser state :runner {:user r :text "/undo-click"})
+        (core/command-parser state :runner {:user r :text "/undo-click"})
+        (is (changed? [(:click (get-runner)) -1
+                       (:credit (get-runner)) +1]
+              (click-credit state :runner))
+            "Clicked for a cred after undoing more clicks than there were taken"))))
+
+  (testing "/undo-turn"
+    (let [r {:username "Runner"}
+          c {:username "Corp"}]
+      (do-game
+        (new-game {:corp {:hand ["Hedge Fund"]}})
+        (dotimes [n 3]
+          (click-credit state :corp))
+        (end-turn state :corp)
+        (start-turn state :runner)
+        (is (changed? [(:click (get-runner)) -1
+                       (:credit (get-runner)) +1]
+              (click-credit state :runner))
+            "Clicked for a cred")
+        (core/command-parser state :runner {:user r :text "/undo-turn"})
+        (core/command-parser state :corp {:user c :text "/undo-turn"})
+        (start-turn state :runner)
+        (is (changed? [(:click (get-runner)) -1
+                       (:credit (get-runner)) +1]
+              (click-credit state :runner))
+            "Clicked for a cred after restarting turn"))))
+
   (testing "/unique"
     (let [user {:username "Runner"}]
       (do-game


### PR DESCRIPTION
~~Turns out we had no unit tests for undo turn~~ turns out we did, but it wasn't a very complete one.

Closes #7717