### PR TITLE
Add a function to simplify revealing cards

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -51,7 +51,7 @@
    [game.core.play-instants :refer [play-instant]]
    [game.core.prompts :refer [cancellable clear-wait-prompt]]
    [game.core.props :refer [add-counter add-icon add-prop remove-icon]]
-   [game.core.revealing :refer [reveal]]
+   [game.core.revealing :refer [reveal reveal-loud]]
    [game.core.rezzing :refer [derez get-rez-cost rez]]
    [game.core.runs :refer [bypass-ice can-run-server? gain-next-run-credits get-runnable-zones
                            make-run prevent-access successful-run-replace-breach
@@ -471,18 +471,15 @@
                  :this-card-run true
                  :mandatory true
                  :ability
-                 {:msg "reveal 3 random cards from HQ"
-                  :req (req (<= 1 (count (:hand corp))))
+                 {:req (req (<= 1 (count (:hand corp))))
                   :async true
                   :effect (req (let [chosen-cards (take 3 (shuffle (:hand corp)))]
-                                 (system-msg
-                                   state side
-                                   (str "reveals " (enumerate-str (map :title chosen-cards))
-                                        " from HQ"))
-                                 (continue-ability
-                                   state side
-                                   (move-ab chosen-cards (min 2 (count chosen-cards)))
-                                   card nil)))}})]}))
+                                 (wait-for
+                                   (reveal-loud state side card nil chosen-cards)
+                                   (continue-ability
+                                     state side
+                                     (move-ab chosen-cards (min 2 (count chosen-cards)))
+                                     card nil))))}})]}))
 
 (defcard "By Any Means"
   {:on-play
@@ -638,8 +635,7 @@
                                    :choices ["OK"]}
                                   card nil))
                             (do
-                              (wait-for (reveal state side target)
-                                        (system-msg state :corp (str "reveals " (:title target) " from HQ"))
+                              (wait-for (reveal-loud state side card {:forced true} target)
                                         (continue-ability
                                           state :runner
                                           {:msg "gain [Click] and draw 1 card"
@@ -1254,12 +1250,8 @@
                 :effect (req (let [cards-to-reveal (take 2 (shuffle (:hand corp)))
                                    cards-to-trash (filter #(is-type? % target) cards-to-reveal)
                                    credits (* 4 (count cards-to-trash))]
-                               (system-msg state side
-                                           (str "uses " (:title card) " to reveal "
-                                                (enumerate-str (map :title cards-to-reveal))
-                                                " from HQ"))
                                (wait-for
-                                 (reveal state side cards-to-reveal)
+                                 (reveal-loud state side card nil cards-to-reveal)
                                  (if (pos? credits)
                                    (do (system-msg
                                          state side
@@ -1408,7 +1400,7 @@
 (defcard "Executive Wiretaps"
   {:on-play
    {:msg (msg "reveal " (enumerate-str (sort (map :title (:hand corp)))) " from HQ")
-    :change-in-game-state (req (seq (:deck corp)))
+    :change-in-game-state (req (seq (:hand corp)))
     :async true
     :effect (effect (reveal eid (:hand corp)))}})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -48,7 +48,7 @@
    [game.core.prompts :refer [cancellable clear-wait-prompt]]
    [game.core.props :refer [add-counter add-icon add-prop remove-icon]]
    [game.core.purging :refer [purge]]
-   [game.core.revealing :refer [reveal]]
+   [game.core.revealing :refer [reveal reveal-loud]]
    [game.core.rezzing :refer [derez get-rez-cost rez]]
    [game.core.runs :refer [bypass-ice encounter-ends end-run
                            force-ice-encounter get-current-encounter prevent-access
@@ -1867,30 +1867,14 @@
                                       :max (req 3)}
                             :async true
                             :effect (req (wait-for
-                                           (reveal state side targets)
+                                           (reveal-loud state side card {:and-then ", and shuffle [them] into R&D"} targets)
                                            (doseq [c targets]
                                              (move state :corp c :deck))
                                            (shuffle! state :corp :deck)
                                            (effect-completed state :corp eid)))
-                            :cancel-effect (effect (shuffle! :deck)
-                                                   (effect-completed eid))
-                            :msg (msg
-                                   "reveal "
-                                   (enumerate-str
-                                     (filter identity
-                                             [(when-let [h (->> targets
-                                                                (filter in-hand?)
-                                                                (map :title)
-                                                                not-empty)]
-                                                (str (enumerate-str h)
-                                                     " from HQ"))
-                                              (when-let [d (->> targets
-                                                                (filter in-discard?)
-                                                                (map :title)
-                                                                not-empty)]
-                                                (str (enumerate-str d)
-                                                     " from Archives"))]))
-                                   " and shuffle them into R&D")}
+                            :cancel-effect (effect (system-msg (str "uses " (:title card) " to shuffle R&D"))
+                                                   (shuffle! :deck)
+                                                   (effect-completed eid))}
         draw-reveal-shuffle {:async true
                              :label "Draw cards, reveal and shuffle agendas"
                              :waiting-prompt true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -40,7 +40,7 @@
    [game.core.prompts :refer [cancellable clear-wait-prompt show-wait-prompt]]
    [game.core.props :refer [add-counter add-prop]]
    [game.core.purging :refer [purge]]
-   [game.core.revealing :refer [reveal]]
+   [game.core.revealing :refer [reveal reveal-loud]]
    [game.core.rezzing :refer [derez rez]]
    [game.core.runs :refer [end-run make-run]]
    [game.core.say :refer [system-msg]]
@@ -267,6 +267,7 @@
 (defcard "Attitude Adjustment"
   {:on-play
    {:async true
+    :msg (msg "draw 2 cards")
     :effect
     (req (wait-for
            (draw state side 2)
@@ -280,30 +281,17 @@
                                         (in-discard? %)))}
               :async true
               :show-discard true
-              :effect
-              (req (wait-for
-                     (reveal state side targets)
-                     (wait-for
-                       (gain-credits state side (* 2 (count targets)))
-                       (doseq [c targets]
-                         (move state :corp c :deck))
-                       (shuffle! state :corp :deck)
-                       (let [from-hq (map :title (filter in-hand? targets))
-                             from-archives (map :title (filter in-discard? targets))]
-                         (system-msg
-                           state side
-                           (str "uses " (:title card) " to reveal "
-                                (enumerate-str
-                                  (filter identity
-                                          [(when (not-empty from-hq)
-                                             (str (enumerate-str from-hq)
-                                                  " from HQ"))
-                                           (when (not-empty from-archives)
-                                             (str (enumerate-str from-archives)
-                                                  " from Archives"))]))
-                                ", shuffle them into R&D and gain "
-                                (* 2 (count targets)) " [Credits]")))
-                       (effect-completed state side eid))))}
+              :effect (req (let [to-gain (* 2 (count targets))]
+                             (wait-for
+                               (reveal-loud state side card
+                                                {:and-then (str ", gain " to-gain " [Credits], and shuffle [them] into R&D")}
+                                                targets)
+                               (wait-for
+                                 (gain-credits state side to-gain)
+                                 (doseq [c targets]
+                                   (move state :corp c :deck))
+                                 (shuffle! state :corp :deck)
+                                 (effect-completed state side eid)))))}
              card nil)))}})
 
 (defcard "Audacity"
@@ -483,38 +471,33 @@
     :effect (effect (damage eid :meat 7 {:card card}))}})
 
 (defcard "Bring Them Home"
-  (letfn [(hide-away [cards]
-            {:msg (msg "place " (enumerate-str (map :title cards))
-                       " from the grip to the top of the stack")
-             :async true
-             :effect (req (doseq [c (shuffle cards)]
-                            (move state :runner c :deck {:front true}))
-                          (continue-ability
-                            state side
-                            {:optional
-                             {:prompt "Shuffle 1 random card from the grip into the stack?"
-                              :req (req (threat-level 3 state))
-                              :waiting-prompt true
-                              :yes-ability
-                              {:cost [(->c :credit 2)]
-                               :req (req (seq (:hand runner)))
-                               :effect (req (let [target-card (first (shuffle (:hand runner)))]
-                                              (wait-for
-                                                (reveal state side target-card)
-                                                (system-msg state side (str "shuffles " (:title target-card) " into the stack"))
-                                                (move state :runner target-card :deck)
-                                                (shuffle! state :runner :deck))))}}}
-                            card nil))})]
+  (let [threat-abi
+        {:optional
+         {:prompt "Shuffle 1 random card from the grip into the stack?"
+          :req (req (threat-level 3 state))
+          :waiting-prompt true
+          :yes-ability
+          {:cost [(->c :credit 2)]
+           :req (req (seq (:hand runner)))
+           :effect (req (let [target-card (first (shuffle (:hand runner)))]
+                          (wait-for
+                            (reveal-loud state side card {:and-then " and shuffle it into the Stack"} target-card)
+                            (move state :runner target-card :deck)
+                            (shuffle! state :runner :deck))))}}}]
     {:on-play
      {:async true
       :req (req (or (last-turn? state :runner :trashed-card)
                     (last-turn? state :runner :stole-agenda)))
       :effect (req
                 (let [chosen-cards (take 2 (shuffle (:hand runner)))]
-                  (continue-ability
-                    state side
-                    (hide-away chosen-cards)
-                    card nil)))}}))
+                  (wait-for
+                    (reveal-loud state side card {:and-then " and place [them] on the top of the stack (in a random order)"} chosen-cards)
+                    (doseq [c (shuffle chosen-cards)]
+                      (move state :runner c :deck {:front true}))
+                    (continue-ability
+                      state side
+                      threat-abi
+                      card nil))))}}))
 
 (defcard "Building Blocks"
   {:on-play
@@ -522,11 +505,10 @@
     :choices {:card #(and (corp? %)
                           (has-subtype? % "Barrier")
                           (in-hand? %))}
-    :msg (msg "reveal " (:title target))
     :async true
     :change-in-game-state (req (seq (:hand corp)))
     :effect (req (wait-for
-                   (reveal state side target)
+                   (reveal-loud state side card nil target)
                    (corp-install state side eid target nil {:ignore-all-cost true
                                                             :msg-keys {:install-source card
                                                                        :display-origin true}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -59,7 +59,7 @@
    [game.core.play-instants :refer [play-instant]]
    [game.core.prompts :refer [cancellable]]
    [game.core.props :refer [add-counter add-icon remove-icon]]
-   [game.core.revealing :refer [reveal]]
+   [game.core.revealing :refer [reveal reveal-loud]]
    [game.core.rezzing :refer [derez rez]]
    [game.core.runs :refer [active-encounter? bypass-ice can-run-server? get-runnable-zones
                            gain-run-credits get-current-encounter
@@ -283,12 +283,21 @@
    :events [(trash-on-empty :power)]
    :abilities [{:cost [(->c :power 1)]
                 :keep-menu-open :while-power-tokens-left
-                :msg "look at the top card of Stack"
-                :optional
-                {:prompt (msg "Add " (:title (first (:deck runner))) " to bottom of Stack?")
-                 :yes-ability
-                 {:msg "add the top card of Stack to the bottom"
-                  :effect (req (move state side (first (:deck runner)) :deck))}}}]})
+                :msg "reveal the top card of Stack"
+                :req (req (seq (:deck runner)))
+                :async true
+                :effect (req
+                          (let [top-card (first (:deck runner))]
+                            (wait-for
+                              (reveal-loud state side card nil top-card)
+                              (continue-ability
+                                state side
+                                {:optional
+                                 {:prompt (msg "Add " (:title top-card) " to bottom of Stack?")
+                                  :yes-ability
+                                  {:msg (str "move " (:title top-card) " to the bottom of the Stack")
+                                   :effect (req (move state side (first (:deck runner)) :deck))}}}
+                                card nil))))}]})
 
 (defcard "Armitage Codebusting"
   {:data {:counter {:credit 12}}

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -422,7 +422,7 @@
                         (= (:previous-zone card) [:set-aside])
                         "among the set-aside cards"
                         :else
-                        (str "the " (name-zone :runner (:previous-zone card)))))
+                        (name-zone :runner (:previous-zone card))))
                  "")
         pre-lhs (when (every? (complement string/blank?) [cost-str prepend-cost-str])
                   (str prepend-cost-str ", and then "))

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -1,6 +1,11 @@
 (ns game.core.revealing
   (:require
-    [game.core.engine :refer [trigger-event-sync]]))
+   [clojure.string :as string]
+   [game.core.engine :refer [trigger-event-sync]]
+   [game.core.say :refer [system-msg]]
+   [game.core.servers :refer [name-zone]]
+   [game.utils :refer [enumerate-str]]
+   [jinteki.utils :refer [other-side]]))
 
 (defn reveal-hand
   "Reveals a side's hand to opponent and spectators."
@@ -16,3 +21,17 @@
   "Trigger the event for revealing one or more cards."
   [state side eid & targets]
   (apply trigger-event-sync state side eid (if (= :corp side) :corp-reveal :runner-reveal) (flatten targets)))
