### PR TITLE
added some more cpu logging

### DIFF
--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -36,7 +36,7 @@
   [state side {:keys [user text] :as args}]
   (let [author (or user (get-in @state [side :user]))
         text (if (= (str/trim text) "null") " null" text)]
-    (if-let [command (parse-command text)]
+    (if-let [command (parse-command state text)]
       (when (and (not= side nil) (not= side :spectator))
         (command state side)
         (system-say state side (str "[!]" (:username author) " uses a command: " text)))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -61,7 +61,7 @@
   [{state :state :as lobby} side user message]
   (when (and state @state)
     (let [message (if (= (str/trim message) "null") " null" message)]
-      (if (and side user (parse-command message))
+      (if (and side user (parse-command state message))
         (update-and-send-diffs! main/handle-say lobby side user message)
         ;; if side is nil, then it's a notification
         (let [f (if (some? side) main/handle-say main/handle-notification)

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -11,7 +11,7 @@
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
 
-(def log-stat-frequency (enc/ms :secs 15))
+(def log-stat-frequency (enc/ms :mins 15))
 
 (defn subscriber-time-metrics
   "average time | oldest"

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -5,14 +5,13 @@
    [cljc.java-time.duration :as duration]
    [cljc.java-time.instant :as inst]
    [game.core.board :refer [all-active]]
-   [sigmund.commands.cpu-load :as cl]
    [web.app-state :refer [app-state]]
    [web.lobby :refer [lobby-update-uids]]
    [web.ws :refer [connected-sockets connections_]]
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
 
-(def log-stat-frequency (enc/ms :mins 5))
+(def log-stat-frequency (enc/ms :secs 15))
 
 (defn subscriber-time-metrics
   "average time | oldest"
@@ -35,6 +34,29 @@
   [lobbies]
   (frequencies (reduce concat [] (map lobby->active-cards (vals lobbies)))))
 
+(defn lobby->recent-commands
+  [lobby]
+  (if (:started lobby)
+    (let [state (:state lobby)
+          commands (or (:command-log @state) [])
+          recent (filter #(inst/is-after (inst/plus-seconds (:timestamp %) (* 15 60)) (inst/now))
+                         commands)]
+      (map :command recent))
+    []))
+
+(defn recent-command-frequencies
+  [lobbies]
+  (frequencies (reduce concat [] (map lobby->recent-commands (vals lobbies)))))
+
+(defn- heap-usage
+  []
+  (.getHeapMemoryUsage (java.lang.management.ManagementFactory/getMemoryMXBean)))
+
+(defn- system-load-average
+  []
+  (let [bean (java.lang.management.ManagementFactory/getOperatingSystemMXBean)]
+    (str (int (* 100 (/ (.getSystemLoadAverage bean) (.getAvailableProcessors bean)))) "%")))
+
 (defonce log-stats
   (go (while true
     (<! (timeout log-stat-frequency))
@@ -42,7 +64,8 @@
           lobbies-count (count lobbies)
           players (reduce + 0 (map #(count (:players %)) (vals lobbies)))
           spectators (reduce + 0 (map #(count (:spectators %)) (vals lobbies)))
-          freqs (active-card-frequencies lobbies)
+          card-freqs (active-card-frequencies lobbies)
+          cmd-freqs (recent-command-frequencies lobbies)
           user-cache-count (count (:users @app-state))
           lobby-sub-count (count (filter identity (vals (:lobby-updates @app-state))))
           lobby-update-uids (count (lobby-update-uids))
@@ -74,5 +97,7 @@
                      " }"))
       ;; TODO - once we've got this set up on the server, wrap it in a try/catch - only ever display
       ;; the warning once!
-      (timbre/info (str "Active Cards (across all lobbies): " freqs))
-      (timbre/info (str (with-out-str (cl/print-cpu-load) "\n\n")))))))
+      (timbre/info (str "Active Cards (across all lobbies): " card-freqs))
+      (timbre/info (str "Recent Commands (across all lobbies): " cmd-freqs))
+      (timbre/info (str "System Load (average): " (system-load-average)
+                        " - heap: " (heap-usage) "\n"))))))

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -11,7 +11,7 @@
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
 
-(def log-stat-frequency (enc/ms :mins 15))
+(def log-stat-frequency (enc/ms :mins 5))
 
 (defn subscriber-time-metrics
   "average time | oldest"
@@ -39,7 +39,7 @@
   (if (:started lobby)
     (let [state (:state lobby)
           commands (or (:command-log @state) [])
-          recent (filter #(inst/is-after (inst/plus-seconds (:timestamp %) (* 15 60)) (inst/now))
+          recent (filter #(inst/is-after (inst/plus-seconds (:timestamp %) (* 5 60)) (inst/now))
                          commands)]
       (map :command recent))
     []))


### PR DESCRIPTION
* Count of active players and spectators
* Frequency map of all active cards across all games
* ~~CPU utilization via sigmund~~ CPU utilization via `java.lang.management.ManagementFactory/getOperatingSystemMXBean`
* Heap utilization via `java.lang.management.ManagementFactory/getMemoryMXBean`
* Frequency map of all recently used commands

see:
![info_000](https://github.com/user-attachments/assets/0e878c50-c23b-4ceb-8516-3616c17fab77)

Once we've run this one the server for a day or two, I'll write some code to parse our server logs and try and identify if anything in particular (cards, spectators, etc) happens to correspond to the spikes.

~~Sigmund relies on some native code (`libsigar-...so`), and I don't know what that's going to look like on our production server, so we may have to spend a few minutes figuring out which exact libs go where, or alternatively how to actually just cram those into the jar.~~