### PR TITLE
streamline broadcast to lobbies

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -184,7 +184,7 @@
         (when lobby?
           (stats/game-started db lobby?)
           (lobby/send-lobby-state lobby?)
-          (lobby/broadcast-lobby-list)
+          (lobby/broadcast-lobby-list (lobby/users-not-in-game))
           (send-state-to-participants :game/start lobby? (diffs/public-states (:state lobby?))))))))
 
 (defmethod ws/-msg-handler :game/leave
@@ -200,7 +200,7 @@
         (handle-message-and-send-diffs!
           lobby? nil nil (str (:username user) " has left the game.")))
       (lobby/send-lobby-list uid)
-      (lobby/broadcast-lobby-list)
+      (lobby/broadcast-lobby-list (lobby/users-not-in-game))
       (when ?reply-fn (?reply-fn true)))))
 
 (defn uid-in-lobby-as-original-player? [uid]
@@ -305,7 +305,7 @@
           (do
             (lobby/send-lobby-state lobby?)
             (lobby/send-lobby-ting lobby?)
-            (lobby/broadcast-lobby-list)
+            (lobby/broadcast-lobby-list (lobby/users-not-in-game))
             (main/handle-notification (:state lobby?) watch-str)
             (send-state-to-uid! uid :game/start lobby? (diffs/public-states (:state lobby?)))
             (when ?reply-fn (?reply-fn 200)))


### PR DESCRIPTION
Marking this is a draft because:
1) I'm not 100% confident in this
2) I want to test it out on playtest for a week or two

So my two insights:
1) If we need to send stuff to 50 or so people, we're currently doing it all on one thread (we typically have a single thread maxed out)
2) people in a game only care about updates that involve them, and (for that little counter in the corner) if a game is created or destroyed

So I think I tackled both of those. Not sure if I did it right. It seems to work locally, but that's not a good measure of anything. I'll throw it up on the playtest server tonight.