### PR TITLE
use stringer/strcat instead of str for all of our string composition

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -61,6 +61,7 @@
                  [org.clojure/data.csv "1.0.0"]
                  [dev.weavejester/medley "1.8.0"]
                  [org.slf4j/slf4j-nop "1.7.32"]
+                 [stringer "0.4.1"]
                  [integrant "0.8.0"]
                  [cljc.java-time "0.1.18"]
                  [time-literals "0.1.5"]

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -24,7 +24,8 @@
    [game.core.to-string :refer [card-str]]
    [game.macros :refer [effect msg req wait-for]]
    [game.utils :refer :all]
-   [jinteki.utils :refer :all]))
+   [jinteki.utils :refer :all]
+   [stringer.core :as s]))
 ;; Card definitions
 
 (defcard "Corp Basic Action Card"
@@ -130,18 +131,18 @@
                               (wait-for (resolve-ability
                                           state side
                                           (make-eid state eid)
-                                          {:prompt (str "Pay the additional cost to trash " (:title target) "?")
+                                          {:prompt (s/strcat "Pay the additional cost to trash " (:title target) "?")
                                            :choices [(when can-pay cost-strs) "No"]
                                            :async true
                                            :effect (req (if (= target "No")
-                                                          (do (system-msg state side (str "declines to pay the additional cost to trash " (:title target)))
+                                                          (do (system-msg state side (s/strcat "declines to pay the additional cost to trash " (:title target)))
                                                               (effect-completed state side eid))
                                                           (wait-for (pay state side (make-eid state
                                                                                               (assoc eid
                                                                                                      :additional-costs additional-costs
                                                                                                      :source-type :trash-card))
                                                                          nil additional-costs)
-                                                                    (system-msg state side (str (:msg async-result) " as an additional cost to trash " (:title target)))
+                                                                    (system-msg state side (s/strcat (:msg async-result) " as an additional cost to trash " (:title target)))
                                                                     (complete-with-result state side eid target))))}
                                           card nil)
                                         (if async-result

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -59,7 +59,8 @@
    [game.core.winning :refer [check-win-by-agenda]]
    [game.macros :refer [continue-ability effect msg req wait-for]]
    [game.utils :refer :all]
-   [jinteki.utils :refer :all]))
+   [jinteki.utils :refer :all]
+   [stringer.core :as s]))
 
 ;;; Helper functions for Draft cards
 (def draft-points-target
@@ -114,7 +115,7 @@
                                      state side
                                      {:optional
                                       {:waiting-prompt true
-                                       :prompt (req (str "Pay 1 [Credits] to prevent exposing " (card-str state (:card context)) "?"))
+                                       :prompt (req (s/strcat "Pay 1 [Credits] to prevent exposing " (card-str state (:card context)) "?"))
                                        :player :corp
                                        :no-ability
                                        {:async true
@@ -125,7 +126,7 @@
                                         (req (wait-for
                                                (pay state :corp (make-eid state eid) card [(->c :credit 1)])
                                                (system-msg state :corp
-                                                           (str (:msg async-result)
+                                                           (s/strcat (:msg async-result)
                                                                 " to prevent exposing "
                                                                 (card-str state (:card context))))
                                                (effect-completed state side eid)))}}}
@@ -174,7 +175,7 @@
                                           :async true
                                           :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target saved] (zone->name (second (get-zone %))))
                                                                                    (all-installed state :corp))]
-                                                         (system-msg state side (str "chooses " target " and " saved " to be saved from the rules apocalypse and trashes "
+                                                         (system-msg state side (s/strcat "chooses " target " and " saved " to be saved from the rules apocalypse and trashes "
                                                                                      (quantify (count to-be-trashed) "card")))
                                                          ;; these cards get trashed by the game and not by players
                                                          (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
@@ -204,7 +205,7 @@
                             (swap! state assoc-in [:runner :play-area] directives)
                             (continue-ability
                               state side
-                              {:prompt (str "Choose 3 starting directives")
+                              {:prompt (s/strcat "Choose 3 starting directives")
                                :choices {:max 3
                                          :all true
                                          :card #(and (runner? %)
@@ -214,13 +215,13 @@
                                                 state side
                                                 (make-eid state eid) (first targets)
                                                 {:ignore-all-cost true
-                                                 :custom-message (fn [_] (str "starts with " (:title (first targets)) " in play"))})
+                                                 :custom-message (fn [_] (s/strcat "starts with " (:title (first targets)) " in play"))})
                                               (wait-for
                                                 (runner-install
                                                   state side
                                                   (make-eid state eid) (second targets)
                                                   {:ignore-all-cost true
-                                                   :custom-message (fn [_] (str "starts with " (:title (second targets)) " in play"))})
+                                                   :custom-message (fn [_] (s/strcat "starts with " (:title (second targets)) " in play"))})
                                                 (wait-for
                                                   (runner-install
                                                   state side
@@ -229,7 +230,7 @@
                                                                            next
                                                                            first)
                                                   {:ignore-all-cost true
-                                                   :custom-message (fn [_] (str "starts with " (:title (-> targets
+                                                   :custom-message (fn [_] (s/strcat "starts with " (:title (-> targets
                                                                            next
                                                                            next
                                                                            first)) " in play"))})
@@ -360,7 +361,7 @@
                                                                (if (has-subtype? program "Trojan")
                                                                  (update! state :runner (dissoc-in program [:special :street-artist]))
                                                                  (do
-                                                                   (system-msg state side (str "uses " (:title card) " to trash " (:title program)))
+                                                                   (system-msg state side (s/strcat "uses " (:title card) " to trash " (:title program)))
                                                                    (trash-cards state side eid [program] {:cause-card card})))))}])))}
                     card nil))}]})
 
@@ -436,8 +437,8 @@
              :choices ["Event" "Resource" "Program" "Hardware" "None"]
              :effect (req (update! state side (assoc card :card-target (if (= "None" target) nil target)))
                           (if (= "None" target)
-                            (system-msg state side (str "declines to use " (:title card)))
-                            (system-msg state side (str "uses " (:title card) " to name " target))))}
+                            (system-msg state side (s/strcat "declines to use " (:title card)))
+                            (system-msg state side (s/strcat "uses " (:title card) " to name " target))))}
             {:event :runner-install
              :req (req (and (:card-target card)
                             (is-type? (:card context) (:card-target card))
@@ -535,7 +536,7 @@
                           :effect (req (chosen-damage state :corp target))}
                          card nil))}
               :no-ability
-              {:effect (req (system-msg state :corp (str "declines to use " (:title card))))}}}]})
+              {:effect (req (system-msg state :corp (s/strcat "declines to use " (:title card))))}}}]})
 
 (defcard "Cybernetics Division: Humanity Upgraded"
   {:static-abilities [(hand-size+ -1)]})
@@ -550,7 +551,7 @@
                                        (assoc card
                                               :flipped true
                                               :face :back
-                                              :code (str (subs (:code card) 0 5) "flip")))))]
+                                              :code (s/strcat (subs (:code card) 0 5) "flip")))))]
     {:flags {:server-limit 1}
      :events [{:event :pre-first-turn
                :req (req (= side :corp))
@@ -573,7 +574,7 @@
                           :async true
                           :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target] (zone->name (second (get-zone %))))
                                                                    (all-installed state :corp))]
-                                         (system-msg state side (str "chooses " target
+                                         (system-msg state side (s/strcat "chooses " target
                                                                      " to be saved from the rules apocalypse and trashes "
                                                                      (quantify (count to-be-trashed) "card")))
                                         ; these cards get trashed by the game and not by players
@@ -601,7 +602,7 @@
                                 (swap! state assoc-in [:runner :register :trashed-card] true)
                                 (swap! state assoc-in [:runner :register :trashed-accessed-card] true)
                                 (system-msg state :runner
-                                            (str "uses " (:title card) " to"
+                                            (s/strcat "uses " (:title card) " to"
                                                  " trash " (:title target)
                                                  " at no cost"))
                                 (trash state side eid target nil))))}]})
