### PR TITLE
effcom doesn't crash the lobby

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -730,10 +730,7 @@
                 :cost [(->c :click 1) (->c :agenda 1)]
                 :effect (effect (gain-clicks 2)
                                 (register-turn-flag!
-                                  card :can-advance
-                                  (fn [state side card]
-                                    ((constantly false)
-                                     (toast state :corp "Cannot advance cards this turn due to Efficiency Committee." "warning")))))
+                                  card :can-advance (constantly false)))
                 :keep-menu-open :while-agenda-tokens-left
                 :msg "gain [Click][Click]"}]})
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -730,7 +730,10 @@
                 :cost [(->c :click 1) (->c :agenda 1)]
                 :effect (effect (gain-clicks 2)
                                 (register-turn-flag!
-                                  card :can-advance (constantly false)))
+                                  card :can-advance
+                                  (fn [state side card]
+                                    ((constantly false)
+                                     (toast state :corp "Cannot advance cards this turn due to Efficiency Committee." "warning")))))
                 :keep-menu-open :while-agenda-tokens-left
                 :msg "gain [Click][Click]"}]})
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -731,9 +731,7 @@
                 :effect (effect (gain-clicks 2)
                                 (register-turn-flag!
                                   card :can-advance
-                                  (fn [state side card]
-                                    ((constantly false)
-                                     (toast state :corp "Cannot advance cards this turn due to Efficiency Committee." "warning")))))
+                                  (constantly false)))
                 :keep-menu-open :while-agenda-tokens-left
                 :msg "gain [Click][Click]"}]})
 

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -9,7 +9,7 @@
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.effects :refer [get-effects]]
    [game.core.engine :refer [pay resolve-ability trigger-event]]
-   [game.core.flags :refer [can-advance? untrashable-while-resources?]]
+   [game.core.flags :refer [untrashable-while-resources?]]
    [game.core.gaining :refer [gain-credits]]
    [game.core.installing :refer [corp-can-pay-and-install? corp-install
                                  runner-can-pay-and-install? runner-install]]

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -92,7 +92,6 @@
                 :cost [(->c :click 1) (->c :credit 1)]
                 :async true
                 :msg (msg "advance " (card-str state (:card context)))
-                :req (req (can-advance? state side (:card context)))
                 :effect (effect (update-advancement-requirement (:card context))
                                 (add-prop (get-card state (:card context)) :advance-counter 1)
                                 (play-sfx "click-advance")

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3970,9 +3970,7 @@
              :duration :until-runner-turn-begins
              :effect (effect (register-turn-flag!
                                card :can-advance
-                               (fn [state side card]
-                                 ((constantly false)
-                                  (toast state :corp "Cannot advance cards this turn due to The Price of Freedom." "warning")))))}]})
+                               (constantly false)))}]})
 
 (defcard "Three Steps Ahead"
   {:on-play

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -581,9 +581,13 @@
   [state side {:keys [card] :as context}]
   (when-let [card (get-card state card)]
     (let [context (assoc context :card card)]
-      (play-ability state side {:card (get-in @state [:corp :basic-action-card])
-                                :ability 4
-                                :targets [context]}))))
+      ;; note that can-advance potentially generates toasts (effcom),
+      ;; so it cannot go in the req of basic, since that can generate infinite toast loops
+      ;; when update-and-send-diffs causes more updates that need to be updated and sent...
+      (when (can-advance? state side card)
+        (play-ability state side {:card (get-in @state [:corp :basic-action-card])
+                                  :ability 4
+                                  :targets [context]})))))
 
 ;;; Runner actions
 (defn click-run

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -584,10 +584,11 @@
       ;; note that can-advance potentially generates toasts (effcom),
       ;; so it cannot go in the req of basic, since that can generate infinite toast loops
       ;; when update-and-send-diffs causes more updates that need to be updated and sent...
-      (when (can-advance? state side card)
+      (if (can-advance? state side card)
         (play-ability state side {:card (get-in @state [:corp :basic-action-card])
                                   :ability 4
-                                  :targets [context]})))))
+                                  :targets [context]})
+        (toast state :corp "Cannot advance cards this turn." "warning")))))
 
 ;;; Runner actions
 (defn click-run

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -125,7 +125,8 @@
   Sends a command to clear any server side toasts."
   [msg toast-type options]
   (set! (.-options js/toastr) (toastr-options options))
-  (let [f (aget js/toastr (if (= "exception" toast-type) "error" toast-type))]
+  (js/console.log toast-type)
+  (let [f (aget js/toastr (if (= "exception" toast-type) "error" (or toast-type "warning")))]
     (f (if (= "exception" toast-type) (build-exception-msg msg (:last-error @game-state)) msg))))
 
 (defonce side (r/cursor game-state [:side]))

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -125,8 +125,7 @@
   Sends a command to clear any server side toasts."
   [msg toast-type options]
   (set! (.-options js/toastr) (toastr-options options))
-  (js/console.log toast-type)
-  (let [f (aget js/toastr (if (= "exception" toast-type) "error" (or toast-type "warning")))]
+  (when-let [f (aget js/toastr (if (= "exception" toast-type) "error" toast-type))]
     (f (if (= "exception" toast-type) (build-exception-msg msg (:last-error @game-state)) msg))))
 
 (defonce side (r/cursor game-state [:side]))


### PR DESCRIPTION
Essentially:
* We create a toast 
* The frontend acks the toast
* When we process an action, we run checkpoint+cleanup
* this includes when we ack a toast...
* checkpoint+cleanup involves checking if we can advance cards (it runs through it at least twice)
* we just added two or more extra toasts

I believe this actually spikes the entire server, since it creates a very rapid dedicated stream of ws messages, so it (and potentially similar things) would explain a tiny slice of the lag complaints we get.

This is really quite cursed. Add to the fact that for some reason, the toasts don't actually flush on the corp side until the runner gets a toast most of the time (this has been ongoing for like 5 years too :joy:), and I can see how this stayed unresolved for so long.

For now, I've moved `can-advance?` to process-action, instead of basic, so it doesn't get queried every single server frame, only when you click to advance something.

Closes #7734
Closes #6713