### PR TITLE
indexed install messages work again

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -212,7 +212,7 @@
                                                         eid target nil
                                                         {:ignore-all-cost true
                                                          :msg-keys {:install-source card
-                                                                    :index target-position
+                                                                    :origin-index target-position
                                                                     :display-origin true}
                                                          :install-state :rezzed-no-cost})))
                                        :cancel-effect

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -804,7 +804,7 @@
                              :async true
                              :effect (effect (corp-install eid target nil {:ignore-all-cost true
                                                                            :msg-keys {:install-source card
-                                                                                      :index (first (positions #{target} (take 5 (:deck corp))))
+                                                                                      :origin-index (first (positions #{target} (take 5 (:deck corp))))
                                                                                       :display-origin true}}))
                              :cancel-effect (effect (system-msg "does not install any of the top 5 cards")
                                                     (effect-completed eid))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -641,7 +641,7 @@
                                             (effect (system-msg (str "declines to use " (get-title card) " to install a card from the top of R&D"))
                                                     (effect-completed eid))
                                             :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
-                                                                                                     :index (first (keep-indexed #(when (same-card? target %2) %1) top))
+                                                                                                     :origin-index (first (keep-indexed #(when (same-card? target %2) %1) top))
                                                                                                      :display-origin true}}))}
                                            card nil))))}]}))
 

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1819,7 +1819,7 @@
                                        (corp-install state side eid ice zone {:ignore-all-cost true
                                                                               :install-state :rezzed-no-cost
                                                                               :display-message false
-                                                                              :index index}))
+                                                                              :origin-index index}))
                                    (do (system-msg state side (str "uses " (:title card) " to shuffle R&D"))
                                        (effect-completed state side eid))))))))}})
 
@@ -2169,7 +2169,7 @@
              :choices (req (conj (vec (get-remote-names state)) "New remote"))
              :async true
              :effect (effect (corp-install eid chosen target {:msg-keys {:install-source card
-                                                                         :index (first (positions #{chosen} (take 5 (:deck corp))))
+                                                                         :origin-index (first (positions #{chosen} (take 5 (:deck corp))))
                                                                          :display-origin true}}))})]
     {:on-play
      {:async true


### PR DESCRIPTION
I typed half the keys wrong when I rewrote this system :eyes:

Closes #7764

![architect](https://github.com/user-attachments/assets/a95fd2e5-3ae6-490c-8d40-277c9d0dc1b6)