@@ -638,7 +639,7 @@
                                             :choices (cancellable (filter #(corp-installable-type? %) top))
                                             :async true
                                             :cancel-effect
-                                            (effect (system-msg (str "declines to use " (get-title card) " to install a card from the top of R&D"))
+                                            (effect (system-msg (s/strcat "declines to use " (get-title card) " to install a card from the top of R&D"))
                                                     (effect-completed eid))
                                             :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
                                                                                                      :index (first (keep-indexed #(when (same-card? target %2) %1) top))
@@ -706,7 +707,7 @@
                       (wait-for (resolve-ability state side (pick-virus-counters-to-spend play-or-rez) card nil)
                                 (if-let [msg (:msg async-result)]
                                   (do (system-msg state :runner
-                                                  (str "uses " (:title card) " to"
+                                                  (s/strcat "uses " (:title card) " to"
                                                        " trash " (:title accessed-card)
                                                        " at no cost, spending " msg))
                                       (trash state side eid (assoc accessed-card :seen true) {:accessed true}))
@@ -834,13 +835,13 @@
               {:event :tags-changed
                :effect (req (if (is-tagged? state)
                               (when-not (get-in @state [:runner :openhand])
-                                (system-msg state :corp (str "uses " (get-title card) " make the Runner play with [runner-pronoun] grip revealed"))
-                                (system-msg state :corp (str "uses " (get-title card) " to see that the Runner currently has "
+                                (system-msg state :corp (s/strcat "uses " (get-title card) " make the Runner play with [runner-pronoun] grip revealed"))
+                                (system-msg state :corp (s/strcat "uses " (get-title card) " to see that the Runner currently has "
                                                              (format-grip runner) " in [runner-pronoun] grip"))
                               (reveal-hand state :runner))
                             (when (get-in @state [:runner :openhand])
-                              (system-msg state :corp (str "uses " (get-title card) " stop making the Runner play with [runner-pronoun] grip revealed"))
-                              (system-msg state :corp (str "uses " (get-title card) " to note that the Runner had "
+                              (system-msg state :corp (s/strcat "uses " (get-title card) " stop making the Runner play with [runner-pronoun] grip revealed"))
+                              (system-msg state :corp (s/strcat "uses " (get-title card) " to note that the Runner had "
                                                            (format-grip runner) " in [runner-pronoun] grip before it was concealed"))
                               (conceal-hand state :runner))))}]
    :effect (req (when (is-tagged? state)
@@ -868,15 +869,15 @@
                              card-type (:type itarget)]
                          (if (some #(is-type? % (:type itarget)) (:hand runner))
                            {:optional
-                            {:prompt (str "Install another " card-type " from the grip?")
+                            {:prompt (s/strcat "Install another " card-type " from the grip?")
                              :yes-ability
-                             {:prompt (str "Choose a " card-type " to install")
+                             {:prompt (s/strcat "Choose a " card-type " to install")
                               :choices {:card #(and (is-type? % card-type)
                                                     (in-hand? %))}
                               :async true
                               :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
                                                                                                                                        :display-origin true}}))}}}
-                           {:prompt (str "You have no " card-type " to install")
+                           {:prompt (s/strcat "You have no " card-type " to install")
                             :choices ["Carry on!"]
                             :prompt-type :bogus}))
                        card nil))}]})
@@ -891,7 +892,7 @@
                                                (assoc card
                                                       :flipped true
                                                       :face :back
-                                                      :code (str (subs (:code card) 0 5) "flip")
+                                                      :code (s/strcat (subs (:code card) 0 5) "flip")
                                                       :subtype "Digital")))
                          (update-link state))]
     {:static-abilities [(link+ (req (:flipped card)) 1)
@@ -926,7 +927,7 @@
                :async true
                :effect (req (wait-for (draw state :runner 1)
                                       (wait-for (lose-credits state :runner (make-eid state eid) 1)
-                                                (system-msg state :runner (str "uses " (:title card) " to draw 1 card and lose 1 [Credits]"))
+                                                (system-msg state :runner (s/strcat "uses " (:title card) " to draw 1 card and lose 1 [Credits]"))
                                                 (effect-completed state side eid))))}]
      :abilities [{:label "flip identity"
                   :msg "flip [their] identity manually"
@@ -945,7 +946,7 @@
                 :label "Reveal the top card of the Stack"
                 :async true
                 :effect (req (if-let [revealed-card (-> runner :deck first)]
-                               (do (system-msg state side (str "uses " (:title card) " to reveal "
+                               (do (system-msg state side (s/strcat "uses " (:title card) " to reveal "
                                                                (:title revealed-card) " from the top of the Stack"))
                                    (reveal state side eid revealed-card))
                                (effect-completed state side eid)))}
@@ -954,7 +955,7 @@
                 :label "Reveal a random card from the Grip"
                 :async true
                 :effect (req (if-let [revealed-card (-> runner :hand shuffle first)]
-                               (do (system-msg state side (str "uses " (:title card) " to reveal "
+                               (do (system-msg state side (s/strcat "uses " (:title card) " to reveal "
                                                                (:title revealed-card) " from the Grip"))
                                    (reveal state side eid revealed-card))
                                (effect-completed state side eid)))}]})
@@ -1045,7 +1046,7 @@
              :prompt (msg "Choose a copy of " (:title card) " to use this game")
              :choices ["The Brewery" "The Tank" "The Greenhouse"]
              :effect (effect (update! (assoc card :biotech-target target :face :front))
-                             (system-msg (str "has chosen a copy of " (:title card) " for this game")))}]
+                             (system-msg (s/strcat "has chosen a copy of " (:title card) " for this game")))}]
    :abilities [{:label "Check chosen flip identity"
                 :effect (req (case (:biotech-target card)
                                "The Brewery"
@@ -1065,16 +1066,16 @@
                                (update! state side (assoc (get-card state card) :biotech-used true))
                                (case flip
                                  "The Brewery"
-                                 (do (system-msg state side (str "uses " flip " to do 2 net damage"))
+                                 (do (system-msg state side (s/strcat "uses " flip " to do 2 net damage"))
                                      (update! state side (assoc card :code "brewery" :face :brewery))
                                      (damage state side eid :net 2 {:card card}))
                                  "The Tank"
-                                 (do (system-msg state side (str "uses " flip " to shuffle Archives into R&D"))
+                                 (do (system-msg state side (s/strcat "uses " flip " to shuffle Archives into R&D"))
                                      (shuffle-into-deck state side :discard)
                                      (update! state side (assoc card :code "tank" :face :tank))
                                      (effect-completed state side eid))
                                  "The Greenhouse"
-                                 (do (system-msg state side (str "uses " flip " to place 4 advancement counters "
+                                 (do (system-msg state side (s/strcat "uses " flip " to place 4 advancement counters "
                                                                  "on a card that can be advanced"))
                                      (update! state side (assoc card :code "greenhouse" :face :greenhouse))
                                      (continue-ability
@@ -1083,7 +1084,7 @@
                                         :choices {:req (req (can-be-advanced? state target))}
                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))}
                                        card nil))
-                                 (toast state :corp (str "Unknown Jinteki Biotech: Life Imagined card: " flip) "error"))))}]})
+                                 (toast state :corp (s/strcat "Unknown Jinteki Biotech: Life Imagined card: " flip) "error"))))}]})
 
 (defcard "Jinteki: Personal Evolution"
   (let [ability {:async true
@@ -1102,7 +1103,7 @@
                          (= (:damage-type context) :net)
                          (pos? (:amount context))))
              :effect (req (let [c (first (get-in @state [:runner :deck]))]
-                            (system-msg state :corp (str "uses " (:title card) " to trash " (:title c)
+                            (system-msg state :corp (s/strcat "uses " (:title card) " to trash " (:title c)
                                                          " from the top of the stack"))
                             (mill state :corp eid :runner 1)))}]})
 
@@ -1210,7 +1211,7 @@
               :yes-ability {:msg "force the Corp to draw 1 card"
                             :async true
                             :effect (effect (draw :corp eid 1))}
-              :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}]
+              :no-ability {:effect (effect (system-msg (s/strcat "declines to use " (:title card))))}}}]
    :abilities [(set-autoresolve :auto-fire "Laramy Fisk: Savvy Investor")]})
 
 (defcard "Lat: Ethical Freelancer"
@@ -1227,7 +1228,7 @@
                                       :msg "draw 1 card"
                                       :effect (effect (draw :runner eid 1))}
                         :no-ability
-                        {:effect (effect (system-msg (str "declines to use " (:title card))))}}}
+                        {:effect (effect (system-msg (s/strcat "declines to use " (:title card))))}}}
                        card nil))}]
    :abilities [(set-autoresolve :auto-fire "Lat: Ethical Freelancer")]})
 
