### PR TITLE
only send typing event when typing is not set

### DIFF
--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -48,11 +48,13 @@
 (defn send-typing
   "Send a typing event to server for this user if it is not already set in game state AND user is not a spectator"
   [s]
-  (let [text (:msg @s)]
-    (when (and (not (:replay @game-state))
-               (not-spectator?))
-      (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
-                                  :typing (boolean (seq text))}]))))
+  (r/with-let [typing (r/cursor game-state [:typing])]
+    (let [text (:msg @s)]
+      (when (and (not (:replay @game-state))
+                 (not @typing)
+                 (not-spectator?))
+        (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
+                                    :typing (boolean (seq text))}])))))
 
 (defn indicate-action []
   (when (not-spectator?)


### PR DESCRIPTION
This is a start. Right now we're sending 1 event per keystroke. This will at least cull a large chunk of that.
I still need to figure out rate limiting for these, because you can still send a dozen of these before the first one of your events reaches the server, then a dozen more before it makes it's way back (some people really do type fast :eyes:)