### PR TITLE
use claypoole to seperate lobby threads from game threads

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -60,6 +60,7 @@
                  [cond-plus "1.1.1"]
                  [org.clojure/data.csv "1.0.0"]
                  [dev.weavejester/medley "1.8.0"]
+                 [org.clj-commons/claypoole "1.2.2"]
                  [org.slf4j/slf4j-nop "1.7.32"]
                  [integrant "0.8.0"]
                  [cljc.java-time "0.1.18"]

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -334,6 +334,7 @@
                                                                       (lobby/handle-set-last-update gameid uid)))
         {:keys [state mute-spectators] :as lobby?} (get-in new-app-state [:lobbies gameid])
         message (if mute-spectators "muted" "unmuted")]
+    ;; assert thread pool works like I think
     (when (and lobby? state (lobby/player? uid lobby?))
       (lobby/game-thread
         lobby?

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -20,7 +20,7 @@
 
 (read-write/print-time-literals-clj!)
 
-(defonce lobby-pool (cp/threadpool 1))
+(defonce lobby-pool (cp/threadpool 1 {:name "lobbies-thread"}))
 (defn lobby-thread [& body]
   (cp/future lobby-pool body))
 
@@ -56,7 +56,7 @@
      :corp-spectators []
      :runner-spectators []
      :messages []
-     :pool (cp/threadpool 1) ;; each lobby can have it's own thread
+     :pool (cp/threadpool 1 {:name (str "game-" gameid)}) ;; each lobby can have it's own thread
      ;; options
      :precon (validate-precon format precon gateway-type)
      :allow-spectator allow-spectator


### PR DESCRIPTION
This is following from what I said on slack, specifically:
* All of our ws comminication is blocking right now
* We can't process in-game actions until we finish off the queue of lobby actions
* We can't process actions in-game until we finish off processing actions in *another* game

So ideally we should:
1) Make every lobby request resolve before handling the next one
2) Make every request within a game resolve before handling the next one
3) Game A should not be waiting for Game B
4) Game A,B should not be waiting on the lobby

So I've set us up like follows:
1) There's a threadpool (with one thread) for lobby updates. Every lobby update comes through here, and they should all end up getting processed sequentially
2) Each lobby has it's own threadpool (with one thread). Things that happen within a game (conceding, taking an action or command, resync, muting spectators, talking, indicating typing) will all execute sequentially on that thread only.

As far as I know/if I understand what I'm doing right, it shouldn't be possible for things to be mis-ordered unless it was already possible to happen when we were running on a single thread.

Consider this an alternative approach to #7732, though I can probably still pick a few changes out of that.

This seems to work ok on my machine, but I should test it on the playtest server to be sure.