### PR TITLE
get user block options from the app state instead of the lobby

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -209,7 +209,7 @@
        (select-non-nil-keys lobby-keys))))
 
 (defn get-blocked-list [user]
-  (->> user :options :blocked-users (map str/lower-case)))
+  (->> (app-state/get-user (:username user)) :options :blocked-users (map str/lower-case)))
 
 (defn filter-lobby-list
   [lobbies user]


### PR DESCRIPTION
Turns out preprocessing the lobby list stripped the user options out before they could be checked for blocking.

We probably should have been checking options in the app-state (so they're up to date) anyway though.

Closes #7827