@@ -1266,7 +1267,7 @@
 (defcard "MaxX: Maximum Punk Rock"
   (let [ability {:msg (msg (let [deck (:deck runner)]
                              (if (pos? (count deck))
-                               (str "trash " (enumerate-str (map :title (take 2 deck))) " from the stack and draw 1 card")
+                               (s/strcat "trash " (enumerate-str (map :title (take 2 deck))) " from the stack and draw 1 card")
                                "trash the top 2 cards from the stack and draw 1 card - but the stack is empty")))
                  :label "trash and draw cards"
                  :once :per-turn
@@ -1298,7 +1299,7 @@
                                  :async true
                                  :effect (req (access-bonus state side breached-server 1 :end-of-access)
                                               (effect-completed state side eid))}
-                                :no-ability {:effect (effect (system-msg (str "declines to use " (:title card) " to access 1 additional card")))}}}
+                                :no-ability {:effect (effect (system-msg (s/strcat "declines to use " (:title card) " to access 1 additional card")))}}}
                               card nil)))}]})
 
 (defcard "MirrorMorph: Endless Iteration"
@@ -1418,7 +1419,7 @@
                  :async true
                  :effect (req (if (and (> 3 (count (:hand runner)))
                                        (:runner-phase-12 @state))
-                                (do (system-msg state :runner (str "uses " (:title card) " to gain 1 [Credits]"))
+                                (do (system-msg state :runner (s/strcat "uses " (:title card) " to gain 1 [Credits]"))
                                     (gain-credits state :runner eid 1))
                                 (effect-completed state side eid)))}]
     {:flags {:drip-economy true
@@ -1602,7 +1603,7 @@
               :effect
               (effect (continue-ability
                         {:optional
-                         {:prompt (str "Trash " (:title (first (:deck corp))) "?")
+                         {:prompt (s/strcat "Trash " (:title (first (:deck corp))) "?")
                           :yes-ability
                           {:msg "trash the top card of R&D"
                            :async true
@@ -1647,7 +1648,7 @@
                     (continue-ability
                       state side
                       {:optional
-                       {:prompt (str "Rez " (:title inst-target) ", paying additional costs?")
+                       {:prompt (s/strcat "Rez " (:title inst-target) ", paying additional costs?")
                         :yes-ability {:msg (msg "rez " (:title inst-target)
                                                 ", paying additional costs")
                                       :async true
@@ -1695,8 +1696,8 @@
           (ob-ability [target-cost]
             {:optional
              {:prompt (if (>= target-cost 0)
-                        (str "Install a " target-cost "-cost card from your deck?")
-                        (str "Shuffle your deck (search for a " target-cost "-cost card from your deck?)"))
+                        (s/strcat "Install a " target-cost "-cost card from your deck?")
+                        (s/strcat "Shuffle your deck (search for a " target-cost "-cost card from your deck?)"))
               :once :per-turn
               :waiting-prompt true
               :yes-ability
@@ -1726,7 +1727,7 @@
                                  :effect (effect (shuffle! :corp :deck))}
                                 card nil)))}
               :no-ability
-              {:effect (effect (system-msg (str "declines to use " (:title card))))}}})]
+              {:effect (effect (system-msg (s/strcat "declines to use " (:title card))))}}})]
     {:events [{:event :corp-trash
                :req (req (and
                            (installed? (:card context))
@@ -1788,7 +1789,7 @@
              :choices {:req (req (and (installed? target) (can-be-advanced? state target)))}
              :msg (msg "place 1 advancement token on " (card-str state target))
              :effect (effect (add-prop :corp eid target :advance-counter 1 {:placed true}))
-             :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
+             :cancel-effect (effect (system-msg (s/strcat "declines to use " (:title card)))
                                     (effect-completed eid))}]})
 
 (defcard "Quetzal: Free Spirit"
@@ -1973,7 +1974,7 @@
                                                        (reduce +))]
                                 (continue-ability
                                   state side
-                                  {:prompt (str "Choose a piece of ice with no advancement tokens to place "
+                                  {:prompt (s/strcat "Choose a piece of ice with no advancement tokens to place "
                                                 (quantify agenda-points "advancement token") " on")
                                    :choices {:card #(selectable-ice? %)}
                                    :msg (msg "place " (quantify agenda-points "advancement token")
@@ -2011,7 +2012,7 @@
                             :msg (msg (let [[chosen other](if (= target c1)
                                                             [c1 c2]
                                                             [c2 c1])]
-                                        (str "add " (:title other) " from the heap to the grip."
+                                        (s/strcat "add " (:title other) " from the heap to the grip."
                                              " Corp removes " (:title chosen) " from the game")))
                             :effect (req (let [[chosen other] (if (= target c1)
                                                                 [c1 c2]
@@ -2096,7 +2097,7 @@
            :msg (msg "swap the positions of " (card-str state (first targets))
                      " and " (card-str state (second targets)))
            :effect (req (swap-ice state side (first targets) (second targets)))}
-          :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}]
+          :no-ability {:effect (effect (system-msg (s/strcat "declines to use " (:title card))))}}}]
     {:events [(assoc swap-ability :event :agenda-scored)
               (assoc swap-ability :event :agenda-stolen)]}))
 
@@ -2149,10 +2150,10 @@
               :yes-ability
               {:effect (req (if-let [found-card (some #(when (= (:title %) (:title (:card context))) %) (concat (:deck corp) (:play-area corp)))]
                               (do (move state side found-card :hand)
-                                  (system-msg state side (str "uses " (:title card) " to add a copy of "
+                                  (system-msg state side (s/strcat "uses " (:title card) " to add a copy of "
                                                               (:title found-card) " to HQ, and shuffle R&D"))
                                   (shuffle! state side :deck))
-                              (do (system-msg state side (str "shuffles R&D"))
+                              (do (system-msg state side (s/strcat "shuffles R&D"))
                                   (shuffle! state side :deck))))}}}]})
 
 (defcard "The Masque: Cyber General"
@@ -2189,7 +2190,7 @@
                                 :async true
                                 :waiting-prompt true
                                 :msg (msg (if (= target "Pay [Click] and 2 [Credits]")
-                                            (str "force the runner to " (decapitalize target))
+                                            (s/strcat "force the runner to " (decapitalize target))
                                             "do 1 core damage"))
                                 :effect (req (if (= target "Pay [Click] and 2 [Credits]")
                                                (wait-for (pay state side (make-eid state eid) card [(->c :click 1) (->c :credit 2)])
@@ -2210,13 +2211,13 @@
                           (capitalize (cost->string (->c :trash-installed 1))))])
          :msg (msg (if (= "End the run" target)
                      (decapitalize target)
-                     (str "force the runner to " (decapitalize target))))
+                     (s/strcat "force the runner to " (decapitalize target))))
          :effect (req (if (= "End the run" target)
                         (end-run state :corp eid card)
                         (wait-for (pay state :runner (make-eid state eid) card (->c :trash-installed 1))
                                   (when-let [payment-str (:msg async-result)]
                                     (system-msg state :runner
-                                                (str payment-str
+                                                (s/strcat payment-str
                                                      " due to " (:title card)
                                                      " subroutine")))
                                   (effect-completed state side eid))))}

--- a/src/clj/game/core/bad_publicity.clj
+++ b/src/clj/game/core/bad_publicity.clj
@@ -7,7 +7,8 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.core.toasts :refer [toast]]
-    [game.macros :refer [wait-for]]))
+    [game.macros :refer [wait-for]]
+    [stringer.core :as s]))
 
 (defn bad-publicity-prevent
   [state side n]
@@ -19,7 +20,7 @@
   [state side eid n]
   (if (pos? n)
     (do (gain state :corp :bad-publicity n)
-        (toast state :corp (str "Took " n " bad publicity!") "info")
+        (toast state :corp (s/strcat "Took " n " bad publicity!") "info")
         (trigger-event-sync state side (make-result eid n) :corp-gain-bad-publicity {:amount n}))
     (effect-completed state side eid)))
 
@@ -48,12 +49,12 @@
                      (swap! state assoc-in [:prevent :current] :bad-publicity)
                      (show-prompt
                        state :corp nil
-                       (str "Avoid " (when (< 1 n) "any of the ") n " bad publicity?") ["Done"]
+                       (s/strcat "Avoid " (when (< 1 n) "any of the ") n " bad publicity?") ["Done"]
                        (fn [_]
                          (let [prevent (get-in @state [:bad-publicity :bad-publicity-prevent])]
                            (system-msg state :corp
                                        (if prevent
-                                         (str "avoids "
+                                         (s/strcat "avoids "
                                               (if (= prevent Integer/MAX_VALUE) "all" prevent)
                                               " bad publicity")
                                          "will not avoid bad publicity"))

--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -6,7 +6,8 @@
    [game.core.card-defs :refer [card-def]]
    [game.core.eid :refer [make-eid]]
    [game.core.servers :refer [is-remote? zones->sorted-names]]
-   [game.utils :refer [dissoc-in to-keyword]]))
+   [game.utils :refer [dissoc-in to-keyword]]
+   [stringer.core :as s]))
 
 (defn corp-servers-cards [state]
   (for [server (vals (:servers (:corp @state)))
@@ -188,8 +189,8 @@
         "HQ" [:servers :hq]
         "R&D" [:servers :rd]
         "Archives" [:servers :archives]
-        "New remote" [:servers (keyword (str "remote" (:rid @state)))]
-        [:servers (->> (string/split server #" ") last (str "remote") keyword)]))))
+        "New remote" [:servers (keyword (s/strcat "remote" (:rid @state)))]
+        [:servers (->> (string/split server #" ") last (s/strcat "remote") keyword)]))))
 
 (defn card->server
   "Returns the server map that this card is installed in or protecting."

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -9,7 +9,8 @@
     [game.core.memory :refer [available-mu update-mu]]
     [game.core.say :refer [system-msg]]
     [game.core.tags :refer [update-tag-status]]
-    [game.macros :refer [req]]))
+    [game.macros :refer [req]]
+    [stringer.core :as s]))
 
 (defn- change-msg
   "Send a system message indicating the property change"
@@ -18,8 +19,8 @@
               (= kw :brain-damage) "core damage"
               :else (name kw))]
     (system-msg state side
-                (str "sets " (.replace key "-" " ") " to " new-val
-                     " (" (if (pos? delta) (str "+" delta) delta) ")"))))
+                (s/strcat "sets " (.replace key "-" " ") " to " new-val
+                     " (" (if (pos? delta) (s/strcat "+" delta) delta) ")"))))
 
 (defn- change-map
   "Change a player's property using the :mod system"
@@ -36,8 +37,8 @@
      :value [:regular delta]})
   (update-mu state)
   (system-msg state side
-              (str "sets unused [mu] to " (available-mu state)
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets unused [mu] to " (available-mu state)
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-tags
   "Change a player's tag count"
@@ -45,8 +46,8 @@
   (gain state :runner :tag delta)
   (update-tag-status state)
   (system-msg state :runner
-              (str "sets Tags to " (get-in @state [:runner :tag :total])
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets Tags to " (get-in @state [:runner :tag :total])
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-bad-pub
   "Change a player's base bad pub count"
@@ -55,8 +56,8 @@
     (deduct state :corp [:bad-publicity (Math/abs delta)])
     (gain state :corp :bad-publicity delta))
   (system-msg state :corp
-              (str "sets Bad Publicity to " (get-in @state [:corp :bad-publicity :base])
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets Bad Publicity to " (get-in @state [:corp :bad-publicity :base])
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-agenda-points
   "Change a player's total agenda points, using floating effects."
@@ -71,8 +72,8 @@
        :value delta}))
   (update-all-agenda-points state side)
   (system-msg state side
-              (str "sets [their] agenda points to " (get-in @state [side :agenda-point])
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets [their] agenda points to " (get-in @state [side :agenda-point])
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-link
   "Change the runner's link, using floating effects."
@@ -83,8 +84,8 @@
      :value delta})
   (update-link state)
   (system-msg state side
-              (str "sets [their] [link] to " (get-link state)
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets [their] [link] to " (get-link state)
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-hand-size
   "Change the player's hand-size, using floating effects."
@@ -97,8 +98,8 @@
        :value delta}))
   (update-hand-size state side)
   (system-msg state side
-              (str "sets [their] hand size to " (hand-size state side)
-                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+              (s/strcat "sets [their] hand size to " (hand-size state side)
+                   " (" (if (pos? delta) (s/strcat "+" delta) delta) ")")))
 
 (defn- change-generic
   "Change a player's base generic property."

--- a/src/clj/game/core/charge.clj
+++ b/src/clj/game/core/charge.clj
@@ -5,7 +5,8 @@
    [game.core.eid :refer [effect-completed]]
    [game.core.say :refer [system-msg]]
    [game.macros :refer [req msg effect]]
-   [game.core.props :refer [add-counter]]))
+   [game.core.props :refer [add-counter]]
+   [stringer.core :as s]))
 
 (defn can-charge
   "A card can be charged if it has at least one power counter"
@@ -34,7 +35,7 @@
       :prompt "Choose an installed card"
       :choices {:card #(can-charge state side %)}
       :async true
-      :msg (msg "charge " (:title target) (when (> n 1) (str n " times")))
-      :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to charge a card"))
+      :msg (msg "charge " (:title target) (when (> n 1) (s/strcat n " times")))
+      :cancel-effect (effect (system-msg (s/strcat "declines to use " (:title card) " to charge a card"))
                              (effect-completed eid))
       :effect (req (charge-card state side eid target n))})))

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -11,7 +11,8 @@
     [game.core.winning :refer [flatline]]
     [game.macros :refer [wait-for]]
     [game.utils :refer [dissoc-in enumerate-str side-str]]
