### PR TITLE
Eru queues twice

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1329,14 +1329,14 @@
                                     (gain-credits state side eid 9)))}]})
 
 (defcard "Eru Ayase-Pessoa"
-  (let [constant-ability
+  (let [constant-effect
         {:event :breach-server
          :req (req (and (threat-level 3 state)
                         (= :rd target)
                         (= :archives (first (:server run)))))
          :msg "access 1 additional card"
          :effect (effect (access-bonus :rd 1))}
-        ability
+        replace-breach-event
         (successful-run-replace-breach
           {:target-server :archives
            :this-card-run true
@@ -1344,7 +1344,8 @@
            :ability {:msg "breach R&D"
                      :async true
                      :effect (req (breach-server state :runner eid [:rd] nil))}})]
-    {:events [constant-ability]
+    {:events [constant-effect
+              replace-breach-event]
      :abilities [{:action true
                   :cost [(->c :click 1)]
                   :msg "make a run on Archives"
@@ -1354,7 +1355,6 @@
                   :async true
                   :effect
                   (req (wait-for (gain-tags state :runner 1 {:unpreventable true})
-                                 (register-events state side card [ability])
                                  (make-run state side eid :archives (get-card state card))))}]}))
 
 (defcard "Fall Guy"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2315,6 +2315,26 @@
       (click-prompt state :runner "No action")
       (is (empty? (get-run)) "Run has ended"))))
 
+(deftest eru-ayase-pessoa-threat-3-with-mercury
+  (do-game
+    (new-game {:corp {:score-area ["City Works Project"]
+                      :hand []
+                      :deck ["Hedge Fund" "Hedge Fund" "Hedge Fund"]}
+               :runner {:id "Mercury: Chrome Libertador"
+                        :hand ["Eru Ayase-Pessoa"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Eru Ayase-Pessoa")
+    (let [eru (get-resource state 0)]
+      (is (changed? [(count-tags state) 1]
+            (card-ability state :runner (refresh eru) 0))
+          "Got 1 tag")
+      (run-continue state)
+      (click-prompt state :runner "Yes")
+      (click-prompt state :runner "No action")
+      (click-prompt state :runner "No action")
+      (click-prompt state :runner "No action")
+      (is (empty? (get-run)) "Run has ended"))))
+
 (deftest fan-site
   ;; Fan Site - Add to score area as 0 points when Corp scores an agenda
   (do-game


### PR DESCRIPTION
Eru was actually queuing up two of the breach replacement for some reason, and making you pick between the two. Mercury was just an innocent bystander all along.

Closes #7737