### PR TITLE
Auto break standard cards

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -32,7 +32,7 @@
                               lose-credits]]
    [game.core.hand-size :refer [hand-size runner-hand-size+]]
    [game.core.hosting :refer [host]]
-   [game.core.ice :refer [all-subs-broken? any-subs-broken? break-sub pump
+   [game.core.ice :refer [all-subs-broken? any-subs-broken? auto-icebreaker break-sub pump
                           reset-all-ice update-all-ice update-all-icebreakers
                           update-breaker-strength]]
    [game.core.installing :refer [runner-can-install? runner-can-pay-and-install? runner-install]]
@@ -789,7 +789,7 @@
              :msg (msg "reduce the install cost of " (:title target) " by 1 [Credits]")}]})
 
 (defcard "e3 Feedback Implants"
-  {:abilities [(break-sub 1 1 "All" {:req (req true)})]})
+  (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:req (req (any-subs-broken? current-ice))})]}))
 
 (defcard "Ekomind"
   (let [update-base-mu (fn [state n] (swap! state assoc-in [:runner :memory :base] n))]
@@ -820,14 +820,15 @@
                                                     true))))}]))}]})
 
 (defcard "Endurance"
-  {:data {:counter {:power 3}}
-   :static-abilities [(mu+ 2)]
-   :events [{:event :successful-run
-             :req (req (first-event? state :runner :successful-run))
-             :msg "place 1 power counter on itself"
-             :async true
-             :effect (effect (add-counter eid card :power 1 nil))}]
-   :abilities [(break-sub [(->c :power 2)] 2 "All")]})
+  (auto-icebreaker
+    {:data {:counter {:power 3}}
+     :static-abilities [(mu+ 2)]
+     :events [{:event :successful-run
+               :req (req (first-event? state :runner :successful-run))
+               :msg "place 1 power counter on itself"
+               :async true
+               :effect (effect (add-counter eid card :power 1 nil))}]
+     :abilities [(break-sub [(->c :power 2)] 2 "All")]}))
 
 (defcard "Feedback Filter"
   {:interactions {:prevent [{:type #{:net :brain}
@@ -1704,9 +1705,10 @@
                 :effect (req (damage-prevent state side :meat 1))}]})
 
 (defcard "Poison Vial"
-  {:data {:counter {:power 3}}
-   :events [(trash-on-empty :power)]
-   :abilities [(break-sub [(->c :power 1)] 2 "All" {:req (req (any-subs-broken? current-ice))})]})
+  (auto-icebreaker
+    {:data {:counter {:power 3}}
+     :events [(trash-on-empty :power)]
+     :abilities [(break-sub [(->c :power 1)] 2 "All" {:req (req (any-subs-broken? current-ice))})]}))
 
 (defcard "Polyhistor"
   (let [abi {:optional

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -338,50 +338,51 @@
                                (get-card state card) nil))}]})
 
 (defcard "Boomerang"
-  {:on-install {:prompt "Choose an installed piece of ice"
-                :msg (msg "target " (card-str state target))
-                :choices {:card #(and (installed? %)
-                                      (ice? %))}
-                :effect (effect (add-icon card target "B" (faction-label card))
-                                (update! (assoc-in (get-card state card) [:special :boomerang-target] target)))}
-   :leave-play (effect (remove-icon card))
-   :abilities [(assoc
-                 (break-sub
-                   [(->c :trash-can)] 2 "All"
-                   {:req (req (if-let [boomerang-target (get-in card [:special :boomerang-target])]
-                                (some #(same-card? boomerang-target (:ice %)) (:encounters @state))
-                                true))}) ; When eg. flipped by Assimilator
-                 :effect
-                 (req (wait-for
-                        (trash state side (make-eid state eid) card
-                               {:cause :ability-cost
-                                :cause-card card
-                                :unpreventable true})
-                        (continue-ability
-                          state :runner
-                          (when-let [[boomerang] async-result]
-                            (break-sub
-                              nil 2 "All"
-                              {:additional-ability
-                               {:effect
-                                (effect
-                                  (register-events
-                                    boomerang
-                                    [{:event :run-ends
-                                      :duration :end-of-run
-                                      :optional
-                                      {:req (req (and (:successful target)
-                                                      (not (zone-locked? state :runner :discard))
-                                                      (some #(= (:title card) (:title %)) (:discard runner))))
-                                       :once :per-run
-                                       :prompt (msg "Shuffle a copy of " (:title card) " back into the Stack?")
-                                       :yes-ability
-                                       {:msg (msg "shuffle a copy of " (:title card) " back into the Stack")
-                                        :effect (effect (move (some #(when (= (:title card) (:title %)) %)
-                                                                    (:discard runner))
-                                                              :deck)
-                                                        (shuffle! :deck))}}}]))}}))
-                          card nil))))]})
+  (auto-icebreaker
+    {:on-install {:prompt "Choose an installed piece of ice"
+                  :msg (msg "target " (card-str state target))
+                  :choices {:card #(and (installed? %)
+                                        (ice? %))}
+                  :effect (effect (add-icon card target "B" (faction-label card))
+                                  (update! (assoc-in (get-card state card) [:special :boomerang-target] target)))}
+     :leave-play (effect (remove-icon card))
+     :abilities [(assoc
+                   (break-sub
+                     [(->c :trash-can)] 2 "All"
+                     {:req (req (if-let [boomerang-target (get-in card [:special :boomerang-target])]
+                                  (some #(same-card? boomerang-target (:ice %)) (:encounters @state))
+                                  true))}) ; When eg. flipped by Assimilator
+                   :effect
+                   (req (wait-for
+                          (trash state side (make-eid state eid) card
+                                 {:cause :ability-cost
+                                  :cause-card card
+                                  :unpreventable true})
+                          (continue-ability
+                            state :runner
+                            (when-let [[boomerang] async-result]
+                              (break-sub
+                                nil 2 "All"
+                                {:additional-ability
+                                 {:effect
+                                  (effect
+                                    (register-events
+                                      boomerang
+                                      [{:event :run-ends
+                                        :duration :end-of-run
+                                        :optional
+                                        {:req (req (and (:successful target)
+                                                        (not (zone-locked? state :runner :discard))
+                                                        (some #(= (:title card) (:title %)) (:discard runner))))
+                                         :once :per-run
+                                         :prompt (msg "Shuffle a copy of " (:title card) " back into the Stack?")
+                                         :yes-ability
+                                         {:msg (msg "shuffle a copy of " (:title card) " back into the Stack")
+                                          :effect (effect (move (some #(when (= (:title card) (:title %)) %)
+                                                                      (:discard runner))
+                                                                :deck)
+                                                          (shuffle! :deck))}}}]))}}))
+                            card nil))))]}))
 
 (defcard "Box-E"
   {:static-abilities [(mu+ 2)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -668,15 +668,12 @@
       (strength-pump (->c :credit 3 {:stealth 1}) 4 :end-of-run)]}))
 
 (defcard "Boi-tatá"
-  (letfn [(was-a-runner-card?
-            [target]
-            (runner? (:card (first target))))]
-    {:static-abilities [{:type :card-ability-cost
-                         :req (req (and (same-card? card (:card context))
-                                        (not (no-event? state side :runner-trash was-a-runner-card?))))
-                         :value (->c :credit -1)}]
-     :abilities [(break-sub 2 2 "Sentry")
-                 (strength-pump 3 3)]}))
+  (let [was-a-runner-card? (fn [target] (runner? (:card (first target))))
+        discount-fn (req (when (not (no-event? state side :runner-trash was-a-runner-card?))
+                           [(->c :credit -1)]))]
+    (auto-icebreaker
+      {:abilities [(break-sub 2 2 "Sentry" {:break-cost-bonus discount-fn})
+                   (strength-pump 3 3 :end-of-encounter {:pump-cost-bonus discount-fn})]})))
 
 (defcard "Botulus"
   {:implementation "[Erratum] Program: Virus - Trojan"
@@ -2745,8 +2742,7 @@
             {:once :per-run
              :once-key (str (:cid card) "-threat-pump")})]
     (auto-icebreaker
-      {:implementation "Auto-breaking always uses small boost."
-       :abilities [(break-sub 1 1 "Barrier")
+      {:abilities [(break-sub 1 1 "Barrier")
                    (strength-pump 2 3 :end-of-encounter {:auto-pump-sort 1})
                    ;; note - this will get prioritized any time it is cheaper
                    (let [base (strength-pump

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -673,7 +673,7 @@
                            [(->c :credit -1)]))]
     (auto-icebreaker
       {:abilities [(break-sub 2 2 "Sentry" {:break-cost-bonus discount-fn})
-                   (strength-pump 3 3 :end-of-encounter {:pump-cost-bonus discount-fn})]})))
+                   (strength-pump 3 3 :end-of-encounter {:cost-bonus discount-fn})]})))
 
 (defcard "Botulus"
   {:implementation "[Erratum] Program: Virus - Trojan"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -676,15 +676,16 @@
                    (strength-pump 3 3 :end-of-encounter {:cost-bonus discount-fn})]})))
 
 (defcard "Botulus"
-  {:implementation "[Erratum] Program: Virus - Trojan"
-   :data {:counter {:virus 1}}
-   :hosting {:req (req (and (ice? target)
-                            (can-host? state target)))}
-   :events [{:event :runner-turn-begins
-             :effect (effect (add-counter card :virus 1))}]
-   :abilities [(break-sub
-                 [(->c :virus 1)] 1 "All"
-                 {:req (req (same-card? current-ice (:host card)))})]})
+  (auto-icebreaker
+    {:implementation "[Erratum] Program: Virus - Trojan"
+     :data {:counter {:virus 1}}
+     :hosting {:req (req (and (ice? target)
+                              (can-host? state target)))}
+     :events [{:event :runner-turn-begins
+               :effect (effect (add-counter card :virus 1))}]
+     :abilities [(break-sub
+                   [(->c :virus 1)] 1 "All"
+                   {:req (req (same-card? current-ice (:host card)))})]}))
 
 (defcard "Brahman"
   (auto-icebreaker {:abilities [(break-sub 1 2 "All")
@@ -1125,9 +1126,10 @@
                                                                    true))})]}))
 
 (defcard "D4v1d"
-  (let [david-req (req (<= 5 (get-strength current-ice)))]
-    {:data {:counter {:power 3}}
-     :abilities [(break-sub [(->c :power 1)] 1 "All" {:req david-req})]}))
+  (auto-icebreaker
+    (let [david-req (req (<= 5 (get-strength current-ice)))]
+      {:data {:counter {:power 3}}
+       :abilities [(break-sub [(->c :power 1)] 1 "All" {:req david-req})]})))
 
 (defcard "Dagger"
   (auto-icebreaker

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -290,9 +290,10 @@
                    (when (:pump ability)
                      ((:req ability) state side eid card nil)))
         [pump-ability pump-cost]
-        (some->> (:abilities (card-def card))
+        (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                  (keep #(when (can-pump %)
                           [% (:cost %)]))
+                 (filter (complement :auto-pump-ignore))
                  (seq)
                  (sort-by #(-> % first :auto-pump-sort))
                  (apply min-key #(let [costs (second %)]
@@ -431,7 +432,7 @@
                      (when (:pump ability)
                        ((:req ability) state side eid card nil)))
           [pump-ability pump-cost]
-          (some->> (:abilities (card-def card))
+          (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                    (keep #(when (can-pump %)
                             [% (:cost %)]))
                    (seq)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -7,7 +7,7 @@
     [game.core.board :refer [installable-servers]]
     [game.core.card :refer [get-agenda-points get-card]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost score-additional-cost-bonus]]
+    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost pump-card-ability-cost score-additional-cost-bonus]]
     [game.core.effects :refer [any-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [ability-as-handler checkpoint register-pending-event pay queue-event resolve-ability trigger-event-simult]]
@@ -292,7 +292,7 @@
         [pump-ability pump-cost]
         (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                  (keep #(when (can-pump %)
-                          [% (:cost %)]))
+                          [% (pump-card-ability-cost state side % card current-ice)]))
                  (filter (complement :auto-pump-ignore))
                  (seq)
                  (sort-by #(-> % first :auto-pump-sort))
@@ -434,7 +434,7 @@
           [pump-ability pump-cost]
           (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                    (keep #(when (can-pump %)
-                            [% (:cost %)]))
+                            [% (pump-card-ability-cost state side % card current-ice)]))
                    (seq)
                    (sort-by #(-> % first :auto-pump-sort))
                    (apply min-key #(let [costs (second %)]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -7,7 +7,7 @@
     [game.core.board :refer [installable-servers]]
     [game.core.card :refer [get-agenda-points get-card]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost pump-card-ability-cost score-additional-cost-bonus]]
+    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost card-ability-cost score-additional-cost-bonus]]
     [game.core.effects :refer [any-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [ability-as-handler checkpoint register-pending-event pay queue-event resolve-ability trigger-event-simult]]
@@ -292,7 +292,7 @@
         [pump-ability pump-cost]
         (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                  (keep #(when (can-pump %)
-                          [% (pump-card-ability-cost state side % card current-ice)]))
+                          [% (card-ability-cost state side % card current-ice)]))
                  (filter (complement :auto-pump-ignore))
                  (seq)
                  (sort-by #(-> % first :auto-pump-sort))
@@ -434,7 +434,7 @@
           [pump-ability pump-cost]
           (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                    (keep #(when (can-pump %)
-                            [% (pump-card-ability-cost state side % card current-ice)]))
+                            [% (card-ability-cost state side % card current-ice)]))
                    (seq)
                    (sort-by #(-> % first :auto-pump-sort))
                    (apply min-key #(let [costs (second %)]

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -149,6 +149,15 @@
                                                           :ability ability
                                                           :targets targets})])))
 
