### PR TITLE
Enforce conditions better

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -25,7 +25,7 @@
                               remaining-draws]]
    [game.core.effects :refer [is-disabled-reg? register-lingering-effect update-disabled-cards]]
    [game.core.eid :refer [complete-with-result effect-completed is-basic-advance-action? make-eid get-ability-targets]]
-   [game.core.engine :refer [not-used-once? pay register-events resolve-ability trigger-event]]
+   [game.core.engine :refer [not-used-once? pay register-events resolve-ability trigger-event-sync]]
    [game.core.events :refer [first-event? no-event? turn-events event-count]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.flags :refer [lock-zone prevent-current
@@ -1637,11 +1637,7 @@
                (update! state side (assoc-in (get-card state card) [:special :malia-target] nil))
                (remove-icon state :runner card (get-card state malia-target)))
              (update-disabled-cards state)
-             (trigger-event state :runner :disabled-cards-updated)
-             ;; I'm not sure why the side is nil here
-             ;; but the old impl had it, so 🤷
-             ;; --nbk, Apr '24
-             (effect-completed state nil eid))]
+             (trigger-event-sync state nil eid :disabled-cards-updated))]
     {:on-rez {:msg (msg "blank the text box of " (card-str state target))
               :choices {:card #(and (runner? %)
                                     (installed? %)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -25,7 +25,7 @@
                               remaining-draws]]
    [game.core.effects :refer [is-disabled-reg? register-lingering-effect update-disabled-cards]]
    [game.core.eid :refer [complete-with-result effect-completed is-basic-advance-action? make-eid get-ability-targets]]
-   [game.core.engine :refer [not-used-once? pay register-events resolve-ability]]
+   [game.core.engine :refer [not-used-once? pay register-events resolve-ability trigger-event]]
    [game.core.events :refer [first-event? no-event? turn-events event-count]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.flags :refer [lock-zone prevent-current
@@ -1636,6 +1636,8 @@
         (req (when-let [malia-target (get-in card [:special :malia-target])]
                (update! state side (assoc-in (get-card state card) [:special :malia-target] nil))
                (remove-icon state :runner card (get-card state malia-target)))
+             (update-disabled-cards state)
+             (trigger-event state :runner :disabled-cards-updated)
              ;; I'm not sure why the side is nil here
              ;; but the old impl had it, so 🤷
              ;; --nbk, Apr '24

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -131,7 +131,8 @@
 (defn trash-when-tagged
   "Adds abilities for trashing a card when becoming tagged,
   and when updating disabled state while tagged, or on install.
-  cname is provided for labelling the ability"
+  cname is provided for labelling the ability. Cards that disable things in a funny way (ie malia)
+  may need to trigger a `disabled-cards-updated` event"
   [cname c]
   (let [ev {:req (req tagged)
             :interactive (req true)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -110,6 +110,8 @@
                 :msg message
                 :effect (effect (effect-fn eid card targets))}]})
 
+
+
 (defn companion-builder
   "pay-credits-req says when it can be used. turn-ends-ability defines what happens,
   and requires `effect-completed`."
@@ -125,6 +127,23 @@
                :async true
                :effect (effect (continue-ability turn-ends-ability card targets))}]
      :abilities [ability]}))
+
+(defn trash-when-tagged
+  "Adds abilities for trashing a card when becoming tagged,
+  and when updating disabled state while tagged, or on install.
+  cname is provided for labelling the ability"
+  [cname c]
+  (let [ev {:req (req tagged)
+            :interactive (req true)
+            :ability-name (str cname " (trash if tagged)")
+            :msg (msg "trash itself due to being tagged")
+            :async true
+            :effect (req (trash state side eid card {:unpreventable true :cause-card card}))}
+        evs [(assoc ev :event :tags-changed)
+             (assoc ev :event :disabled-cards-updated)]]
+    (assoc c
+           :events (into [] (concat (:events c) evs))
+           :on-install ev)))
 
 (defn bitey-boi
   [f]
@@ -2675,8 +2694,9 @@
   {:static-abilities [(runner-hand-size+ 2)]})
 
 (defcard "Rachel Beckman"
-  {:trash-when-tagged true
-   :in-play [:click-per-turn 1]})
+  (trash-when-tagged
+    "Rachel Beckman"
+    {:in-play [:click-per-turn 1]}))
 
 (defcard "Raymond Flint"
   {:events [{:event :corp-gain-bad-publicity
@@ -3840,14 +3860,15 @@
                        :value 1}]})
 
 (defcard "Zona Sul Shipping"
-  {:events [{:event :runner-turn-begins
-             :effect (effect (add-counter card :credit 1))}]
-   :trash-when-tagged true
-   :abilities [{:action true
-                :cost [(->c :click 1)]
-                :msg (msg "gain " (get-counters card :credit) " [Credits]")
-                :label "Take all credits"
-                :async true
-                :effect (effect (add-counter card :credit
-                                             (- (get-counters card :credit)))
-                                (gain-credits eid (get-counters card :credit)))}]})
+  (trash-when-tagged
+    "Zona Sul Shipping"
+    {:events [{:event :runner-turn-begins
+               :effect (effect (add-counter card :credit 1))}]
+     :abilities [{:action true
+                  :cost [(->c :click 1)]
+                  :msg (msg "gain " (get-counters card :credit) " [Credits]")
+                  :label "Take all credits"
+                  :async true
+                  :effect (effect (add-counter card :credit
+                                               (- (get-counters card :credit)))
+                                  (gain-credits eid (get-counters card :credit)))}]}))

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1099,21 +1099,6 @@
                 (effect-completed state nil eid))
       (effect-completed state nil eid))))
 