+
+(defn reveal-explicit
+  "Trigger the event for revealing one or more cards, and also handle the log printout"
+  [state side eid card {:keys [forced] :as args} & targets]
+  (let [cards-by-zone (group-by #(select-keys % [:side :zone]) (flatten targets))
+        strs (map #(str (enumerate-str (map :title (get cards-by-zone %)))
+                        " from " (name-zone (:side %) (:zone %)))
+                  (keys cards-by-zone))]
+    (if forced
+      (system-msg state (other-side side) (str " uses " (:title card) " to force the "
+                                               (string/capitalize (name side)) " to reveal "
+                                               (enumerate-str strs)))
+      (system-msg state side (str " uses " (:title card) " to reveal " (enumerate-str strs))))
+    (reveal state side eid targets)))

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -35,8 +35,8 @@
         plural-repr (if (< 1 (count (flatten targets))) "them" "it")
         follow-up (when and-then (string/replace and-then #"(\[it\])|(\[them\])" plural-repr))]
     (if forced
-      (system-msg state (other-side side) (str " uses " (:title card) " to force the "
+      (system-msg state (other-side side) (str "uses " (:title card) " to force the "
                                                (string/capitalize (name side)) " to reveal "
                                                (enumerate-str strs) follow-up))
-      (system-msg state side (str " uses " (:title card) " to reveal " (enumerate-str strs) follow-up)))
+      (system-msg state side (str "uses " (:title card) " to reveal " (enumerate-str strs) follow-up)))
     (reveal state side eid targets)))

--- a/src/clj/game/core/servers.clj
+++ b/src/clj/game/core/servers.clj
@@ -46,9 +46,9 @@
                    :else side)
         zone (if (keyword? zone) [zone] (vec zone))]
   (cond
-    (= zone [:hand]) (if (= side "Runner") "Grip" "HQ")
-    (= zone [:discard]) (if (= side "Runner") "Heap" "Archives")
-    (= zone [:deck]) (if (= side "Runner") "Stack" "R&D")
+    (= zone [:hand]) (if (= side "Runner") "the Grip" "HQ")
+    (= zone [:discard]) (if (= side "Runner") "the Heap" "Archives")
+    (= zone [:deck]) (if (= side "Runner") "the Stack" "R&D")
     (= zone [:set-aside]) "set-aside cards"
     (= (take 1 zone) [:rig]) "Rig"
     (= (take 2 zone) [:servers :hq]) "the root of HQ"

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -836,7 +836,7 @@
                :runner {:hand ["Burner"]}})
     (take-credits state :corp)
     (play-run-event state "Burner" :hq)