+(defn pump-card-ability-cost
+  ([state side ability card] (pump-card-ability-cost state side ability card nil))
+  ([state side ability card targets]
+   (merge-costs
+     [(:cost ability)
+      (:additional-cost ability)
+      (when-let [pump-fn (:pump-cost-bonus ability)]
+        (pump-fn state side (make-eid state) card targets))])))
+
 (defn jack-out-cost
   [state side]
   (get-effects state side :jack-out-additional-cost))

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -123,6 +123,8 @@
   ([state side ability card] (card-ability-cost state side ability card nil))
   ([state side ability card targets]
    (let [base-cost [(:cost ability)
+                    (when-let [cost-bonus-fn (:cost-bonus ability)]
+                      (cost-bonus-fn state side (make-eid state) card targets))
                     (get-effects state side :card-ability-cost
                                  {:card card
                                   :ability ability
@@ -148,15 +150,6 @@
       (get-effects state side :break-sub-additional-cost {:card card
                                                           :ability ability
                                                           :targets targets})])))
-
-(defn pump-card-ability-cost
-  ([state side ability card] (pump-card-ability-cost state side ability card nil))
-  ([state side ability card targets]
-   (merge-costs
-     [(:cost ability)
-      (:additional-cost ability)
-      (when-let [pump-fn (:pump-cost-bonus ability)]
-        (pump-fn state side (make-eid state) card targets))])))
 
 (defn jack-out-cost
   [state side]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -243,11 +243,12 @@
                                              :paid/targets [card]}))))
 
 ;; Trash
