### PR TITLE
Side spectate on frontend too

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -486,29 +486,32 @@
 
 (defn public-states
   "Generates privatized states for the Corp, Runner, any spectators, and the history from the base state.
-  If `:spectatorhands` is on, all information is passed on to spectators as well."
-  [state]
-  (let [stripped-state (strip-state state)
-        corp-state (state-summary stripped-state state :corp)
-        runner-state (state-summary stripped-state state :runner)
-        replay-state (strip-for-replay stripped-state corp-state runner-state)]
-    ;; corp, runner, spectator, history
-    {:corp-state corp-state
-     :runner-state runner-state
-     :spect-state (strip-for-spectators replay-state corp-state runner-state)
-     :corp-spect-state (strip-for-corp-spect replay-state corp-state runner-state)
-     :runner-spect-state (strip-for-runner-spect replay-state corp-state runner-state)
-     :hist-state replay-state}))
+  If `:spectatorhands` is on, all information is passed on to spectators as well.
+  note that when joining or starting a game, all states are always generated.
+  Otherwise when computing diffs, only the relevant states are needed, and we can skip computing the other ones."
+  ([state] (public-states state true true true))
+  ([state spectators? corp-spectators? runner-spectators?]
+   (let [stripped-state (strip-state state)
+         corp-state (state-summary stripped-state state :corp)
+         runner-state (state-summary stripped-state state :runner)
+         replay-state (strip-for-replay stripped-state corp-state runner-state)]
+     ;; corp, runner, spectator, history
+     {:corp-state corp-state
+      :runner-state runner-state
+      :spect-state (when spectators? (strip-for-spectators replay-state corp-state runner-state))
+      :corp-spect-state (when corp-spectators? (strip-for-corp-spect replay-state corp-state runner-state))
+      :runner-spect-state (when runner-spectators? (strip-for-runner-spect replay-state corp-state runner-state))
+      :hist-state replay-state})))
 
 (defn public-diffs [old-state new-state spectators? corp-spectators? runner-spectators?]
   (let [{old-corp :corp-state old-runner :runner-state
          old-spect :spect-state old-hist :hist-state
          old-corp-spect :corp-spect-state
-         old-runner-spect :runner-spect-state} (when old-state (public-states (atom old-state)))
+         old-runner-spect :runner-spect-state} (when old-state (public-states (atom old-state) spectators? corp-spectators? runner-spectators?))
         {new-corp :corp-state new-runner :runner-state
          new-spect :spect-state new-hist :hist-state
          new-corp-spect :corp-spect-state
-         new-runner-spect :runner-spect-state} (public-states new-state)]
+         new-runner-spect :runner-spect-state} (public-states new-state spectators? corp-spectators? runner-spectators?)]
     {:runner-diff (differ/diff old-runner new-runner)
      :corp-diff (differ/diff old-corp new-corp)
      :spect-diff (when spectators? (differ/diff old-spect new-spect))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -209,6 +209,18 @@
           ; else
           nil)))))
 
+(defn spectate-side []
+  (let [corp-specs (get-in @app-state [:current-game :corp-spectators])
+        runner-specs (get-in @app-state [:current-game :runner-spectators])
+        me (:user @app-state)]
+    (cond
+      (some #(= (:uid %) (:uid me)) corp-specs)
+      :corp
+      (some #(= (:uid %) (:uid me)) runner-specs)
+      :runner
+      :else
+      nil)))
+
 (defn spectator-view-hidden?
   "Checks if spectators are allowed to see hidden information, such as hands and face-down cards"
   []
@@ -2078,7 +2090,9 @@
        :reagent-render
        (fn []
         (when (and @corp @runner @side true)
-           (let [me-side (if (= :spectator @side) :corp @side)
+          (let [me-side (if (= :spectator @side)
+                          (or (spectate-side) :corp)
+                          @side)
                  op-side (utils/other-side me-side)
                  me (r/cursor game-state [me-side])
                  opponent (r/cursor game-state [op-side])
@@ -2186,7 +2200,8 @@
                      [play-area-view me-user (tr [:game.play-area "Play Area"]) me-play-area]
                      [rfg-view op-current (tr [:game.current "Current"]) false]
                      [rfg-view me-current (tr [:game.current "Current"]) false]])
-                  (when-not (= @side :spectator)
+                  (when (or (not= @side :spectator)
+                            (and (spectator-view-hidden?) (spectate-side)))
                     [button-pane {:side me-side :active-player active-player :run run :encounters encounters
                                   :end-turn end-turn :runner-phase-12 runner-phase-12
                                   :corp-phase-12 corp-phase-12 :corp corp :runner runner


### PR DESCRIPTION
ok I've done a couple of things here.

First:
* only actually compute the spectator diffs if there are spectators (or during a resync/watch/join event)
That should actually cut out a lot of processing I think.

Second:
* If you're spectating as a specific side in an open-info game, flip the gameboard to that side
* If you're  spectating as a specific side in an open-info game, you can see prompts

Hopefully that should feel more natural, and it should help testing groups (or people learning to play) to do so more naturally without needing to communicate in riddles.

Webm is a bit choppy because weyland doesn't update that contexts unless the window is in an active browser context (needed three of them to demo this).

[output.webm](https://github.com/user-attachments/assets/3c0d0752-89f4-4577-8aaf-db70d08287e0)