### PR TITLE
Issue 7493: Add credit cost of cards alongside their names and influence in deck builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pom.xml
 .nrepl-history
 .rebel_readline_history
 .idea
+*.iml
 .eastwood
 .cache
 
@@ -68,4 +69,3 @@ data/cards-pt.edn
 data/cards-ru.edn
 data/cards-zh-hans.edn
 data/cards-zh-hant.edn
-/netrunner.iml

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ pom.xml
 .nrepl-history
 .rebel_readline_history
 .idea
-*.iml
 .eastwood
 .cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ data/cards-pt.edn
 data/cards-ru.edn
 data/cards-zh-hans.edn
 data/cards-zh-hant.edn
+/netrunner.iml

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -391,10 +391,8 @@
   [card]
   (when (:cost card)
     [:div.card-cost
-     (render-message (str (:cost card) "[credit]"))
-     ]
-    )
-  )
+     (render-message (str (:cost card) "[credit]"))]
+    ))
 
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -15,7 +15,7 @@
     [nr.utils :refer [alliance-dots banned-span cond-button
                       deck-points-card-span dots-html format->slug format-date-time
                       influence-dot influence-dots mdy-formatter non-game-toast num->percent
-                      restricted-span rotated-span set-scroll-top slug->format store-scroll-top]]
+                      restricted-span rotated-span set-scroll-top slug->format store-scroll-top render-message]]
     [nr.ws :as ws]
     [reagent-modals.modals :as reagent-modals]
     [reagent.core :as r]
@@ -387,6 +387,15 @@
             (set-deck-on-state s deck)
             (put! select-channel (:deck @s)))))))
 
+(defn card-cost-html
+  [card]
+  (when (:cost card)
+    [:div.card-cost
+     (render-message (str (:cost card) "[credit]"))
+     ]
+    )
+  )
+
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"
   [format card qty in-faction allied?]
@@ -667,7 +676,8 @@
                                   (not valid) " invalid"))
                 :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                 :on-mouse-leave #(put! zoom-channel false)} title]
-        [card-influence-html format card modqty infaction allied]])
+        (card-cost-html card)
+        (card-influence-html format card modqty infaction allied)])
      card)])
 
 (defn line-qty-span
@@ -697,6 +707,7 @@
                                         (not valid) " invalid"))
                       :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                       :on-mouse-leave #(put! zoom-channel false)} name]
+              (card-cost-html card)
               (card-influence-html format card modqty infaction allied)])
            card)])
 

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -388,9 +388,18 @@
             (put! select-channel (:deck @s)))))))
 
 (defn card-cost-html
-  [card]
-  (when (:cost card)
-    [:div.card-cost (render-message (str (:cost card) "[credit]"))]))
+  [s card]
+  (let  [show-credit-cost (:show-credit-cost @s)
+         show-mu-cost (:show-mu-cost @s)
+         is-edit (:edit @s)]
+    (when (or show-credit-cost show-mu-cost)
+      [:div.card-cost-wrapper
+       [:span.card-cost {:class (when is-edit "edit")}
+        (when show-mu-cost
+          (when-let [mu (:memoryunits card)] [:div.cost-item (render-message (str  mu "[mu] "))]))
+        (when show-credit-cost
+          (when-let [cost (:cost card)] [:div.cost-item (render-message (str cost "[credit]"))]))]
+       ])))
 
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"
@@ -672,7 +681,6 @@
                                   (not valid) " invalid"))
                 :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                 :on-mouse-leave #(put! zoom-channel false)} title]
-        (card-cost-html card)
         (card-influence-html format card modqty infaction allied)])
      card)])
 
@@ -703,7 +711,6 @@
                                         (not valid) " invalid"))
                       :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                       :on-mouse-leave #(put! zoom-channel false)} name]
-              (card-cost-html card)
               (card-influence-html format card modqty infaction allied)])
            card)])
 
@@ -807,7 +814,8 @@
                                                 :card (:card line)})
                                 :type "button"} "+"]
                 [line-name-span deck line]]
-               [line-span deck line])]))]))])
+               [line-span deck line]
+               )(card-cost-html s (:card line))]))]))])
 
 (defn decklist-notes
   [deck]
@@ -857,6 +865,21 @@
    ;;    (tr [:deck-builder.create-game "Create Game"])])
    ])
 
+(defn view-toggles
+  [s deck]
+  [:div.decklist-view-options
+   [:h4 "View Options"]
+   (when (= (:side (:identity deck)) "Runner")
+     [:div
+      [:input {:type "checkbox" :checked (:show-mu-cost @s)
+               :on-change #(swap! s assoc :show-mu-cost (.. % -target -checked))}]
+      [:span "Show Memory Cost"]])
+   [:div
+    [:input {:type "checkbox" :checked (:show-credit-cost @s)
+             :on-change #(swap! s assoc :show-credit-cost (.. % -target -checked))}]
+    [:span "Show Credit Cost"]]
+   ])
+
 (defn selected-panel
   [s]
   [:div.decklist
@@ -870,6 +893,7 @@
           :else [view-buttons s deck])
         [:h3 (:name deck)]
         [decklist-header deck cards]
+        (view-toggles s deck)
         [decklist-contents s deck cards]
         (when-not (:edit @s)
           [decklist-notes deck])]))])
@@ -1057,7 +1081,9 @@
                    :deck nil
                    :side-filter all-sides-filter
                    :faction-filter all-factions-filter
