### PR TITLE
Clean up set aside

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -71,7 +71,7 @@
    [game.core.servers :refer [central->name is-central? is-remote?
                               protecting-same-server? remote->name target-server unknown->kw
                               zone->name zones->sorted-names]]
-   [game.core.set-aside :refer [set-aside get-set-aside set-aside-for-me]]
+   [game.core.set-aside :refer [set-aside set-aside-for-me]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.tags :refer [gain-tags lose-tags tag-prevent]]
    [game.core.to-string :refer [card-str]]
@@ -3084,8 +3084,7 @@
                                              {:cost-bonus -1
                                               :no-toast true}))
                                 (seq (:hosted card))))
-                :effect (req (set-aside state side eid (:hosted card))
-                             (let [set-aside-cards (get-set-aside state side eid)]
+                :effect (req (let [set-aside-cards (set-aside state side eid (:hosted card))]
                                (wait-for (trash state side card {:cause :ability-cost :cause-card card})
                                          (system-msg state side "trashed")
                                          (continue-ability
@@ -3303,8 +3302,7 @@
                :once-key :the-class-act-put-bottom
                :async true
                :effect
-               (req (set-aside-for-me state :runner eid (take (inc target) (:deck runner)))
-                    (let [cards (get-set-aside state :runner eid)]
+               (req (let [cards (set-aside-for-me state :runner eid (take (inc target) (:deck runner)))]
                       (continue-ability
                         state side
                         {:waiting-prompt true

--- a/src/clj/game/core/drawing.clj
+++ b/src/clj/game/core/drawing.clj
@@ -80,8 +80,7 @@
            (effect-completed state side eid)
            (let [to-draw (take draws-after-prevent (get-in @state [side :deck]))
                  set-aside-eid eid]
-             (set-aside-for-me state side set-aside-eid to-draw)
-             (let [drawn (get-set-aside state side set-aside-eid)
+             (let [drawn (set-aside-for-me state side set-aside-eid to-draw)
                    drawn-count (count drawn)]
                (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % drawn-count) 0))
                (if (not no-update-draw-stats)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -13,6 +13,7 @@
     [game.core.ice :refer [update-all-ice update-breaker-strength]]
     [game.core.moving :refer [move]]
     [game.core.say :refer [system-msg]]
+    [game.core.set-aside :refer [clean-set-aside!]]
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.core.winning :refer [flatline]]
@@ -143,6 +144,7 @@
                (unregister-floating-events state side :end-of-next-run)
                (unregister-lingering-effects state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
                (unregister-floating-events state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
+               (clean-set-aside! state side)
                (doseq [card (all-active-installed state :runner)]
                  ;; Clear :installed :this-turn as turn has ended
                  (when (= :this-turn (installed? card))


### PR DESCRIPTION
Makes it so that:
* Setting cards aside returns you those cards, instead of requiring you to query again to get them
* at the end of your turn, we clear out all the info for set-aside cards that are no longer set-aside (it's a tiny amount - only cids and the eid number, but since every card you draw passes through the set-aside zone, I feel like it could add up).
* And I cleaned up a couple of uses of set-aside