-(defmethod value :trash-can [cost] 1)
+(defmethod value :trash-can [cost] (:cost/amount cost))
 (defmethod label :trash-can [cost] "[trash]")
 (defmethod payable? :trash-can
   [cost state side eid card]
-  (installed? (get-card state card)))
+  (and (installed? (get-card state card))
+       (= 1 (value cost))))
 (defmethod handler :trash-can
   [cost state side eid card]
   (wait-for (trash state side card {:cause :ability-cost

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -3,7 +3,7 @@
     [game.core.board :refer [all-active-installed all-installed card->server]]
     [game.core.card :refer [get-card ice? installed? rezzed? has-subtype?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost pump-card-ability-cost]]
+    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid make-result]]
     [game.core.effects :refer [any-effects get-effects register-lingering-effect sum-effects]]
     [game.core.engine :refer [ability-as-handler pay resolve-ability trigger-event trigger-event-simult queue-event checkpoint]]
@@ -689,7 +689,7 @@
       :cost [cost]
       :pump strength
       :pump-bonus (:pump-bonus args)
-      :pump-cost-bonus (:pump-cost-bonus args)
+      :cost-bonus (:cost-bonus args)
       :auto-pump-sort (:auto-break-sort args)
       :auto-pump-ignore (:auto-pump-ignore args)
       :msg (msg "increase its strength from " (get-strength card)
@@ -724,7 +724,7 @@
               [pump-ability pump-cost]
               (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                  (keep #(when (can-pump %)
-                          [% (pump-card-ability-cost state side % card current-ice)]))
+                          [% (card-ability-cost state side % card current-ice)]))
                  (seq)
                  (sort-by #(-> % first :auto-pump-sort))
                  (apply min-key #(let [costs (second %)]

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -773,7 +773,7 @@
                                        pump-ability))
                             (vec (concat abs
                                          (when (and break-ability
-                                                    (or pump-ability (zero? strength-diff))
+                                                    (or (not (get-strength card)) pump-ability (zero? strength-diff))
                                                     no-unbreakable-subs
                                                     (pos? unbroken-subs)
                                                     (can-pay? state side eid card total-cost))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -3,7 +3,7 @@
     [game.core.board :refer [all-active-installed all-installed card->server]]
     [game.core.card :refer [get-card ice? installed? rezzed? has-subtype?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost]]
+    [game.core.cost-fns :refer [break-sub-ability-cost pump-card-ability-cost]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid make-result]]
     [game.core.effects :refer [any-effects get-effects register-lingering-effect sum-effects]]
     [game.core.engine :refer [ability-as-handler pay resolve-ability trigger-event trigger-event-simult queue-event checkpoint]]
@@ -689,6 +689,7 @@
       :cost [cost]
       :pump strength
       :pump-bonus (:pump-bonus args)
+      :pump-cost-bonus (:pump-cost-bonus args)
       :auto-pump-sort (:auto-break-sort args)
       :auto-pump-ignore (:auto-pump-ignore args)
       :msg (msg "increase its strength from " (get-strength card)
@@ -723,7 +724,7 @@
               [pump-ability pump-cost]
               (some->> (filter (complement :auto-pump-ignore) (:abilities (card-def card)))
                  (keep #(when (can-pump %)
-                          [% (:cost %)]))
+                          [% (pump-card-ability-cost state side % card current-ice)]))
                  (seq)
                  (sort-by #(-> % first :auto-pump-sort))
                  (apply min-key #(let [costs (second %)]

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -3,7 +3,7 @@
     [game.core.board :refer [all-active all-active-installed]]
     [game.core.card :refer [get-card map->Card program? runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost pump-card-ability-cost]]
+    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
     [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-default-events register-events resolve-ability unregister-events]]
@@ -146,8 +146,6 @@
                        (cond
                          (:break-cost ab)
                          (assoc ab :cost (break-sub-ability-cost state side ab card))
-                         (:pump ab)
-                         (assoc ab :cost (pump-card-ability-cost state side ab card))
                          :else
                          ab)]]
              (add-cost-label-to-ability ab (card-ability-cost state side ab-cost card)))))

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -3,7 +3,7 @@
     [game.core.board :refer [all-active all-active-installed]]
     [game.core.card :refer [get-card map->Card program? runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
+    [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost pump-card-ability-cost]]
     [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-default-events register-events resolve-ability unregister-events]]
