### PR TITLE
Rework threading model

### DIFF
--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -67,6 +67,7 @@
   (swap! app-state assoc-in [:lobby-updates uid] (inst/now)))
 
 (defn receive-lobby-updates?
+  "checks if a user receives lobby updates, and updates the state if they've timed out to amortize subsequent checks. Mutates"
   [uid]
   (if-let [last-ping (get-in @app-state [:lobby-updates uid])]
     (if (.isBefore (inst/now) (inst/plus last-ping lobby-subs-timeout-hours chrono/hours))
@@ -84,5 +85,5 @@
 (defonce cleanup-lobby-subs
   (go (while true
         (<! (timeout lobby-subs-clearout-freq))
-        (doseq [[uid] (get-users)]
+        (doseq [{uid :uid} (vals (:users @app-state))]
           (receive-lobby-updates? uid)))))

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -8,6 +8,7 @@
    [jinteki.validator :refer [calculate-deck-status]]
    [monger.collection :as mc]
    [monger.result :refer [acknowledged?]]
+   [web.lobby :as lobby]
    [web.mongodb :refer [->object-id ->object-id]]
    [web.nrdb :as nrdb]
    [web.utils :refer [response mongo-time-to-utc-string]]

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -101,7 +101,9 @@
   [{{db :system/db
      {username :username} :user} :ring-req
     uid :uid
-    {:keys [input]} :?data}]
+    {:keys [input]} :?data
+    id :id
+    timestamp :timestamp}]
   (try
     (let [deck (nrdb/download-public-decklist db input)]
       (if (every? #(contains? deck %) [:name :identity :cards])
@@ -116,4 +118,5 @@
           (ws/broadcast-to! [uid] :decks/import-success "Imported"))
         (ws/broadcast-to! [uid] :decks/import-failure "Failed to parse imported deck.")))
     (catch Exception _
-      (ws/broadcast-to! [uid] :decks/import-failure "Failed to import deck."))))
+      (ws/broadcast-to! [uid] :decks/import-failure "Failed to import deck.")))
+  (lobby/log-delay! timestamp id))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -230,13 +230,12 @@
           (not (or user-blocked-players? players-blocked-user?))))
       lobbies)))
 