-    [jinteki.utils :refer [str->int]]))
+    [jinteki.utils :refer [str->int]]
+    [stringer.core :as s]))
 
 (defn damage-bonus
   "Registers a bonus of n damage to the next damage application of the given type."
@@ -28,7 +29,7 @@
 
 (defn prevention-prompt-msg
   [damage-amount damage-type prevented]
-  (str "Prevent "
+  (s/strcat "Prevent "
        (when (< 1 damage-amount) "any of the ")
        damage-amount
        " " (damage-name damage-type) " damage?"
@@ -122,7 +123,7 @@
                   (when (= dmg-type :brain)
                     (swap! state update-in [:runner :brain-damage] #(+ % n)))
                   (when-let [trashed-msg (enumerate-str (map get-title cards-trashed))]
-                    (system-msg state :runner (str "trashes " trashed-msg " due to " (damage-name dmg-type) " damage")))
+                    (system-msg state :runner (s/strcat "trashes " trashed-msg " due to " (damage-name dmg-type) " damage")))
                   (swap! state update-in [:stats :corp :damage :all] (fnil + 0) n)
                   (swap! state update-in [:stats :corp :damage dmg-type] (fnil + 0) n)
                   (if (< (count hand) n)
@@ -160,17 +161,17 @@
               (> n already-prevented))
        ;; player can prevent damage
        (do (system-msg state player "has the option to prevent damage")
-           (show-wait-prompt state other-player (str (side-str player) " to prevent damage"))
+           (show-wait-prompt state other-player (s/strcat (side-str player) " to prevent damage"))
            (swap! state assoc-in [:prevent :current] type)
            (show-prompt
              state player nil
-             (str "Prevent " (when (< 1 (- n already-prevented)) "any of the ") (- n already-prevented) " " (damage-name type) " damage?")
+             (s/strcat "Prevent " (when (< 1 (- n already-prevented)) "any of the ") (- n already-prevented) " " (damage-name type) " damage?")
              ["Done"]
              (fn [_] (let [prevent (get-in @state [:damage :damage-prevent type])
                            damage-prevented (if prevent (- prevent already-prevented) false)]
                        (system-msg state player
                                    (if damage-prevented
-                                     (str "prevents "
+                                     (s/strcat "prevents "
                                           (if (= damage-prevented Integer/MAX_VALUE) "all" damage-prevented)
                                           " " (damage-name type) " damage")
                                      "will not prevent damage"))

--- a/src/clj/game/core/drawing.clj
+++ b/src/clj/game/core/drawing.clj
@@ -11,7 +11,8 @@
     [game.core.winning :refer [win-decked]]
     [game.macros :refer [continue-ability msg req wait-for]]
     [game.utils :refer [quantify safe-zero?]]
-    [jinteki.utils :refer [other-side]]))
+    [jinteki.utils :refer [other-side]]
+    [stringer.core :as s]))
 
 (defn max-draw
   "Put an upper limit on the number of cards that can be drawn in this turn."
@@ -44,7 +45,7 @@
 
 (defn first-time-draw-bonus
   [side n]
-  (let [event (keyword (str "pre-" (name side) "-draw"))]
+  (let [event (keyword (s/strcat "pre-" (name side) "-draw"))]
     {:event event
      :msg "draw 1 additional card"
      ;; The req catches draw events that happened before the card was installed
@@ -72,7 +73,7 @@
          (when (< draws-after-prevent draws-wanted)
            (let [prevented (- draws-wanted draws-after-prevent)]
              (system-msg state (other-side side)
-                         (str "prevents " (quantify prevented "card") " from being drawn"))))
+                         (s/strcat "prevents " (quantify prevented "card") " from being drawn"))))
          (if (or (and (= side active-player)
                       (get-in @state [side :register :cannot-draw]))
                  (not (pos? draws-after-prevent))
@@ -113,11 +114,11 @@
      (draw state side eid n args)
      (continue-ability
        state side
-       {:optional {:prompt (str "Draw " (quantify n "card") "?")
+       {:optional {:prompt (s/strcat "Draw " (quantify n "card") "?")
                    :yes-ability {:async true
                                  :msg (msg "draw " (quantify n " card"))
                                  :effect (req (draw state side eid n))}
-                   :no-ability {:effect (req (system-msg state side (str "declines to use " (get-title card) " to draw cards")))}}}
+                   :no-ability {:effect (req (system-msg state side (s/strcat "declines to use " (get-title card) " to draw cards")))}}}
        card nil))))
 
 (defn draw-up-to
@@ -127,7 +128,7 @@
      (draw state side eid 0 args)
      (continue-ability
        state side
-       {:prompt (str "Draw how many cards?" (when-not allow-zero-draws " (minimum 1)"))
+       {:prompt (s/strcat "Draw how many cards?" (when-not allow-zero-draws " (minimum 1)"))
         :choices {:number (req n)
                   :max (req n)
                   :default (req n)}

--- a/src/clj/game/core/expose.clj
+++ b/src/clj/game/core/expose.clj
@@ -8,7 +8,8 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.core.to-string :refer [card-str]]
-    [game.macros :refer [wait-for]]))
+    [game.macros :refer [wait-for]]
+    [stringer.core :as s]))
 
 (defn expose-prevent
   [state _ n]
@@ -16,7 +17,7 @@
 
 (defn- resolve-expose
   [state side eid target]
-  (system-msg state side (str "exposes " (card-str state target {:visible true})))
+  (system-msg state side (s/strcat "exposes " (card-str state target {:visible true})))
   (if-let [ability (:on-expose (card-def target))]
     (wait-for (resolve-ability state side ability target nil)
               (trigger-event-sync state side (make-result eid target) :expose target))
@@ -38,7 +39,7 @@
                     (do (system-msg state :corp "has the option to prevent a card from being exposed")
                         (show-wait-prompt state :runner "Corp to prevent the expose")
                         (show-prompt state :corp nil
-                                     (str "Prevent " (:title target) " from being exposed?") ["Done"]
+                                     (s/strcat "Prevent " (:title target) " from being exposed?") ["Done"]
                                      (fn [_]
                                        (clear-wait-prompt state :runner)
                                        (if (get-in @state [:expose :expose-prevent])

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -8,7 +8,8 @@
     [game.core.servers :refer [zone->name]]
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
-    [game.utils :refer [enumerate-str same-card? same-side?]]))
+    [game.utils :refer [enumerate-str same-card? same-side?]]
+    [stringer.core :as s]))
 
 (defn card-flag?
   "Checks the card to see if it has a :flags entry of the given flag-key, and with the given value if provided"
@@ -225,10 +226,10 @@
        :persistent-flag false
        ;; Uniqueness
        :unique (or ignore-unique
-                   (reason-toast (str "Cannot rez a second copy of " title " since it is unique. Please trash the other"
+                   (reason-toast (s/strcat "Cannot rez a second copy of " title " since it is unique. Please trash the other"
                                       " copy first")))
        ;; Rez requirement
-       :req (reason-toast (str "Rez requirements for " title " are not fulfilled"))))))
+       :req (reason-toast (s/strcat "Rez requirements for " title " are not fulfilled"))))))
 
 (defn can-steal?
   "Checks if the runner can steal agendas"
@@ -250,7 +251,7 @@
   (let [cards (->> @state :stack :current-turn :can-run (map :card))]
     (if (empty? cards)
       true
-      (do (when-not silent (toast state side (str "Cannot run due to " (enumerate-str (map :title cards))))
+      (do (when-not silent (toast state side (s/strcat "Cannot run due to " (enumerate-str (map :title cards))))
         false))))))
 
 (defn can-access?
@@ -264,7 +265,7 @@
   (let [cards (get-preventing-cards state side card :can-access [:current-run :current-turn :persistent])]
     (if (empty? cards)
       true
-      (do (toast state side (str "Cannot access " (card-str state card) " because of " (enumerate-str (map :title cards))) "info")
+      (do (toast state side (s/strcat "Cannot access " (card-str state card) " because of " (enumerate-str (map :title cards))) "info")
           false))))
 
 (defn can-advance?

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -16,7 +16,8 @@
     [game.core.update :refer [update!]]
     [game.macros :refer [req]]
     [game.utils :refer [make-cid server-card to-keyword]]
-    [jinteki.utils :refer [make-label]]))
+    [jinteki.utils :refer [make-label]]
+    [stringer.core :as s]))
 
 (defn subroutines-init
   "Initialised the subroutines associated with the card, these work as abilities"
@@ -110,7 +111,7 @@
                    (cond
                      (fn? recurring) (recurring state side eid c nil)
                      (number? recurring) recurring
-                     :else (throw (Exception. (str (:title card) " - Recurring isn't number or fn"))))}))
+                     :else (throw (Exception. (s/strcat (:title card) " - Recurring isn't number or fn"))))}))
          _ (when recurring (update! state side (assoc-in c [:counter :recurring] 0)))
          _ (doseq [[c-type c-num] data]
              (add-counter state side (get-card state c) c-type c-num {:placed true}))
@@ -176,7 +177,7 @@
   (when-let [cdef (card-def card)]
     ;; Card is defined - hence implemented
     (if-let [impl (:implementation cdef)]
-      (if (:recurring cdef) (str impl ". Recurring credits usage not restricted") impl)
+      (if (:recurring cdef) (s/strcat impl ". Recurring credits usage not restricted") impl)
       (if (:recurring cdef) "Recurring credits usage not restricted" :full))))
 
 (defn make-card

--- a/src/clj/game/core/mark.clj
+++ b/src/clj/game/core/mark.clj
@@ -4,7 +4,8 @@
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->name]]
    [game.core.update :refer [update!]]
-   [game.macros :refer [req]]))
+   [game.macros :refer [req]]
+   [stringer.core :as s]))
 
 (defn set-mark
   [state new-mark]
@@ -19,7 +20,7 @@
   [state]
   (let [new-mark (rand-nth [:hq :rd :archives])]
     (set-mark state new-mark)
-    (system-msg state :runner (str "identifies [their] mark to be " (central->name new-mark)))))
+    (system-msg state :runner (s/strcat "identifies [their] mark to be " (central->name new-mark)))))
 
 (def identify-mark-ability
   {:effect (req (when (nil? (:mark @state)) (identify-mark state)))})

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -5,7 +5,8 @@
    [game.core.card-defs :refer [card-def]]
    [game.core.eid :refer [make-eid]]
    [game.core.effects :refer [get-effect-maps get-effect-value get-effects is-disabled-reg? register-lingering-effect]]
