### PR TITLE
Rez all to end screen

### DIFF
--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -726,6 +726,8 @@
           :end-turn "End Turn"
           :mandatory-draw "Mandatory Draw"
           :take-clicks "Take Clicks"
+          :rez-all "Rez All"
+          :reveal-my-hand "Reveal My Hand"
           :hq "HQ"
           :grip "Grip"
           :rfg "Removed from the game"

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -13,7 +13,7 @@
    [jinteki.cards :refer [all-cards]]
    [jinteki.utils :refer [add-cost-to-label is-tagged? select-non-nil-keys
                           str->int] :as utils]
-   [nr.appstate :refer [app-state]]
+   [nr.appstate :refer [app-state current-gameid]]
    [nr.cardbrowser :refer [card-as-text]]
    [nr.end-of-game-stats :refer [build-game-stats]]
    [nr.gameboard.actions :refer [send-command]]
@@ -28,6 +28,7 @@
    [nr.translations :refer [tr tr-side tr-game-prompt]]
    [nr.utils :refer [banned-span checkbox-button cond-button get-image-path
                      image-or-face render-icons render-message]]
+   [nr.ws :as ws]
    [reagent.core :as r]))
 
 (declare stacked-card-view show-distinct-cards)
@@ -1291,6 +1292,18 @@
            [:div (tr [:game.time-taken] time)]
            [:br]
            [build-game-stats (get-in @game-state [:stats :corp]) (get-in @game-state [:stats :runner])]
+           (when (not= :spectator (:side @game-state))
+             [:br]
+             [:div {:class "end-of-game-buttons"}
+              (when (= :corp (:side @game-state))
+                [:button#rez-all
+                 {:on-click #(ws/ws-send! [:game/say {:gameid (current-gameid app-state)
+                                                      :msg "/rez-all"}])}
+                 (tr [:game.rez-all "Rez All"])])
+              [:button#reveal-hand
+               {:on-click #(ws/ws-send! [:game/say {:gameid (current-gameid app-state)
+                                                    :msg "/show-hand"}])}
+               (tr [:game.reveal-my-hand "Reveal My Hand"])]])
            [:button.win-right {:on-click #(reset! win-shown true) :type "button"} "✘"]])))))
 
 (defn build-start-box

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -420,6 +420,10 @@
         position: absolute
         width: 100%
 
+    .end-of-game-buttons
+        float: right
+        margin-top: 1em
+
     .card-wrapper
         display: inline-block
         margin-right: 4px


### PR DESCRIPTION
Rez-all now allows for flipping gendies faceup

Added buttons to the end screen for rezzing all and revealing hand - these just call the ingame commands.

![runner-perspective](https://github.com/user-attachments/assets/c6864608-5dc7-4e89-af47-5a956d9b1c3c)

![corp-view](https://github.com/user-attachments/assets/56b55d83-8c05-405d-b8df-0be7df7a1916)

Closes #5986