-(defn summaries-for-lobbies [filtered-lobbies]
-  (->> filtered-lobbies
-       (map lobby-summary)
+(defn sorted-lobbies [lobbies]
+  "ideally we only sort these once"
+  (->> (map lobby-summary lobbies)
        (sort-by :date)
        (reverse)
-       (sort-by :started)
-       (into [])))
+       (sort-by :started)))
 
 (comment
   (->> (for [x (range 5 10)]
@@ -247,11 +246,11 @@
 
 (defn prepare-lobby-list
   [lobbies users]
-  (for [user users
-        :let [uid (:uid user)]]
-     (let [filtered-lobbies (filter-lobby-list lobbies user)
-           lobby-summaries (summaries-for-lobbies filtered-lobbies)]
-       [uid [:lobby/list lobby-summaries]])))
+  (let [in-order (sorted-lobbies lobbies)]
+    (for [user users
+          :let [uid (:uid user)]]
+      (let [filtered-lobbies (into [] (filter-lobby-list in-order user))]
+       [uid [:lobby/list filtered-lobbies]]))))
 
 (defn lobby-update-uids
   []

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -245,12 +245,11 @@
        (summaries-for-lobbies)))
 
 (defn prepare-lobby-list
-  [lobbies users]
-  (let [in-order (sorted-lobbies lobbies)]
-    (for [user users
-          :let [uid (:uid user)]]
-      (let [filtered-lobbies (into [] (filter-lobby-list in-order user))]
-       [uid [:lobby/list filtered-lobbies]]))))
+  [in-order-lobbies users]
+  (for [user users
+        :let [uid (:uid user)]]
+    (let [filtered-lobbies (into [] (filter-lobby-list in-order-lobbies user))]
+      [uid [:lobby/list filtered-lobbies]])))
 
 (defn lobby-update-uids
   []
@@ -266,8 +265,9 @@
      (broadcast-lobby-list users)))
   ([users]
    (assert (or (sequential? users) (nil? users)) (str "Users must be a sequence: " (pr-str users)))
-   (let [lobbies (app-state/get-lobbies)]
-     (doseq [[uid ev] (prepare-lobby-list lobbies users)]
+   (let [lobbies (app-state/get-lobbies)
+         in-order (sorted-lobbies lobbies)]
+     (doseq [[uid ev] (prepare-lobby-list in-order users)]
        (when uid
          (ws/chsk-send! uid ev))))))
 

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -119,7 +119,8 @@
 (defmethod ig/init-key :sente/router [_ _opts]
   (sente/start-server-chsk-router!
     ch-chsk
-    event-msg-handler))
+    event-msg-handler
+    {:simple-auto-threading? true}))
 
 (defmethod ig/halt-key! :sente/router [_ stop-fn]
   (when (fn? stop-fn)

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -119,8 +119,7 @@
 (defmethod ig/init-key :sente/router [_ _opts]
   (sente/start-server-chsk-router!
     ch-chsk
-    event-msg-handler
-    {:simple-auto-threading? true}))
+    event-msg-handler))
 
 (defmethod ig/halt-key! :sente/router [_ stop-fn]
   (when (fn? stop-fn)

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -6,12 +6,18 @@
    [cljc.java-time.instant :as inst]
    [game.core.board :refer [all-active]]
    [web.app-state :refer [app-state]]
-   [web.lobby :refer [lobby-update-uids pool-occupants-info]]
+   [web.lobby :refer [lobby-update-uids pool-occupants-info fetch-delay-log!]]
    [web.ws :refer [connected-sockets connections_]]
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
 
 (def log-stat-frequency (enc/ms :mins 5))
+
+(defn format-delay! []
+  (let [delays (fetch-delay-log!)
+        av #(quot (reduce + 0 %) (count %))
+        fmt #(str "Average: " (av %) "ms - Max: " (reduce max 0 %) " ms - Count: " (count %))]
+    (str (update-vals delays fmt))))
 
 (defn subscriber-time-metrics
   "average time | oldest"
@@ -70,6 +76,7 @@
           lobby-sub-count (count (filter identity (vals (:lobby-updates @app-state))))
           lobby-update-uids (count (lobby-update-uids))
           [average-sub-time oldest-sub-time] (subscriber-time-metrics (filter identity (vals (:lobby-updates @app-state))))
+          latencies (format-delay!)
           ajax-uid-count (count (:ajax @connected-sockets))
           ajax-conn-counts (seq (map count (:ajax @connections_)))
           ajax-conn-total (reduce + ajax-conn-counts)
@@ -96,6 +103,7 @@
                      " conn: " ws-conn-total
                      " }"))
       (timbre/info (str "pool occupants: " (seq (pool-occupants-info))))
+      (timbre/info latencies)
       ;; TODO - once we've got this set up on the server, wrap it in a try/catch - only ever display
       ;; the warning once!
       (timbre/info (str "Active Cards (across all lobbies): " card-freqs))

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -13,10 +13,21 @@
 
 (def log-stat-frequency (enc/ms :mins 5))
 
+(defn percentile [vector percentile]
+  ;; see: https://scicloj.github.io/stats-with-clojure/stats_with_clojure.basic_statistics.html
+  (let [sorted-vector (sort vector)
+        idx (int (* percentile (/ (count sorted-vector) 100)))]
+    (str (nth sorted-vector idx) "ms")))
+
+(defn- format-percentiles [data percentiles]
+  (apply str (interpose "/" (map #(percentile (vec data) %) percentiles))))
+
 (defn format-delay! []
   (let [delays (fetch-delay-log!)
+        percentiles [5 25 50 75 95]
         av #(quot (reduce + 0 %) (count %))
-        fmt #(str "Average: " (av %) "ms - Max: " (reduce max 0 %) " ms - Count: " (count %))]
+        fmt #(str "Average: " (av %) "ms - Count: " (count %) " - Percentiles (5/25/50/75/95): "
+                  (format-percentiles % percentiles))]
     (str (update-vals delays fmt))))
 
 (defn subscriber-time-metrics

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -6,7 +6,7 @@
    [cljc.java-time.instant :as inst]
    [game.core.board :refer [all-active]]
    [web.app-state :refer [app-state]]
-   [web.lobby :refer [lobby-update-uids]]
+   [web.lobby :refer [lobby-update-uids pool-occupants-info]]
    [web.ws :refer [connected-sockets connections_]]
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
@@ -95,6 +95,7 @@
                      " uid: " ws-uid-count
                      " conn: " ws-conn-total
                      " }"))
+      (timbre/info (str "pool occupants: " (seq (pool-occupants-info))))
       ;; TODO - once we've got this set up on the server, wrap it in a try/catch - only ever display
       ;; the warning once!
       (timbre/info (str "Active Cards (across all lobbies): " card-freqs))

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -1,5 +1,6 @@
 (ns web.ws
   (:require
+   [cljc.java-time.instant :as inst]
    [clojure.core.async :refer [<! >! chan go timeout]]
    [web.app-state :refer [register-user! deregister-user!]]
    [web.user :refer [active-user?]]
@@ -91,7 +92,7 @@
   "Wraps `-msg-handler` with logging, error catching, etc."
   [event]
   (try
-    (-msg-handler event)
+    (-msg-handler (assoc event :timestamp (inst/now)))
     (catch Exception e
       (println "Caught an error in the message handler")
       (println (.printStackTrace e)))))


### PR DESCRIPTION
This turned out to be 200% easier than I thought it would be.

We're supposedly not meant to use virtual threads for anything that touches atoms, because atoms do funny concurrency things already, so we're still using claypoole's thread pools. But now we're keeping a fixed set of pools (cores+2), and assigning each lobby a pool at random from the least occupied pools. The only thing that really changes (we have to track) is just an integer for each pool. Other than that, this literally plugs 1:1 into the other code I wrote, which is neat.

~~I also enabled the `simple-auto-threading?` option on sente's socket server, which I'll try out on playtest, but that might be overkill.~~ Probably best to trial that later, instead of doing too much at once.

I'm going to sample it on playtest over the next week or two and see if it causes any issues or is noticable at all.

------------------

Summary of changes:
* We use a fixed pool of threads to manage games. Each game is assigned a thread to work with from the pool, and if there are enough games you'll have 2/3+ lobbies on the same thread.
* Everything is still queued up sequentially on the thread, so things will be processed in order still
* The lobby itself uses it's own thread, so lobby updates wont slow down games, and games will (mostly) not slow down other games or the lobby
* We now log the throughput time of each ws interaction as it's handled, and display that in our metrics *(number of invocations, average, percentiles)*
* Prune idle users a little more aggressively (1 hour of no interaction)
* The list of lobbies gets stripped and sorted only once, instead of once per user. *(note that this sort could theoretically mutate the state, which would amortize time across invocations. I don't think it's worth it though)*