-   [game.core.toasts :refer [toast]]))
+   [game.core.toasts :refer [toast]]
+   [stringer.core :as s]))
 
 (defn mu+
   "For use in :static-abilities and register-lingering-effect.
@@ -19,7 +20,7 @@
     :value (cond+
              [(or (vector? value) (fn? value)) value]
              [(number? value) [:regular value]]
-             [:else (throw (Exception. (str "mu+ needs a vector, number, or function: " value)))])}))
+             [:else (throw (Exception. (s/strcat "mu+ needs a vector, number, or function: " value)))])}))
 
 (defn virus-mu+
   "For use in :static-abilities and register-lingering-effect.
@@ -30,7 +31,7 @@
   ([req value] (mu+ req (cond+
                           [(or (vector? value) (fn? value)) value]
                           [(number? value) [:virus value]]
-                          [:else (throw (Exception. (str "virus-mu+ needs a vector, number, or function: " value)))]))))
+                          [:else (throw (Exception. (s/strcat "virus-mu+ needs a vector, number, or function: " value)))]))))
 
 (defn caissa-mu+
   "For use in :static-abilities and register-lingering-effect.
@@ -41,7 +42,7 @@
   ([req value] (mu+ req (cond+
                           [(or (vector? value) (fn? value)) value]
                           [(number? value) [:caissa value]]
-                          [:else (throw (Exception. (str "caissa-mu+ needs a vector, number, or function: " value)))]))))
+                          [:else (throw (Exception. (s/strcat "caissa-mu+ needs a vector, number, or function: " value)))]))))
 
 (defn available-mu
   "Returns the available MU the runner has"

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -21,7 +21,8 @@
     [game.core.winning :refer [check-win-by-agenda]]
     [game.macros :refer [wait-for when-let*]]
     [game.utils :refer [dissoc-in make-cid remove-once same-card? same-side? to-keyword]]
-    [medley.core :refer [insert-nth]]))
+    [medley.core :refer [insert-nth]]
+    [stringer.core :as s]))
 
 ;; Helpers for move
 (defn- remove-old-card
@@ -285,7 +286,7 @@
         (when (and (not unpreventable)
                    (not= cause :ability-cost))
           (swap! state update-in [:trash :trash-prevent] dissoc ktype))
-        (let [type (->> ktype name (str "trash-") keyword)
+        (let [type (->> ktype name (s/strcat "trash-") keyword)
               prevent (get-prevent-list state :runner type)]
           ;; Check for prevention effects
           (if (and (not unpreventable)
@@ -294,14 +295,14 @@
             (do (system-msg state :runner "has the option to prevent trash effects")
                 (show-wait-prompt state :corp "Runner to prevent trash effects")
                 (show-prompt state :runner nil
-                             (str "Prevent the trashing of " (:title card) "?") ["Done"]
+                             (s/strcat "Prevent the trashing of " (:title card) "?") ["Done"]
                              (fn [_]
                                (clear-wait-prompt state :corp)
                                (if-let [_ (get-in @state [:trash :trash-prevent ktype])]
-                                 (do (system-msg state :runner (str "prevents the trashing of " (:title card)))
+                                 (do (system-msg state :runner (s/strcat "prevents the trashing of " (:title card)))
                                      (swap! state update-in [:trash :trash-prevent] dissoc ktype)
                                      (effect-completed state side eid))
-                                 (do (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
+                                 (do (system-msg state :runner (s/strcat "will not prevent the trashing of " (:title card)))
                                      (complete-with-result state side eid card))))
                              {:prompt-type :prevent}))
             ;; No prevention effects: add the card to the trash-list
@@ -643,7 +644,7 @@
                                                                           :unpreventable true})
              (let [card (get-card state card)]
                (when msg
-                 (system-msg state side (str "forfeits " (get-title card))))
+                 (system-msg state side (s/strcat "forfeits " (get-title card))))
                (move state (to-keyword (:side card)) card :rfg)
                (update-all-agenda-points state side)
                (check-win-by-agenda state side)

--- a/src/clj/game/core/optional.clj
+++ b/src/clj/game/core/optional.clj
@@ -8,7 +8,8 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [effect req wait-for]]
-    [clojure.string :as string]))
+    [clojure.string :as string]
+    [stringer.core :as s]))
 
 (defn optional-ability
   "Shows a 'Yes/No' prompt and resolves the given ability's :yes-ability if Yes is chosen, and :no-ability otherwise.
@@ -39,7 +40,7 @@
          "Yes" (prompt-fn {:value "Yes"})
          "No" (prompt-fn {:value "No"})
          (do (when autoresolve-fn
-               (toast state side (str "This prompt can be skipped by clicking "
+               (toast state side (s/strcat "This prompt can be skipped by clicking "
                                       (:title card) " and toggling autoresolve")))
              (show-prompt state side eid card message choices
                           prompt-fn (assoc ability :targets targets))))))))
@@ -69,11 +70,11 @@
   "Makes a card ability which lets the user toggle auto-resolve on an ability. Setting is stored under [:special toggle-kw]."
   [toggle-kw ability-name]
   {:autoresolve true
-   :label (str "Toggle auto-resolve on " ability-name)
-   :prompt (str "Set auto-resolve on " ability-name " to:")
+   :label (s/strcat "Toggle auto-resolve on " ability-name)
+   :prompt (s/strcat "Set auto-resolve on " ability-name " to:")
    :choices ["Always" "Never" "Ask"]
    :effect (effect (update! (assoc-in card [:special toggle-kw] (keyword (string/lower-case target))))
-                   (toast (str "From now on, " ability-name " will "
+                   (toast (s/strcat "From now on, " ability-name " will "
                                ({:always "always" :never "never" :ask "ask whether it should"}
                                 (get-in (get-card state card) [:special toggle-kw]))
                                " resolve.") "info"))})

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -6,7 +6,8 @@
     [game.core.eid :refer [make-eid]]
     [game.core.effects :refer [any-effects]]
     [game.core.toasts :refer [toast]]
-    [jinteki.utils :refer [capitalize]]))
+    [jinteki.utils :refer [capitalize]]
+    [stringer.core :as s]))
 
 (defn ->c
   ([type] (->c type 1))
@@ -100,7 +101,7 @@
 (defn- any-effect-stops-pay?
   "Checks installed cards to see if payment type is being prevented by an active card"
   [state side cost]
-  (let [kw-cost (keyword (str "cannot-pay-" (name (:cost/type cost))))]
+  (let [kw-cost (keyword (s/strcat "cannot-pay-" (name (:cost/type cost))))]
     (any-effects state side kw-cost true? {:amount (:cost/amount cost)})))
 
 (defn can-pay?
@@ -116,7 +117,7 @@
                        (payable? % state side eid card))
                  costs)
        costs
-       (do (when title (toast state side (str "Unable to pay for " title ".")))
+       (do (when title (toast state side (s/strcat "Unable to pay for " title ".")))
            nil)))))
 
 (defn cost-targets
@@ -167,8 +168,8 @@
       (let [cost-type (:cost/type cost)
             cost-string (label cost)]
         (cond
-          (#{:click :lose-click} cost-type) (str "spend " cost-string)
-          (= :credit cost-type) (str "pay " cost-string)
+          (#{:click :lose-click} cost-type) (s/strcat "spend " cost-string)
+          (= :credit cost-type) (s/strcat "pay " cost-string)
           :else cost-string)))
     (try (cost->string (first cost))
          (catch Throwable t
@@ -192,5 +193,5 @@
   ([cost-str verb] (build-spend-msg cost-str verb nil))
   ([cost-str verb verb2]
    (if (string/blank? cost-str)
-     (str (or verb2 (str verb "s")) " ")
-     (str cost-str " to " verb " "))))
+     (s/strcat (or verb2 (s/strcat verb "s")) " ")
+     (s/strcat cost-str " to " verb " "))))

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -8,7 +8,8 @@
     [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]))
+    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]
+    [stringer.core :as s]))
 
 (defn- pick-counter-triggers
   [state side eid current-cards selected-cards counter-count message]
@@ -31,8 +32,8 @@
   ([specific-card target-count] (pick-virus-counters-to-spend specific-card target-count (hash-map) 0))
   ([specific-card target-count selected-cards counter-count]
    {:async true
-    :prompt (str "Choose a card with virus counters ("
-                 counter-count (str " of " target-count)
+    :prompt (s/strcat "Choose a card with virus counters ("
+                 counter-count (s/strcat " of " target-count)
                  " virus counters)")
     :choices {:card #(and (if specific-card
                             (or (same-card? % specific-card)
@@ -54,7 +55,7 @@
                                        card nil)
                      (let [message (enumerate-str (map #(let [{:keys [card number]} %
                                                           title (:title card)]
-                                                      (str (quantify number "virus counter") " from " title))
+                                                      (s/strcat (quantify number "virus counter") " from " title))
                                                    (vals selected-cards)))]
                        (pick-counter-triggers state side eid selected-cards selected-cards counter-count message)))))
     :cancel-effect (if target-count
@@ -63,7 +64,7 @@
                           (complete-with-result state side eid :cancel))
                      (req (let [message (enumerate-str (map #(let [{:keys [card number]} %
                                                                title (:title card)]
-                                                           (str (quantify number "virus counter") " from " title))
+                                                           (s/strcat (quantify number "virus counter") " from " title))
                                                         (vals selected-cards)))]
                            (complete-with-result state side eid {:number counter-count :msg message}))))}))
 