-    (is (last-log-contains? state "reveals Hedge Fund, Hedge Fund, and Hedge Fund from HQ"))
+    (is (last-log-contains? state "reveal Hedge Fund, Hedge Fund, and Hedge Fund from HQ"))
     (is (changed? [(count (:deck (get-corp))) 2
                    (count (:hand (get-corp))) -2]
                   (click-prompt state :runner "Hedge Fund")

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2846,7 +2846,7 @@
         (let [hand    (:hand (get-corp))
               gate    (get-ice state :hq 0)
               log-str (str "Corp uses Gatekeeper to reveal.+"
-                           " from HQ and shuffle them into R&D")]
+                           " from HQ, and shuffle them into R&D")]
           (run-on state "HQ")
           (rez state :corp gate)
           (run-continue state)
@@ -2868,7 +2868,7 @@
         (let [discard    (:discard (get-corp))
               gate    (get-ice state :hq 0)
               log-str (str "Corp uses Gatekeeper to reveal.+"
-                           " from Archives and shuffle them into R&D")]
+                           " from Archives, and shuffle them into R&D")]
           (run-on state "HQ")
           (rez state :corp gate)
           (run-continue state)
@@ -2893,7 +2893,7 @@
               discard (:discard (get-corp))
               gate    (get-ice state :hq 0)
               log-str (str "Corp uses Gatekeeper to reveal.+ from HQ "
-                           "and .+ from Archives and shuffle them into R&D")]
+                           "and .+ from Archives, and shuffle them into R&D")]
           (run-on state "HQ")
           (rez state :corp gate)
           (run-continue state)

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -640,7 +640,7 @@
         "2 Runner cards moved off the grip")
     (is (= "Sure Gamble" (:title (nth (:deck (get-runner)) 0))) "Sure Gamble on top of the deck")
     (is (= "Sure Gamble" (:title (nth (:deck (get-runner)) 1))) "Another Sure Gamble on top of the deck")
