### PR TITLE
Display encounter info

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -162,7 +162,8 @@
 (defn profile-keys []
   [:background :pronouns :language :default-format :show-alt-art :blocked-users
    :alt-arts :card-resolution :deckstats :gamestats :card-zoom :pin-zoom
-   :card-back :stacked-cards :ghost-trojans :sides-overlap :archives-sorted :heap-sorted
+   :card-back :stacked-cards :ghost-trojans :display-encounter-info
+   :sides-overlap :archives-sorted :heap-sorted
    :labeled-cards :labeled-unrezzed-cards :bespoke-sounds])
 
 (defn update-profile-handler

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -49,6 +49,7 @@
   (swap! app-state assoc-in [:options :player-stats-icons] (:player-stats-icons @s))
   (swap! app-state assoc-in [:options :stacked-cards] (:stacked-cards @s))
   (swap! app-state assoc-in [:options :ghost-trojans] (:ghost-trojans @s))
+  (swap! app-state assoc-in [:options :display-encounter-info] (:display-encounter-info @s))
   (swap! app-state assoc-in [:options :sides-overlap] (:sides-overlap @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
   (swap! app-state assoc-in [:options :log-width] (:log-width @s))
@@ -69,6 +70,7 @@
   (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
   (.setItem js/localStorage "ghost-trojans" (:ghost-trojans @s))
+  (.setItem js/localStorage "display-encounter-info" (:display-encounter-info @s))
   (.setItem js/localStorage "sides-overlap" (:sides-overlap @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (.setItem js/localStorage "card-back" (:card-back @s))
@@ -372,7 +374,13 @@
                              :value true
                              :checked (:ghost-trojans @s)
                              :on-change #(swap! s assoc-in [:ghost-trojans] (.. % -target -checked))}]
-             (tr [:settings.ghost-trojans "Display ghosts for hosted programs"])]]
+             (tr [:settings.display-encounter-info "Display ghosts for hosted programs"])]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:display-encounter-info @s)
+                             :on-change #(swap! s assoc-in [:display-encounter-info] (.. % -target -checked))}]
+             (tr [:settings.display-encounter-info "Always display encounter info dialog"])]]
            [:div
             [:label [:input {:type "checkbox"
                              :value true
@@ -575,7 +583,7 @@
 
      [api-keys s]
 
-     [:section 
+     [:section
       [:span.flash-message (:flash-message @s)]]]])}))
 
 (defn account []
@@ -600,6 +608,7 @@
                        :card-resolution (get-in @app-state [:options :card-resolution])
                        :stacked-cards (get-in @app-state [:options :stacked-cards])
                        :ghost-trojans (get-in @app-state [:options :ghost-trojans])
+                       :display-encounter-info (get-in @app-state [:options :display-encounter-info])
                        :sides-overlap (get-in @app-state [:options :sides-overlap])
                        :player-stats-icons (get-in @app-state [:options :player-stats-icons])
                        :runner-board-order (get-in @app-state [:options :runner-board-order])

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -580,17 +580,27 @@
      (doall
        (map-indexed
          (fn [i sub]
-           [:div {:key i}
-            [:span (cond (:broken sub)
-                         {:class :disabled
-                          :style {:font-style :italic}}
-                         (false? (:resolve sub))
-                         {:class :dont-resolve
-                          :style {:text-decoration :line-through}})
-             (render-icons (str " [Subroutine] " (:label sub)))]
-            [:span.float-right
-             (cond (:broken sub) banned-span
-                   (:fired sub) "✅")]])
+           (let [fire-sub #(when (= :corp (:side @game-state))
+                             (send-command "subroutine" {:card ice
+                                                         :subroutine i})
+                             (close-card-menu))]
+             [:div {:key i
+                    :tab-index 0
+                    :on-click fire-sub
+                    :on-key-down #(when (= "Enter" (.-key %))
+                                    (fire-sub))
+                    :on-key-up #(when (= " " (.-key %))
+                                  (fire-sub))}
+              [:span (cond (:broken sub)
+                           {:class :disabled
+                            :style {:font-style :italic}}
+                           (false? (:resolve sub))
+                           {:class :dont-resolve
+                            :style {:text-decoration :line-through}})
+               (render-icons (str " [Subroutine] " (:label sub)))]
+              [:span.float-right
+               (cond (:broken sub) banned-span
+                     (:fired sub) "✅")]]))
          subroutines))]))
 
 (defn card-abilities [card abilities subroutines]
@@ -1430,7 +1440,7 @@
                :on-mouse-out #(card-highlight-mouse-out % ice button-channel)}
          (tr [:game.encounter-ice "Encounter ice"]) ": " (render-message (get-title ice))]
         [:hr]
-        (when (:button @app-state)
+        (when (or (:button @app-state) (get-in @app-state [:options :display-encounter-info]))
           [encounter-info-div ice])])
      (when @run
        [:h4 (tr [:game.current-phase "Current phase"]) ":" [:br] (get phase->title (:phase @run) (tr [:game.unknown-phase "Unknown phase"]))])
@@ -1500,7 +1510,7 @@
                :on-mouse-out #(card-highlight-mouse-out % ice button-channel)}
          (tr [:game.encounter-ice "Encounter ice"]) ": " (render-message (get-title ice))]
         [:hr]
-        (when (:button @app-state)
+        (when (or (:button @app-state)  (get-in @app-state [:options :display-encounter-info]))
           [encounter-info-div ice])])
      (when @run
        [:h4 (tr [:game.current-phase "Current phase"]) ":" [:br] (get phase->title phase)])

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -32,7 +32,13 @@
                         :value true
                         :checked (get-in @app-state [:options :ghost-trojans])
                         :on-change #(swap! app-state assoc-in [:options :ghost-trojans] (.. % -target -checked))}]
-        (tr [:ingame-settings.ghost-trojans "Display hosted trojans in rig"])]]]
+        (tr [:ingame-settings.ghost-trojans "Display hosted trojans in rig"])]]
+      [:div
+       [:label [:input {:type "checkbox"
+                        :value true
+                        :checked (get-in @app-state [:options :display-encounter-info])
+                        :on-change #(swap! app-state assoc-in [:options :display-encounter-info] (.. % -target -checked))}]
+        (tr [:ingame-settings.display-encounter-info "Always display encounter info"])]]]
 
      [:section
       [:h4 (tr [:ingame-settings.card-sorting "Sorting"])]


### PR DESCRIPTION
Option to always display the encounter info div while an ice is being encountered.

Corp can also fire subroutines from those buttons like they can by clicking on ice.

Closes [#6245](https://github.com/mtgred/netrunner/issues/6245)