@@ -142,9 +142,14 @@
 (defn update-ability-cost-str
   [state side card ability-kw]
   (into [] (for [ab (get card ability-kw)
-                 :let [ab-cost (if (:break-cost ab)
-                                 (assoc ab :cost (break-sub-ability-cost state side ab card))
-                                 ab)]]
+                 :let [ab-cost
+                       (cond
+                         (:break-cost ab)
+                         (assoc ab :cost (break-sub-ability-cost state side ab card))
+                         (:pump ab)
+                         (assoc ab :cost (pump-card-ability-cost state side ab card))
+                         :else
+                         ab)]]
              (add-cost-label-to-ability ab (card-ability-cost state side ab-cost card)))))
 
 (defn update-abilities-cost-str

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -133,7 +133,7 @@
 (defn- basic-program-test
   "tests a program which has simple boost and break functionality"
   [{:keys [name boost break threat counters-modify-strength run-event-bonus subtypes tags
-           click-prompt-on-install click-prompt-on-encounter]}]
+           click-prompt-on-install click-prompt-on-encounter runner-trash-ev]}]
   ;; set threat level like {:threat 3}
   ;; set str modify counters like {:counters-modify-strength {:type :power
   ;;                                                          :granularity x (default 1)
@@ -151,7 +151,7 @@
         (new-game {:corp {:credits 100
                           :hand ["Mother Goddess" type]}
                    :runner {:credits 100
-                            :hand [name "Dirty Laundry"]}})
+                            :hand [name "Dirty Laundry" "Spy Camera"]}})
         ;;set the threat level when appropriate
         (when threat
           (do (game.core.change-vals/change
@@ -173,6 +173,12 @@
         (play-from-hand state :runner name)
         (when click-prompt-on-install
           (click-prompt state :runner click-prompt-on-install))
+        ;; boi-tata may require a card to be trashed
+        (when runner-trash-ev
+          (play-from-hand state :runner "Spy Camera")
+          (core/gain state :runner :click 1)
+          (card-ability state :runner (get-hardware state 0) 1)
+          (click-prompt state :runner "OK"))
         (let [card (get-program state 0)
               ice (get-ice state :hq 0)
               base-breaker-str (get-strength (refresh card))]
@@ -1255,6 +1261,17 @@
                                  (second (:abilities (refresh boi)))
                                  (refresh boi)))
           "Cost reduction from trash"))))