-    (is (last-log-contains? state "place Sure Gamble and Sure Gamble from the grip to the top of the stack"))
+    (is (last-log-contains? state "reveal Sure Gamble and Sure Gamble from"))
     (is (no-prompt? state :corp) "No additional prompt because threat level is not met")
     (is (zero? (:click (get-corp))) "Terminal ends turns")))
 


### PR DESCRIPTION
Closes #7729

Essentially, I added a `reveal-loud` function, `reveal-loud [state side eid card args & targets]`, which stratifies the cards and prints them out nicely for you.

You can optionally pass in `and-then` as an arg, to format it like "[x] reveals ([y] from [z], ..) [and then]". Additionally, the `and-then` part of the argument matches the pattern ([it]|[them]) and inserts the correct form depending on if there are one or multiple cards being revealed - because I found this quite awkward to do in code, and I found a few places where I would need to do it (ie revealing 1 card with gatekeeper/adjustment vs. revealing 2).

I cleaned  up all the cards which were cumbersome and ugly looking. I also updated `name-zone` to refer to `stack, heap, grip` as `the stack, the heap, the grip`, and updated the exactly one part of the code-base where that was relevant. This means functions relying on name-zone don't need to double-check what they enter to see if they need to add an article to it.

For example, Gatekeeper (I also made it print out that it's shuffling when you say no). The only difference in terms of player experience is that this will correctly say "it" instead of "them" when there is one card shuffled in.

Before:
```Clojure
:effect (req (wait-for
                (reveal state side targets)
                (doseq [c targets]
                  (move state :corp c :deck))
                (shuffle! state :corp :deck)
                (effect-completed state :corp eid)))
:msg (msg "reveal "
       (enumerate-str
         (filter identity  [(when-let [h (->> targets
                                            (filter in-hand?)
                                            (map :title)
                                             not-empty)]
                          (str (enumerate-str h)
                                                     " from HQ"))
                                              (when-let [d (->> targets
                                                                (filter in-discard?)
                                                                (map :title)
                                                                not-empty)]
                                                (str (enumerate-str d)
                                                     " from Archives"))]))
                                   " and shuffle them into R&D")}
```
After (the msg key is cut entirely because it's not needed anymore):
```Clojure
:effect (req (wait-for
               (reveal-loud state side card {:and-then ", and shuffle [them] into R&D"} targets)
               (doseq [c targets]
                 (move state :corp c :deck))
               (shuffle! state :corp :deck)
               (effect-completed state :corp eid)))
```

The other two big cleanups were bring them home and attitude adjustment. Angel Arena also didn't reveal before (probably done before revealing was an event), it does now.