### PR TITLE
Issue 7825: Trash Jarogniew Mercs using corp basic action

### DIFF
--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -104,12 +104,8 @@
                 :prompt "Choose a resource to trash"
                 :msg (msg "trash " (:title target))
                 ;; I hate that we need to modify the basic action card like this, but I don't think there's any way around it -nbkelly, '24
-                :choices {:req (req (and (if (and (->> (all-active-installed state :runner)
-                                                       (filter (fn [c] (untrashable-while-resources? c)))
-                                                       (seq))
-                                                  (< 1 (->> (all-active-installed state :runner)
-                                                            (filter resource?)
-                                                            count)))
+                :choices {:req (req (and (if (and (untrashable-while-resources? target)
+                                                  (< (count (filter resource? (all-active-installed state :runner))) 2))
                                            true
                                            (not (untrashable-while-resources? target)))
                                          (resource? target)


### PR DESCRIPTION
This PR seeks to close #7825 

<img width="272" alt="Screenshot 2024-10-21 at 12 42 27 PM" src="https://github.com/user-attachments/assets/44520675-fd0f-482a-80ea-791074732113">


Description of changes:
- adjust implementation of :untrashable-while-resources flag in corp basic action

Methodology described in [this comment](https://github.com/mtgred/netrunner/issues/7825#issuecomment-2427567588)

Fixing this also resolves an unreported but related issue where the current logic creates a situation where a click is spent attempting to trash mercs instead of bouncing off of the `choices` logic

**Testing - here is the log from the test game with the new logic**
```
test1 has created the game.
test2 joined the game.
! MirrorMorph: Endless Iteration - Does not work with terminal Operations
test2 keeps their hand.
test1 keeps their hand.
test2 started their turn 1 with 5  and 5 cards in HQ.
test2 makes their mandatory start of turn draw.
test2 spends  to install a card in Server 1 (new remote).
test2 spends  to use Corp Basic Action Card to gain 1 .
test2 spends  to use Corp Basic Action Card to gain 1 .
test2 is ending their turn 1 with 7  and 5 cards in HQ.
test1 started their turn 1 with 5  and 2 cards in their Grip.
test1 spends  and pays 0  to install Jarogniew Mercs.
test1 spends  and pays 4  to install Earthrise Hotel.
test1 spends  to use Runner Basic Action Card to gain 1 .
test1 spends  to use Runner Basic Action Card to gain 1 .
test1 is ending their turn 1 with 3  and 0 cards in their Grip.
test2 started their turn 2 with 7  and 5 cards in HQ.
test2 makes their mandatory start of turn draw.
// here i attempt to trash mercs first but it does nothing, so i select earthrise first and then trash mercs
test2 spends  and pays 2  to use Corp Basic Action Card to trash Earthrise Hotel.
test2 spends  and pays 2  to use Corp Basic Action Card to trash Jarogniew Mercs.
```