### PR TITLE
set jvm to use more aggressive jit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,6 +87,7 @@
                    :resource-paths ["target"]
                    :clean-targets ^{:protect false} ["target"]
                    :jvm-opts ["-Djdk.attach.allowAttachSelf"
+                              "-XX:TieredStopAtLevel=4"
                               "-XX:+UnlockDiagnosticVMOptions"
                               "-XX:-OmitStackTraceInFastThrow"
                               "-XX:+DebugNonSafepoints"]}


### PR DESCRIPTION
Not sure if this will make a difference, but it seems like our performance is typically pretty bad for ~1-2 days after a reset, and then it's butter smooth after that - so it might be worth trying this.