+
+(deftest boi-tata-automated-test
+  (basic-program-test {:name "Boi-tatá"
+                       :break {:ab 0 :amount 2 :cost 2 :type "Sentry"}
+                       :boost {:ab 1 :amount 3 :cost 3}}))
+
+(deftest boi-tata-automated-test
+  (basic-program-test {:name "Boi-tatá"
+                       :runner-trash-ev true
+                       :break {:ab 0 :amount 2 :cost 1 :type "Sentry"}
+                       :boost {:ab 1 :amount 3 :cost 2}}))
 
 (deftest botulus
   ;; Botulus

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1267,7 +1267,7 @@
                        :break {:ab 0 :amount 2 :cost 2 :type "Sentry"}
                        :boost {:ab 1 :amount 3 :cost 3}}))
 
-(deftest boi-tata-automated-test
+(deftest boi-tata-automated-test-with-trash-ev
   (basic-program-test {:name "Boi-tatá"
                        :runner-trash-ev true
                        :break {:ab 0 :amount 2 :cost 1 :type "Sentry"}


### PR DESCRIPTION
I went through all the standard-legal icebreakers and added `auto-icebreaker` functions for the ones that were missing.

* atman *just works*
* Pressure Spike required me adding a key so the `2:+9` is never considered for auto-breaking
* I rewrote boi-tata so that it actually works again. I updated `action.clj/ice.clj` to actually compute the pump costs, rather than just scry the key in the ability, in order to make this work. We can now apply the `cost-bonus` key to any ability to get scalable cost an abilities (maybe that will be useful later, idk).

I added automated tests for boi-tata too, so we don't break it later.

Additionally:
* I update auto-icebreaker to allow for cards that don't have strength (like botulus, or endurance)
* updated the following cards to use auto-icebreaker
  * D4v1d
  * Botulus
  * Poison Vial
  * Endurance
  * e3 Feedback Implants (I added the cond from posion vial too)

Didn't update quetzal because we don't respect the once-per-turn restriction in auto-icebreaker, and didn't add boomerang because apparently we can pay two trash costs and I don't have time to fix that.

Closes #7360