### PR TITLE
use latest java-time

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,7 @@
                  [org.clj-commons/claypoole "1.2.2"]
                  [org.slf4j/slf4j-nop "1.7.32"]
                  [integrant "0.8.0"]
-                 [cljc.java-time "0.1.18"]
+                 [com.widdindustries/cljc.java-time "0.1.21"]
                  [time-literals "0.1.5"]
                  [metosin/reitit "0.5.18"]]
 


### PR DESCRIPTION
I got sick of seeing the warning about abs being shadowed in java-time, so I checked the package
* It got renamed in 2022 (see: https://clojars.org/cljc.java-time)
* Now we should be using this: https://clojars.org/com.widdindustries/cljc.java-time

I was a bit suspicious, but I double checked and it's
* the same person
* the same github account

It seems like an odd choice to muddle with clojars like that, but I've done worse.