### PR TITLE
Ganked raindrops interaction

### DIFF
--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -276,10 +276,11 @@
                (update-current-encounter state :prevent-subroutine nil)
                (if prevent
                  (checkpoint state nil eid {:duration :subroutine-currently-resolving})
-                 ;; see if there are any effects which can prevent this subroutine
-                 (wait-for (resolve-ability state side (make-eid state eid) (:sub-effect sub) (get-card state ice) nil)
-                           (queue-event state :subroutine-fired {:sub sub :ice ice})
-                           (checkpoint state nil eid {:duration :subroutine-currently-resolving})))))))
+                 (wait-for
+                   (trigger-event-simult state side :subroutine-fired nil {:sub sub :ice ice})
+                   (wait-for
+                     (resolve-ability state side (make-eid state eid) (:sub-effect sub) (get-card state ice) nil)
+                     (checkpoint state nil eid {:duration :subroutine-currently-resolving}))))))))
 
 (defn- resolve-next-unbroken-sub
   ([state side ice subroutines]

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -5681,6 +5681,28 @@
           (click-prompt state :runner "No action"))
         "gained 3 credits from raindrop")))
 
+(deftest raindrops-cut-stone-forced-encounter
+  (do-game
+    (new-game {:corp {:hand ["Ganked!" "Enigma"]}
+               :runner {:hand ["Raindrops Cut Stone"]
+                        :deck [(qty "Ika" 5)]}})
+    (play-from-hand state :corp "Enigma" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Raindrops Cut Stone")
+    (click-prompt state :runner "HQ")
+    (let [enigma (get-ice state :hq 0)]
+      (rez state :corp (refresh enigma))
+      (run-continue-until state :success)
+      (is (last-log-contains? state "Runner accesses Ganked!") "Ganked! message printed to log")
+      (click-prompt state :corp "Yes")
+      (click-card state :corp "Enigma")
+      (let [enc (:ice (core/get-current-encounter state))]
+        (is (= "Enigma" (:title enc)) "Encountering enigma via ganked")
+        ;; should draw 2 from raindrops when we fire subs
+        (is (changed? [(count (:hand (get-runner))) 2]
+              (fire-subs state enc))
+            "Drew 2 cards from raindrops cut stone")))))
+
 ;; Rebirth
 (let [akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"


### PR DESCRIPTION
Following the rabbit hole to it's logical conclusion and trying to figure out why forced encounters specifically don't fire subroutine events before the run ends, but regular encounters do, was too hard.

Raindrops is the only card that interacts with subroutines like this, so I moved the event back a tiny bit to make sure it always gets caught.

Closes #7773