@@ -97,13 +98,13 @@
                              (<= stealth-target stealth-count))
                         (let [remainder (max 0 (- target-count counter-count))
                               remainder-str (when (pos? remainder)
-                                              (str remainder " [Credits]"))
+                                              (s/strcat remainder " [Credits]"))
                               card-strs (when (pos? (count selected-cards))
-                                          (str (enumerate-str (map #(let [{:keys [card number]} %
+                                          (s/strcat (enumerate-str (map #(let [{:keys [card number]} %
                                                                       title (:title card)]
-                                                                  (str number " [Credits] from " title))
+                                                                  (s/strcat number " [Credits] from " title))
                                                                (vals selected-cards)))))
-                              message (str card-strs
+                              message (s/strcat card-strs
                                            (when (and card-strs remainder-str)
                                              " and ")
                                            remainder-str
@@ -126,12 +127,12 @@
          {:async true
           :effect pay-rest}
          {:async true
-          :prompt (str "Choose a credit providing card ("
+          :prompt (s/strcat "Choose a credit providing card ("
                       counter-count (when (and target-count (pos? target-count))
-                                      (str " of " target-count))
+                                      (s/strcat " of " target-count))
                       " [Credits]"
                       (if (pos? stealth-target)
-                         (str ", " (min stealth-count stealth-target) " of " stealth-target " stealth")
+                         (s/strcat ", " (min stealth-count stealth-target) " of " stealth-target " stealth")
                          "")
                       ")")
           :choices {:card #(in-coll? (map :cid provider-cards) (:cid %))}

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -14,7 +14,8 @@
     [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.update :refer [update!]]
     [game.macros :refer [wait-for]]
-    [game.utils :refer [same-card? to-keyword]]))
+    [game.utils :refer [same-card? to-keyword]]
+    [stringer.core :as s]))
 
 (defn async-rfg
   ([state side eid card] (async-rfg state side eid card nil))
@@ -35,7 +36,7 @@
   (let [play-msg (if ignore-cost
                    "play "
                    (build-spend-msg payment-str "play"))]
-    (system-msg state side (str play-msg title (when ignore-cost " at no cost")))
+    (system-msg state side (s/strcat play-msg title (when ignore-cost " at no cost")))
     (implementation-msg state card)
     (if-let [sfx (:play-sound (card-def card))]
       (play-sfx state side sfx)
@@ -67,7 +68,7 @@
                                           (unregister-static-abilities state side card)
                                           (when (= zone :rfg)
                                             (system-msg state side
-                                                        (str "removes " (:title c) " from the game instead of trashing it")))
+                                                        (s/strcat "removes " (:title c) " from the game instead of trashing it")))
                                           (when (has-subtype? card "Terminal")
                                             (lose state side :click (-> @state side :click))
                                             (swap! state assoc-in [:corp :register :terminal] true))

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -21,7 +21,8 @@
    [game.core.shuffling :refer [shuffle-deck]]
    [game.core.toasts :refer [ack-toast]]
    [game.core.turns :refer [end-phase-12 end-turn start-turn]]
-   [game.core.winning :refer [concede]]))
+   [game.core.winning :refer [concede]]
+   [stringer.core :as s]))
 
 (defn checkpoint+clean-up
   [state]
@@ -39,7 +40,7 @@
     (if-let [command (parse-command state text)]
       (when (and (not= side nil) (not= side :spectator))
         (command state side)
-        (system-say state side (str "[!]" (:username author) " uses a command: " text)))
+        (system-say state side (s/strcat "[!]" (:username author) " uses a command: " text)))
       (say state side args))))
 
 (def commands

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -6,7 +6,8 @@
     [game.core.toasts :refer [toast]]
     [game.macros :refer [when-let*]]
     [game.utils :refer [pluralize side-str]]
-    [medley.core :refer [find-first]]))
+    [medley.core :refer [find-first]]
+    [stringer.core :as s]))
 
 (defn choice-parser
   [choices]
@@ -48,9 +49,9 @@
            {:eid (select-keys eid [:eid])
             :card card
             :prompt-type :waiting
-            :msg (str "Waiting for " 
+            :msg (s/strcat "Waiting for "
                       (if (true? waiting-prompt)
-                        (str (side-str side) " to make a decision")
+                        (s/strcat (side-str side) " to make a decision")
                         waiting-prompt))}))
        (add-to-prompt-queue state side newitem)))))
 
@@ -67,7 +68,7 @@
                   #(if (not= (:value %) dice-msg)
                      (f %)
                      (show-prompt state side card
-                                  (str message " (Dice result: " (inc (rand-int 6)) ")")
+                                  (s/strcat message " (Dice result: " (inc (rand-int 6)) ")")
                                   other-choices f args))
                   args))))
 
@@ -147,16 +148,16 @@
                       (str
                         "Choose"
                         (when min-choices
-                          (str " at least " min-choices))
+                          (s/strcat " at least " min-choices))
                         (when (and min-choices max-choices)
                           " and")
                         (when max-choices
-                          (str (if all "" " up to")
+                          (s/strcat (if all "" " up to")
                                " " max-choices))
                         (if max-choices
-                          (str " " (pluralize "target" max-choices))
+                          (s/strcat " " (pluralize "target" max-choices))
                           (if min-choices
-                            (str " " (pluralize "target" min-choices))
+                            (s/strcat " " (pluralize "target" min-choices))
                             " a target"))
                         " for " (:title card)))
                     (if all ["Hide"] ["Done"])
@@ -164,7 +165,7 @@
                       (fn [_]
                         ; "Hide" was selected. Show toast and reapply select prompt. This allows players to access
                         ; prompts that lie "beneath" the current select prompt.
-                        (toast state side (str "You must choose " max-choices " " (pluralize "card" max-choices)))
+                        (toast state side (s/strcat "You must choose " max-choices " " (pluralize "card" max-choices)))
                         (show-select state side card ability update! resolve-ability args))
                       (fn [_]
                         (let [selected (get-in @state [side :selected 0] [])
@@ -172,7 +173,7 @@
                           ; check for :min. If not enough cards are selected, show toast and stay in select prompt
                           (if (and min-choices (< (count cards) min-choices))
                             (do
-                              (toast state side (str "You must choose at least " min-choices " " (pluralize "card" min-choices)))
+                              (toast state side (s/strcat "You must choose at least " min-choices " " (pluralize "card" min-choices)))
                               (show-select state side card ability update! resolve-ability args))
                             (resolve-select state side card
                                             (select-keys (wrap-function args :cancel-effect) [:cancel-effect])
@@ -187,7 +188,7 @@
   The prompt cannot be closed except by a later call to clear-wait-prompt."
   ([state side message] (show-wait-prompt state side message nil))
   ([state side message {:keys [card]}]
-   (show-prompt state side card (str "Waiting for " message) nil nil
+   (show-prompt state side card (s/strcat "Waiting for " message) nil nil
                 {:prompt-type :waiting})))
 
 (defn clear-wait-prompt
@@ -200,8 +201,8 @@
   "Adds a dummy prompt to both side's prompt queues.
    The prompt cannot be closed except by a later call to clear-run-prompts."
   [state msg card]
-  (show-prompt state :runner card (str "You are " msg) nil nil {:prompt-type :run})
-  (show-prompt state :corp card (str "The Runner is " msg) nil nil {:prompt-type :run}))
+  (show-prompt state :runner card (s/strcat "You are " msg) nil nil {:prompt-type :run})
+  (show-prompt state :corp card (s/strcat "The Runner is " msg) nil nil {:prompt-type :run}))
 
 (defn clear-run-prompts
   [state]

--- a/src/clj/game/core/psi.clj
+++ b/src/clj/game/core/psi.clj
@@ -10,11 +10,12 @@
     [game.macros :refer [continue-ability effect wait-for]]
     [jinteki.utils :refer [str->int]]
     [clojure.string :as string]
-    [game.core.payment :refer [->c]]))
+    [game.core.payment :refer [->c]]
+    [stringer.core :as s]))
 
 (defn- bet-to-keyword
   [bet]
-  (keyword (str "bet-" bet)))
+  (keyword (s/strcat "bet-" bet)))
 
 (defn- resolve-psi
   "Resolves a psi game by charging credits to both sides and invoking the appropriate
@@ -41,7 +42,7 @@
                           (swap! state update-in [:stats (if (= card-side :corp) :runner :corp) :psi-game :wins] (fnil + 0) 1)
                           (effect-completed state side eid)))))))
       (show-wait-prompt
-        state side (str (string/capitalize (name opponent)) " to choose psi game credits")))))
+        state side (s/strcat (string/capitalize (name opponent)) " to choose psi game credits")))))
 
 (defn psi-game
   "Starts a psi game by showing the psi prompt to both players. psi is a map containing
@@ -56,8 +57,8 @@
              valid-amounts (remove #(or (any-flag-fn? state :corp :prevent-secretly-spend %)
                                         (any-flag-fn? state :runner :prevent-secretly-spend %))
                                    all-amounts)]
-         (show-prompt-with-dice state s card (str "Choose an amount to spend for " (:title card))
-                                (map #(str % " [Credits]") valid-amounts)
+         (show-prompt-with-dice state s card (s/strcat "Choose an amount to spend for " (:title card))
+                                (map #(s/strcat % " [Credits]") valid-amounts)
                                 #(resolve-psi state s eid card psi (str->int (first (string/split (:value %) #" "))) targets)
                                 {:prompt-type :psi}))))))
 

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -17,7 +17,8 @@
     [game.core.to-string :refer [card-str]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability effect wait-for]]