-(defn trash-on-tag
-  [state _ eid]
-  (let [trash-when-tagged (when (jinteki.utils/is-tagged? state)
-                            (filter :trash-when-tagged (all-installed-runner state)))
-        trash-when-tagged (filter #(not (is-disabled? state nil %)) trash-when-tagged)]
-    (if (seq trash-when-tagged)
-      (wait-for (move* state nil (make-eid state eid)
-                       :trash-cards trash-when-tagged
-                       {:unpreventable true})
-                (doseq [card trash-when-tagged]
-                  (system-say state (to-keyword (:side card))
-                              (str "trashes " (card-str state card) " for being tagged")))
-                (effect-completed state nil eid))
-      (effect-completed state nil eid))))
-
 (defn- enforce-conditions-impl
   [state _ eid cards]
   (if (seq cards)
@@ -1129,15 +1114,13 @@
 
 (defn enforce-conditions
   [state _ eid]
-  (wait-for
-    (trash-on-tag state nil (make-eid state eid))
-    (if-let [cards (seq (filter
-                          #(:enforce-conditions (card-def %))
-                          (concat (all-installed state :corp)
-                                  [(get-in @state [:corp :identity])]
-                                  (all-active-installed state :runner))))]
-      (enforce-conditions-impl state nil eid cards)
-      (effect-completed state nil eid))))
+  (if-let [cards (seq (filter
+                        #(:enforce-conditions (card-def %))
+                        (concat (all-installed state :corp)
+                                [(get-in @state [:corp :identity])]
+                                (all-active-installed state :runner))))]
+    (enforce-conditions-impl state nil eid cards)
+    (effect-completed state nil eid)))
 
 (defn check-restrictions
   [state _ eid]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1121,9 +1121,8 @@
       (wait-for
         (resolve-ability
           state (to-keyword (:side fc))
-          (when-not
-              (is-disabled-reg? state fc)
-            (:enforce-conditions fc))
+          (when-not (is-disabled-reg? state fc)
+            (:enforce-conditions (card-def fc)))
           fc nil)
         (enforce-conditions-impl state nil eid (rest cards))))
     (effect-completed state nil eid)))
@@ -1133,7 +1132,7 @@
   (wait-for
     (trash-on-tag state nil (make-eid state eid))
     (if-let [cards (seq (filter
-                          :enforce-conditions
+                          #(:enforce-conditions (card-def %))
                           (concat (all-installed state :corp)
                                   [(get-in @state [:corp :identity])]
                                   (all-active-installed state :runner))))]

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -190,7 +190,6 @@
                 :subroutines (subroutines-init (assoc card :cid cid) cdef)
                 :abilities (ability-init cdef)
                 :expend (:expend cdef)
-                :trash-when-tagged (:trash-when-tagged cdef)
                 :x-fn (:x-fn cdef)
                 :poison (:poison cdef)
                 :highlight-in-discard (:highlight-in-discard cdef)

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -190,7 +190,6 @@
                 :subroutines (subroutines-init (assoc card :cid cid) cdef)
                 :abilities (ability-init cdef)
                 :expend (:expend cdef)
-                :enforce-conditions (:enforce-conditions cdef)
                 :trash-when-tagged (:trash-when-tagged cdef)
                 :x-fn (:x-fn cdef)
                 :poison (:poison cdef)

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.effects :refer [any-effects sum-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
-    [game.core.engine :refer [trash-on-tag trigger-event trigger-event-simult trigger-event-sync]]
+    [game.core.engine :refer [trigger-event trigger-event-simult trigger-event-sync]]
     [game.core.flags :refer [cards-can-prevent? get-prevent-list]]
     [game.core.gaining :refer [deduct gain]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
@@ -33,8 +33,6 @@
        (trigger-event state :runner :tags-changed {:new-total new-total
                                                    :old-total old-total
                                                    :is-tagged is-tagged?}))
-     (when is-tagged?
-       (trash-on-tag state nil (make-eid state)))
      changed?)))
 
 (defn tag-prevent


### PR DESCRIPTION
* Stripped the trash-on-tagged and enforce-conditions stuff out of the card maps 
* stripped the trash-on-tagged stuff out of the engine entirely and redeffed it in terms of card events
* beckman/zona sul still pass all tests

I think this should debloat the gamestate a tiny bit, and also strips one repetitive function out of engine (from fake-checkpoint), which is nice