-                   :format-filter all-formats-filter})
+                   :format-filter all-formats-filter
+                   :show-credit-cost false
+                   :show-mu-cost false})
         decks (r/cursor app-state [:decks])
         user (r/cursor app-state [:user])
         decks-loaded (r/cursor app-state [:decks-loaded])

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -398,8 +398,7 @@
         (when show-mu-cost
           (when-let [mu (:memoryunits card)] [:div.cost-item (render-message (str  mu "[mu] "))]))
         (when show-credit-cost
-          (when-let [cost (:cost card)] [:div.cost-item (render-message (str cost "[credit]"))]))]
-       ])))
+          (when-let [cost (:cost card)] [:div.cost-item (render-message (str cost "[credit]"))]))]])))
 
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"
@@ -681,7 +680,7 @@
                                   (not valid) " invalid"))
                 :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                 :on-mouse-leave #(put! zoom-channel false)} title]
-        (card-influence-html format card modqty infaction allied)])
+        [card-influence-html format card modqty infaction allied]])
      card)])
 
 (defn line-qty-span
@@ -711,7 +710,7 @@
                                         (not valid) " invalid"))
                       :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                       :on-mouse-leave #(put! zoom-channel false)} name]
-              (card-influence-html format card modqty infaction allied)])
+              [card-influence-html format card modqty infaction allied]])
            card)])
 
 (defn- build-deck-points-tooltip [deck]
@@ -814,8 +813,8 @@
                                                 :card (:card line)})
                                 :type "button"} "+"]
                 [line-name-span deck line]]
-               [line-span deck line]
-               )(card-cost-html s (:card line))]))]))])
+                [line-span deck line])
+             [card-cost-html s (:card line)]]))]))])
 
 (defn decklist-notes
   [deck]
@@ -893,7 +892,7 @@
           :else [view-buttons s deck])
         [:h3 (:name deck)]
         [decklist-header deck cards]
-        (view-toggles s deck)
+        [view-toggles s deck]
         [decklist-contents s deck cards]
         (when-not (:edit @s)
           [decklist-notes deck])]))])

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -876,8 +876,7 @@
    [:div
     [:input {:type "checkbox" :checked (:show-credit-cost @s)
              :on-change #(swap! s assoc :show-credit-cost (.. % -target -checked))}]
-    [:span "Show Credit Cost"]]
-   ])
+    [:span "Show Credit Cost"]]])
 
 (defn selected-panel
   [s]

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -390,9 +390,7 @@
 (defn card-cost-html
   [card]
   (when (:cost card)
-    [:div.card-cost
-     (render-message (str (:cost card) "[credit]"))]
-    ))
+    [:div.card-cost (render-message (str (:cost card) "[credit]"))]))
 
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -134,7 +134,6 @@
                     .credit
                         margin-left: .1rem
 
-
                 button.small
                     margin: 3px 6px 3px 0
 

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -121,18 +121,42 @@
                 margin-top: 10px
                 columns(2, 5px)
 
+            .line:hover
+                background: rgba(19 26 35 .46)
+
             .line
                 position: relative
                 overflow: visible
                 line-height: 20px
                 white-space:pre
+                columns(2, 1rem)
 
-                .card-cost
-                    display: inline-flex
-                    margin-left: .2rem
+                .card-cost-wrapper
+                    display: flex;
+                    position:relative;
+                    overflow: visible;
+                    width: auto;
+                    justify-content flex-end;
 
-                    .credit
-                        margin-left: .1rem
+                    .card-cost
+                        line-height: .75rem;
+                        margin-top: .25rem;
+                        margin-right: 2rem;
+                        display: inline-flex;
+                        position: absolute;
+                        justify-content: left;
+
+                    .edit
+                        line-height: .75rem;
+                        margin-top: .35rem;
+                        margin-right: .5rem;
+                    .cost-item
+                        display: inline-flex
+                        margin-inline: .1rem;
+
+                        .credit
+                            margin-left: .1rem
+
 
                 button.small
                     margin: 3px 6px 3px 0

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -99,6 +99,9 @@
             overflow: auto
             -webkit-overflow-scrolling: touch
 
+            .decklist-view-options
+                margin-top: 1rem;
+
             .button-bar
                 padding-bottom: 8px
 
@@ -151,7 +154,7 @@
                         margin-top: .35rem;
                         margin-right: .5rem;
                     .cost-item
-                        display: inline-flex
+                        display: inline-flex;
                         margin-inline: .1rem;
 
                         .credit

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -127,6 +127,14 @@
                 line-height: 20px
                 white-space:pre
 
+                .card-cost
+                    display: inline-flex
+                    margin-left: .1rem
+
+                    .credit
+                        margin-left: .1rem
+
+
                 button.small
                     margin: 3px 6px 3px 0
 

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -129,7 +129,7 @@
 
                 .card-cost
                     display: inline-flex
-                    margin-left: .1rem
+                    margin-left: .2rem
 
                     .credit
                         margin-left: .1rem


### PR DESCRIPTION
Hello,

This PR contains an initial implementation of #7493 

Closes #7493

![Screenshot 2024-10-18 at 11 08 53 PM](https://github.com/user-attachments/assets/bb920e3a-b439-40e3-9119-4bb6037c4479)


This PR adds the credit/mu cost of applicable cards to the Deck Builder `decklist` panel

Description of change:
- adds toggle options to session app-state in `decklist` module
- Conditionally adds wrapped and formatted credit/mu cost content to `line` in `decklist`
- dynamically adjusts css using edit state variable
- add hover background for further readability improvements

Methodology:
- Using the existing display pattern for cost icons will allow for users to quickly understand what this additional information is
- toggle selections will default to false on page load but persist in-session
- uses absolute position to avoid vertical adjustment to line-height and other properties
- per discussion, cost content is right-aligned

Considerations and potential next steps:
- Hover highligting opens up the potential to replace `fake-link` functionality to a larger area for hovering
- We could pin the card preview/expand to the top right of the screen as it is in the gameboard
- alongside this, the text items that are displayed in `Cards` could be a cool toggle for a fully integrated deckbuilding experience in one tab
