### PR TITLE
make matryoshka a cost

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2099,31 +2099,18 @@
 
 (defcard "Matryoshka"
   (let [break-abi {:label "Break X subroutines"
-                   :cost [(->c :x-credits)]
-                   :break-cost [(->c :x-credits)]
-                   :req (req (let [hosted (:hosted (get-card state card))
-                                   valid (filter #(not (facedown? %)) hosted)
-                                   same-title (filter #(= (:title card) (:title %)) valid)]
-                               (and (active-encounter? state)
-                                    current-ice card
-                                    (<= (get-strength current-ice) (get-strength card))
-                                    (not-empty same-title))))
-                                        ; no break-req to not enable auto-pumping
+                   :cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
+                   :break-cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
+                   :req (req (and
+                               (active-encounter? state)
+                               (<= (get-strength current-ice) (get-strength card))))
                    :msg (msg "break " (quantify (cost-value eid :x-credits) "subroutine")
-                             " on " (card-str state current-ice) " and turn 1 hosted copy of "
-                             (:title card) " facedown")
-                   :effect (req
-                             (let [hosted (:hosted (get-card state card))
-                                   valid (filter #(not (facedown? %)) hosted)
-                                   same-title (filter #(= (:title card) (:title %)) valid)
-                                   first-copy (first same-title)]
-                               (flip-facedown state side (get-card state first-copy))
-                               (if (pos? (cost-value eid :x-credits))
-                                 (continue-ability
-                                   state side
-                                   (break-sub nil (cost-value eid :x-credits) "All")
-                                   card nil)
-                                 (effect-completed state side eid))))}
+                             " on " (card-str state current-ice))
+                   :effect (effect
+                             (continue-ability
+                               (when (pos? (cost-value eid :x-credits))
+                                 (break-sub nil (cost-value eid :x-credits) "All" {:repeatable false}))
+                               card nil))}
         host-abi {:action true
                   :label "Host 1 copy of Matryoshka"
                   :prompt (msg "Choose 1 copy of " (:title card) " in the grip")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1982,10 +1982,14 @@
 
 (defcard "Lobisomem"
   (auto-icebreaker {:data {:counter {:power 1}}
-                    :abilities [(break-sub 1 1 "Code Gate")
+                    :abilities [(break-sub 1 1 "Code Gate" {:auto-break-sort 1})
                                 {:label "Break X Barrier subroutines"
                                  :cost [(->c :x-credits) (->c :power 1)]
                                  :break-cost [(->c :x-credits) (->c :power 1)]
+                                 :auto-break-creds-per-sub 1
+                                 :break 0 ;; technically not correct, but it's enough for the engine to pick up for auto-breaking
+                                 :break-req (req (and (active-encounter? state)
+                                                      (has-subtype? current-ice "Barrier")))
                                  :req (req (and
                                              (active-encounter? state)
                                              (<= (get-strength current-ice) (get-strength card))))
@@ -2101,6 +2105,9 @@
   (let [break-abi {:label "Break X subroutines"
                    :cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
                    :break-cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
+                   :auto-break-creds-per-sub 1
+                   :break 0 ;; technically not correct, but it's enough for the engine to pick up for auto-breaking
+                   :break-req (req (active-encounter? state))
                    :req (req (and
                                (active-encounter? state)
                                (<= (get-strength current-ice) (get-strength card))))
@@ -3399,7 +3406,12 @@
                                    :once :per-run
                                    :req (req (and (break-req state side eid card targets)
                                                   (<= (get-strength current-ice) (get-strength card))))
-                                   ; no break-req to not enable auto-pumping
+                                   :auto-break-creds-per-sub 1
+                                   :auto-break-sort 2
+                                   :break 0 ;; technically not correct, but it's enough for the engine to pick up for auto-breaking
+                                   :break-req (req (and (active-encounter? state)
+                                                        (not-used-once? state {:once :per-run} card)
+                                                        (has-subtype? current-ice "Code Gate")))
                                    :msg (msg "break " (quantify (cost-value eid :x-credits) "subroutine")
                                              " on " (card-str state current-ice))
                                    :effect (effect
@@ -3408,6 +3420,8 @@
                                                  (break-sub nil (cost-value eid :x-credits) "Code Gate"))
                                                card nil))}
                                   (break-sub 1 1 "Code Gate" {:label "Break 1 Code Gate subroutine (Virtual restriction)"
+                                                              ;; this should be prioritized when available
+                                                              :auto-break-sort 1
                                                               :req (req (<= 3 (count (filter #(has-subtype? % "Virtual")
                                                                                              (all-active-installed state :runner)))))})
                                   (strength-pump 1 1)]})))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -704,6 +704,15 @@
                               card)
                             duration))})))
 
+(defn substitute-x-credit-costs
+  "Substitute out the 'x-credits' part of a cost when the credit count is known"
+  [cost x scale]
+  (let [pick-x (fn [c] (= (:cost/type c) :x-credits))
+        output-cost (when (and x scale) [(->c :credit (* x scale))])
+        adjusted (remove pick-x cost)]
+    (if (= (count adjusted) (count cost))
+      cost
+      (concat adjusted output-cost))))
 
 (def breaker-auto-pump
   "Updates an icebreaker's abilities with a pseudo-ability to trigger the
@@ -751,6 +760,7 @@
                             (if (pos? subs-broken-at-once)
                               (int (Math/ceil (/ unbroken-subs subs-broken-at-once)))
                               1))
+              break-cost (substitute-x-credit-costs break-cost unbroken-subs (:auto-break-creds-per-sub break-ability))
               total-break-cost (when (and break-cost
                                           times-break)
                                  (repeat times-break break-cost))

--- a/test/clj/game/core/ice_test.clj
+++ b/test/clj/game/core/ice_test.clj
@@ -177,17 +177,21 @@
   (testing "Auto pump available even with no active break ability"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["DNA Tracker"]
+                        :hand ["DNA Tracker" "Enigma"]
                         :credits 20}
                  :runner {:deck ["Utae"]
                           :credits 20}})
       (play-from-hand state :corp "DNA Tracker" "HQ")
+      (play-from-hand state :corp "Enigma" "HQ")
       (rez state :corp (get-ice state :hq 0))
+      (rez state :corp (get-ice state :hq 1))
       (take-credits state :corp)
       (play-from-hand state :runner "Utae")
       (let [utae (get-program state 0)]
         (run-on state :hq)
         (run-continue state)
+        (auto-pump-and-break state (refresh utae))
+        (run-continue-until state :encounter-ice)
         (is (not-empty (filter #(= :auto-pump (:dynamic %)) (:abilities (refresh utae)))) "Auto pump is active")
         (is (empty? (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh utae)))) "No auto break dynamic ability")))))
 


### PR DESCRIPTION
I was intending to do this ages ago and forgot about it.

~~This doesn't actually fix anything, just makes the label display nicely and I guess makes the code look nicer.~~

I figured out a nice way to handle x-costs within our auto-breaking system, and I was able to get lobisomem, matryoshka and utae to all work with it, so I guess this now Closes #7617 and Closes #6896

I added a unit test for utae (since I had to make our auto-break respect the `:once` key as well).

![matryoshka-label](https://github.com/user-attachments/assets/46bdf77b-edfd-4515-aa01-bfd033f93537)
![matry](https://github.com/user-attachments/assets/35e28d35-bb37-4e1f-9cf7-c33e97faadca)
![lobi_000](https://github.com/user-attachments/assets/b0a09362-2657-4f3b-b1c2-298edf0d0bb6)
![lobi](https://github.com/user-attachments/assets/bc08d347-3cef-4dfb-8917-caae5af48ca3)