-    [game.utils :refer [enumerate-str to-keyword]]))
+    [game.utils :refer [enumerate-str to-keyword]]
+    [stringer.core :as s]))
 
 (defn get-rez-cost
   [state side card {:keys [ignore-cost alternative-cost cost-bonus]}]
@@ -40,7 +41,7 @@
       (effect-completed state side eid)
       (wait-for (trash-cards state side hosted-cards {:unpreventable true :game-trash true})
                 (when (pos? (count hosted-cards))
-                  (system-msg state side (str "trashes " (enumerate-str (map #(card-str state %) hosted-cards))
+                  (system-msg state side (s/strcat "trashes " (enumerate-str (map #(card-str state %) hosted-cards))
                                               " because " (:title card)
                                               " cannot host cards")))
                 (effect-completed state side eid)))))
@@ -66,7 +67,7 @@
                                               (update-in [:host :zone] #(map to-keyword %)))))
                     (when-not no-msg
                       (system-msg state side
-                                  (str (build-spend-msg msg "rez" "rezzes")
+                                  (s/strcat (build-spend-msg msg "rez" "rezzes")
                                        (:title card)
                                        (cond
                                          alternative-cost " by paying its alternative cost"
@@ -136,8 +137,8 @@
   ([state side card {:keys [source-card no-msg] :as args}]
    (let [card (get-card state card)]
      (when-not no-msg
-       (system-msg state side (str (if source-card
-                                     (str "uses " (:title source-card) " to derez ")
+       (system-msg state side (s/strcat (if source-card
+                                     (s/strcat "uses " (:title source-card) " to derez ")
                                      "derezzes ")
                                    (:title card))))
      (unregister-events state side card)

--- a/src/clj/game/core/sabotage.clj
+++ b/src/clj/game/core/sabotage.clj
@@ -1,22 +1,22 @@
 (ns game.core.sabotage
   (:require
-    [clojure.string :as string]
     [game.core.card :refer [corp? in-hand?]]
     [game.core.eid :refer [effect-completed]]
     [game.core.engine :refer [resolve-ability]]
     [game.core.moving :refer [trash-cards]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [req msg continue-ability]]
-    [game.utils :refer [pluralize]]))
+    [game.utils :refer [pluralize]]
+    [stringer.core :as s]))
 
 (defn choosing-prompt-req
   [n]
   (req
     (let [cards-rd (count (get-in @state [:corp :deck]))
           forced-hq (- n cards-rd)]
-      (str "Choose"
+      (s/strcat "Choose"
            (when (pos? forced-hq)
-             (str " at least " forced-hq " " (pluralize "card" forced-hq) " and"))
+             (s/strcat " at least " forced-hq " " (pluralize "card" forced-hq) " and"))
            " up to " n " " (pluralize "card" n)
            " to trash from HQ. Remainder will be trashed from top of R&D."))))
 
@@ -32,11 +32,11 @@
                   (str
                     "trashes"
                     (when (pos? selected-hq)
-                      (str " " selected-hq " " (pluralize "card" selected-hq) " from HQ"))
+                      (s/strcat " " selected-hq " " (pluralize "card" selected-hq) " from HQ"))
                     (when (and (pos? selected-hq) (pos? selected-rd))
                       " and")
                     (when (pos? selected-rd)
-                      (str " " selected-rd " " (pluralize "card" selected-rd) " from the top of R&D"))))
+                      (s/strcat " " selected-rd " " (pluralize "card" selected-rd) " from the top of R&D"))))
       (trash-cards state side eid to-trash {:unpreventable true}))))
 
 (defn sabotage-ability

--- a/src/clj/game/core/say.clj
+++ b/src/clj/game/core/say.clj
@@ -1,5 +1,6 @@
 (ns game.core.say
   (:require
+   [stringer.core :as s]
    [cljc.java-time.instant :as inst]
    [clojure.string :as str]
    [game.core.toasts :refer [toast]]))
@@ -54,7 +55,7 @@
   "Prints a system message to log (`say` from user __system__)"
   ([state side text] (system-say state side text nil))
   ([state side text {:keys [hr]}]
-   (say state side (make-system-message (str text (when hr "[hr]"))))))
+   (say state side (make-system-message (s/strcat text (when hr "[hr]"))))))
 
 (defn unsafe-say
   "Prints a reagent hiccup directly to the log. Do not use for any user-generated content!"
@@ -67,23 +68,23 @@
   ([state side text] (system-msg state side text nil))
   ([state side text args]
    (let [username (get-in @state [side :user :username])]
-     (system-say state side (str username " " text ".") args))))
+     (system-say state side (s/strcat username " " text ".") args))))
 
 (defn enforce-msg
   "Prints a message related to a rules enforcement on a given card.
   Example: 'Architect cannot be trashed while installed.'"
   [state card text]
-  (system-say state nil (str (:title card) " " text ".")))
+  (system-say state nil (s/strcat (:title card) " " text ".")))
 
 (defn implementation-msg
   [state card]
   (when (not= :full (:implementation card))
-    (system-say state nil (str "[!] " (:title card) " - " (:implementation card)))))
+    (system-say state nil (s/strcat "[!] " (:title card) " - " (:implementation card)))))
 
 (defn indicate-action
   [state side _]
   (system-say state side
-              (str "[!] Please pause, " (if (= side :corp) "Corp" "Runner") " is acting."))
+              (s/strcat "[!] Please pause, " (if (= side :corp) "Corp" "Runner") " is acting."))
   (toast state side
          "You have indicated action to your opponent"
          "info"

--- a/src/clj/game/core/servers.clj
+++ b/src/clj/game/core/servers.clj
@@ -3,7 +3,8 @@
   (:require
     [game.core.card :refer [get-zone]]
     [game.utils :refer [safe-split string->num]]
-    [clojure.string :as string]))
+    [clojure.string :as string]
+    [stringer.core :as s]))
 
 (defn target-server
   "Returns the server keyword corresponding to the target of a run."
@@ -12,13 +13,13 @@
 
 (defn remote-num->name
   [num]
-  (str "Server " num))
+  (s/strcat "Server " num))
 
 (defn remote->name
   "Converts a remote zone to a string"
   [zone]
   (let [kw (if (keyword? zone) zone (last zone))
-        s (str kw)]
+        s (s/strcat kw)]
     (when (string/starts-with? s ":remote")
       (let [num (last (string/split s #":remote"))]
         (remote-num->name num)))))
@@ -63,7 +64,7 @@
     :rd -2
     :hq -1
     (string->num
-      (last (safe-split (str zone) #":remote")))))
+      (last (safe-split (s/strcat zone) #":remote")))))
 
 (defn zones->sorted-names
   [zones]
@@ -156,7 +157,7 @@
       "R&D" :rd
       "Archives" :archives
       ;; assume "Server N"
-      (->> (string/split name-or-kw-or-zone #" ") last (str "remote") keyword))
+      (->> (string/split name-or-kw-or-zone #" ") last (s/strcat "remote") keyword))
 
     :else
     (second name-or-kw-or-zone)))

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -6,7 +6,8 @@
    [game.core.moving :refer [move move-zone]]
    [game.core.say :refer [system-msg]]
    [game.macros :refer [continue-ability msg req]]
-   [game.utils :refer [enumerate-str quantify]]))
+   [game.utils :refer [enumerate-str quantify]]
+   [stringer.core :as s]))
 
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
@@ -40,9 +41,9 @@
       :msg (msg "shuffle "
                 (let [seen (filter :seen targets)
                       m (count (filter #(not (:seen %)) targets))]
-                  (str (enumerate-str (map :title seen))
+                  (s/strcat (enumerate-str (map :title seen))
                        (when (pos? m)
-                         (str (when-not (empty? seen) " and ")
+                         (s/strcat (when-not (empty? seen) " and ")
                               (quantify m "unseen card")))))
                 " into R&D")
       :waiting-prompt true
@@ -50,7 +51,7 @@
                      (move state side c :deck))
                    (shuffle! state side :deck))
       :cancel-effect (req 
-                      (system-msg state side (str " uses " (:title card) " to shuffle R&D")) 
+                      (system-msg state side (s/strcat " uses " (:title card) " to shuffle R&D"))
                       (shuffle! state side :deck)
                       (effect-completed state side eid))}
      card nil)))

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -9,7 +9,8 @@
     [game.core.say :refer [system-msg]]
     [game.core.toasts :refer [toast]]
     [game.macros :refer [wait-for]]
-    [game.utils :refer [pluralize quantify]]))
+    [game.utils :refer [pluralize quantify]]
+    [stringer.core :as s]))
 
 (defn sum-tag-effects
   [state]
@@ -56,7 +57,7 @@
   [state side eid n]
   (if (pos? n)
     (do (gain state :runner :tag {:base n})
-        (toast state :runner (str "Took " (quantify n "tag") "!") "info")
+        (toast state :runner (s/strcat "Took " (quantify n "tag") "!") "info")
         (update-tag-status state)
         (trigger-event-simult state side eid :runner-gain-tag nil {:amount n}))
     (effect-completed state side eid)))
@@ -77,11 +78,11 @@
                      (swap! state assoc-in [:prevent :current] :tag)
                      (show-prompt
                        state :runner nil
-                       (str "Avoid " (when (< 1 n) "any of the ") (quantify n "tag") "?") ["Done"]
+                       (s/strcat "Avoid " (when (< 1 n) "any of the ") (quantify n "tag") "?") ["Done"]
                        (fn [_]
                          (let [prevent (get-in @state [:tag :tag-prevent])
                                prevent-msg (if prevent
-                                             (str "avoids "
+                                             (s/strcat "avoids "
                                                   (if (= prevent Integer/MAX_VALUE) "all" prevent)
                                                   (pluralize prevent "tag"))
                                              "will not avoid tags")]

--- a/src/clj/game/core/to_string.clj
+++ b/src/clj/game/core/to_string.clj
@@ -1,31 +1,32 @@
 (ns game.core.to-string
   (:require [game.core.card :refer [get-card rezzed? ice? installed? corp? card-index get-title]]
-            [game.core.servers :refer [is-root? zone->name]]))
+            [game.core.servers :refer [is-root? zone->name]]
+            [stringer.core :as s]))
 
 (defn card-str
   "Gets a string description of an installed card, reflecting whether it is rezzed,
   in/protecting a server, facedown, or hosted."
   ([state card] (card-str state card nil))
   ([state {:keys [zone host facedown] :as card} {:keys [visible]}]
-  (str (if (corp? card)
+  (s/strcat (if (corp? card)
          (let [installed-ice (and (ice? card) (installed? card))]
            ; Corp card messages
-           (str (if (or (rezzed? card)
+           (s/strcat (if (or (rezzed? card)
                         visible)
                   (get-title card)
                   (if installed-ice "ice" "a card"))
                 ; Hosted cards do not need "in server 1" messages, host has them
                 (when-not host
-                  (str (cond
+                  (s/strcat (cond
                          installed-ice " protecting "
                          (is-root? zone) " in the root of "
                          :else " in ")
-                       ;TODO add naming of scoring area of corp/runner
+                       ;;TODO add naming of scoring area of corp/runner
                        (zone->name (or (second zone) zone)) ;; handles [:hand] as well as [:servers :hq]
                        (when installed-ice
-                         (str " at position " (card-index state card)))))))
+                         (s/strcat " at position " (card-index state card)))))))
          ; Runner card messages
          (if (or facedown visible)
            "a facedown card"
            (get-title card)))
-       (when host (str " hosted on " (card-str state (get-card state host)))))))
+       (when host (s/strcat " hosted on " (card-str state (get-card state host)))))))

--- a/src/clj/game/core/toasts.clj
+++ b/src/clj/game/core/toasts.clj
@@ -26,8 +26,6 @@
   [state side]
   (when state
     (toast state side
-           (str "Your last action caused a game error on the server. You can keep playing, but there "
-                "may be errors in the game's current state. Please click the button below to submit a report "
-                "to our GitHub issues page.<br/><br/>Use /error to see this message again.")
+           "Your last action caused a game error on the server. You can keep playing, but there may be errors in the game's current state. Please click the button below to submit a report to our GitHub issues page.<br/><br/>Use /error to see this message again."
            "exception"
            {:time-out 0 :close-button true})))

--- a/src/clj/game/core/trace.clj
+++ b/src/clj/game/core/trace.clj
@@ -8,7 +8,8 @@
     [game.core.prompts :refer [clear-wait-prompt show-trace-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg system-say]]
     [game.macros :refer [continue-ability effect wait-for]]
-    [game.core.payment :refer [->c]]))
+    [game.core.payment :refer [->c]]
+    [stringer.core :as s]))
 
 (defn- determine-initiator
   [state {:keys [player]}]
@@ -34,7 +35,7 @@
         trigger-trace (select-keys trace [:player :other :base :bonus :link :ability :strength])]
     (wait-for (pay state other (make-eid state eid) card [(->c :credit boost)])
               (let [payment-str (:msg async-result)]
-                (system-msg state other (str payment-str
+                (system-msg state other (s/strcat payment-str
                                              " to increase " (if (corp-start? trace) "link" "trace")
                                              " strength to " (if (corp-start? trace)
                                                                runner-strength
@@ -45,7 +46,7 @@
                                            (:successful trace)
                                            (:unsuccessful trace))
                                          :eid (make-eid state))]
-                (system-say state player (str "The trace was " (when-not successful "un") "successful."))
+                (system-say state player (s/strcat "The trace was " (when-not successful "un") "successful."))
                 (wait-for (trigger-event-simult state :corp (if successful :successful-trace :unsuccessful-trace)
                                                 nil ;; No special functions
                                                 (assoc trigger-trace
@@ -88,15 +89,15 @@
         trace (assoc trace :strength strength :beat-trace (beat-trace-amount player corp-credits runner-credits link base strength eid))]
     (wait-for (pay state player (make-eid state eid) card [(->c :credit boost)])
               (let [payment-str (:msg async-result)]
-                (system-msg state player (str payment-str
+                (system-msg state player (s/strcat payment-str
                                               " to increase " (if (corp-start? trace) "trace" "link")
                                               " strength to " strength)))
               (clear-wait-prompt state other)
               (show-wait-prompt state player
-                                (str (if (corp-start? trace) "Runner" "Corp")
+                                (s/strcat (if (corp-start? trace) "Runner" "Corp")
                                      " to boost " other-type " strength"))
               (show-trace-prompt state other (make-eid state eid) card
-                                 (str "Boost " other-type " strength?")
+                                 (s/strcat "Boost " other-type " strength?")
                                  #(resolve-trace state side eid card trace %)
                                  trace))))
 
@@ -104,17 +105,17 @@
   "Starts the trace process by showing the boost prompt to the first player (normally corp)."
   [state side eid card {:keys [player other base bonus label] :as trace}]
   (let [this-type (if (corp-start? trace) "trace" "link")]
-    (system-msg state player (str "uses " (:title card)
+    (system-msg state player (s/strcat "uses " (:title card)
                                   " to initiate a trace with strength " ((fnil + 0 0) base bonus)
                                   (when (pos? bonus)
-                                    (str " (" base " + " bonus ")"))
+                                    (s/strcat " (" base " + " bonus ")"))
                                   (when label
-                                    (str " (" label ")"))))
+                                    (s/strcat " (" label ")"))))
     (show-wait-prompt state other
-                      (str (if (corp-start? trace) "Corp" "Runner")
+                      (s/strcat (if (corp-start? trace) "Corp" "Runner")
                            " to boost " this-type " strength"))
     (show-trace-prompt state player (make-eid state eid) card
-                       (str "Boost " this-type " strength?")
+                       (s/strcat "Boost " this-type " strength?")
                        #(trace-reply state side eid card trace %)
                        trace)))
 

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -18,7 +18,7 @@
     [game.core.winning :refer [flatline]]
     [game.macros :refer [continue-ability req wait-for]]
     [game.utils :refer [dissoc-in enumerate-str quantify]]
-    [clojure.string :as string]))
+    [stringer.core :as s]))
 
 (defn- turn-message
   "Prints a message for the start or end of a turn, summarizing credits and cards in hand."
@@ -27,7 +27,7 @@
         hand (if (= side :runner) "[their] Grip" "HQ")
         cards (count (get-in @state [side :hand]))
         credits (get-in @state [side :credit])
-        text (str pre " [their] turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
+        text (s/strcat pre " [their] turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
     (system-msg state side text {:hr (not start-of-turn)})))
 
 (defn end-phase-12
@@ -89,7 +89,7 @@
       (trigger-event state side phase nil)
       (if (not-empty start-cards)
         (toast state side
-               (str "You may use " (enumerate-str (map :title start-cards))
+               (s/strcat "You may use " (enumerate-str (map :title start-cards))
                     (if (= side :corp)
                       " between the start of your turn and your mandatory draw."
                       " before taking your first click."))
@@ -105,17 +105,17 @@
               (effect-completed state side eid))
           (any-effects state side :skip-discard)
           (do
-            (system-msg state side (str "skips [their] discard step this turn"))
+            (system-msg state side (s/strcat "skips [their] discard step this turn"))
             (effect-completed state side eid))
           (> cur-hand-size max-hand-size)
           (continue-ability
             state side
-            {:prompt (str "Discard down to " (quantify max-hand-size "card"))
+            {:prompt (s/strcat "Discard down to " (quantify max-hand-size "card"))
              :choices {:card in-hand?
                        :max (- cur-hand-size (max (hand-size state side) 0))
                        :all true}
              :effect (req (system-msg state side
-                                      (str "discards "
+                                      (s/strcat "discards "
                                            (if (= :runner side)
                                              (enumerate-str (map :title targets))
                                              (quantify (count targets) "card"))
@@ -169,5 +169,5 @@
                  (when (pos? extra-turns)
                    (start-turn state side nil)
                    (swap! state update-in [side :extra-turns] dec)
-                   (system-msg state side (string/join ["will have " (quantify extra-turns "extra turn") " remaining."]))))
+                   (system-msg state side (s/strcat "will have " (quantify extra-turns "extra turn") " remaining."))))
                (effect-completed state side eid)))))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -1,6 +1,7 @@
 (ns game.macros
   (:require [clojure.tools.analyzer.jvm :as a.j]
-            [clojure.tools.analyzer.ast :as ast]))
+            [clojure.tools.analyzer.ast :as ast]
+            [stringer.core :as s]))
 
 (def forms
   (->>
@@ -86,7 +87,7 @@
         nls (emit-only needed-locals)]
     `(fn ~['state 'side 'eid 'card 'targets]
        (assert (or (nil? (:source ~'eid)) (:cid (:source ~'eid)))
-               (str ":source should be a card, received: " (:source ~'eid)))
+               (s/strcat ":source should be a card, received: " (:source ~'eid)))
        (let [~@nls]
          ~@expr))))
 
@@ -94,7 +95,7 @@
   `(req ~@(effect-state-handler expr)))
 
 (defmacro msg [& expr]
-  `(req (str ~@expr)))
+  `(req (s/strcat ~@expr)))
 
 (defmacro wait-for
   [& body]

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -1,5 +1,6 @@
 (ns game.main
-  (:require [cheshire.generate :refer [add-encoder encode-str]]
+  (:require [stringer.core :as s]
+            [cheshire.generate :refer [add-encoder encode-str]]
             [game.core :as core]
             [game.core.toasts :refer [toast]]))
 
@@ -49,4 +50,4 @@
                     (= _id (get-in @state [:runner :user :_id])) :runner
                     :else nil)]
     (swap! state assoc-in [side :user] user)
-    (handle-notification state (str username " rejoined the game."))))
+    (handle-notification state (s/strcat username " rejoined the game."))))

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -7,7 +7,8 @@
    [monger.operators :refer :all]
    [ring.middleware.anti-forgery :as anti-forgery]
    [web.utils :refer [response html-response]]
