### PR TITLE
Add preconstructed to the visible format list

### DIFF
--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -16,13 +16,13 @@
                                   "startup"
                                   "sunset"
                                   "eternal"
+                                  "preconstructed"
                                   "snapshot"
                                   "snapshot-plus"
                                   "neo"
                                   "casual"}
         serialized (get-local-value "visible-formats" "")]
     (if (empty? serialized) default-visible-formats (set (.parse js/JSON serialized)))))
-
 
 (def app-state
   (r/atom {:active-page "/"


### PR DESCRIPTION
Would be nice if it wasn't hidden by default :)

I also removed an extra line of whitespace