-   [web.versions :refer [frontend-version]]))
+   [web.versions :refer [frontend-version]]
+   [stringer.core :as s]))
 
 (defn index-page
   ([request] (index-page request nil nil))
@@ -30,7 +31,7 @@
         (hiccup/include-css "/lib/css/toastr.min.css")
         (if (= "dev" server-mode)
           (hiccup/include-css "/css/netrunner.css")
-          (hiccup/include-css (str "/css/netrunner.css?v=" @frontend-version)))]
+          (hiccup/include-css (s/strcat "/css/netrunner.css?v=" @frontend-version)))]
        [:body
         [:div#sente-csrf-token
          {:style {:display "hidden"}
@@ -48,11 +49,11 @@
         (hiccup/include-js "https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js")
         (hiccup/include-js "/lib/js/toastr.min.js")
         [:script {:type "text/javascript"}
-         (str "var user=" (json/generate-string user) ";")]
+         (s/strcat "var user=" (json/generate-string user) ";")]
         (if (= "dev" server-mode)
           (list (hiccup/include-js "/js/cljs-runtime/goog.base.js")
                 (hiccup/include-js "/js/main.js"))
-          (list (hiccup/include-js (str "/js/main.js?v=" @frontend-version))))]))))
+          (list (hiccup/include-js (s/strcat "/js/main.js?v=" @frontend-version))))]))))
 
 (defn reset-password-page
   [{db :system/db

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -32,7 +32,8 @@
    [web.telemetry]
    [web.utils :refer [tick]]
    [web.versions :refer [banned-msg frontend-version]]
-   [web.ws :refer [ch-chsk event-msg-handler]]))
+   [web.ws :refer [ch-chsk event-msg-handler]]
+   [stringer.core :as s]))
 
 (read-write/print-time-literals-clj!)
 
@@ -52,7 +53,7 @@
 
 (defmethod ig/init-key :mongodb/connection [_ opts]
   (let [{:keys [address port name connection-string]} opts
-        connection (or connection-string (str "mongodb://" address ":" port "/" name))]
+        connection (or connection-string (s/strcat "mongodb://" address ":" port "/" name))]
     (mg/connect-via-uri connection)))
 
 (defmethod ig/halt-key! :mongodb/connection [_ {:keys [conn]}]


### PR DESCRIPTION
I went through (almost) every backend class to do this.
Essentially, java is sloppy and slow with string operations using the basic libraries, and clojure inherits this. Stringer is a bit more optimized, so this is basically a "free" speedup (do note that the compile time will be a little longer, but we don't care too much about that).