### PR TITLE
Worlds 2024 preconstructed lists

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -425,6 +425,7 @@
    ;; :angel-arena-info
    :corp
    :corp-phase-12
+   :decklists
    :encounters
    :end-turn
    :gameid

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -126,8 +126,8 @@
 
 (defn- set-deck-lists
   [state]
-  (let [runner-cards (into (sorted-map) (frequencies (map :title (get-in @state [:runner :deck]))))
-        corp-cards (into (sorted-map) (frequencies (map :title (get-in @state [:corp :deck]))))]
+  (let [runner-cards (sort-by key (frequencies (map :title (get-in @state [:runner :deck]))))
+        corp-cards (sort-by key (frequencies (map :title (get-in @state [:corp :deck]))))]
     (swap! state assoc :decklists {:corp corp-cards :runner runner-cards})))
 
 (defn init-game

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -124,6 +124,12 @@
                      :type "Basic Action"
                      :title "Runner Basic Action Card"})))
 
+(defn- set-deck-lists
+  [state]
+  (let [runner-cards (into (sorted-map) (frequencies (map :title (get-in @state [:runner :deck]))))
+        corp-cards (into (sorted-map) (frequencies (map :title (get-in @state [:corp :deck]))))]
+    (swap! state assoc :decklists {:corp corp-cards :runner runner-cards})))
+
 (defn init-game
   "Initializes a new game with the given players vector."
   [game]
@@ -133,6 +139,8 @@
     (when-let [messages (seq (:messages game))]
       (swap! state assoc :log (into [] messages))
       (system-say state nil "[hr]"))
+    (when (:open-decklists game)
+      (set-deck-lists state))
     (card-init state :corp corp-identity)
     (implementation-msg state corp-identity)
     (card-init state :runner runner-identity)

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -85,7 +85,7 @@
     user :user
     {:keys [gameid now
             allow-spectator api-access format mute-spectators password room save-replay
-            precon gateway-type side singleton spectatorhands timer title]
+            precon gateway-type side singleton spectatorhands timer title open-decklists]
      :or {gameid (random-uuid)
           now (inst/now)}} :options}]
   (let [player {:user user
@@ -102,6 +102,7 @@
      :pool (join-pool!)
      ;; options
      :precon (validate-precon format precon gateway-type)
+     :open-decklists (or open-decklists (when (validate-precon format precon gateway-type) true))
      :allow-spectator allow-spectator
      :api-access api-access
      :format format
@@ -181,6 +182,7 @@
    :messages
    :mute-spectators
    :original-players
+   :open-decklists
    :password
    :players
    :room

--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -397,6 +397,8 @@
                             :intermediate-info "This lobby is using the System Gateway intermediate decks for the Corporation and Runner. These decks have slightly more range than the beginner decks. Games are played to 7 agenda points."
                             :intermediate-ul "System Gateway - Intermediate Teaching Decks"
                             :constructed "Constructed"}
+           :open-decklists "Open Decklists"
+           :open-decklists-b "(open decklists)"
            :singleton "Singleton"
            :singleton-b "(singleton)"
            :singleton-details "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."
@@ -747,6 +749,7 @@
           :mu-count (fn [[unused available]] (str unused " of " available " MU unused"))
           :special-mu-count (fn [[unused available mu-type]] (str unused " of " available " " mu-type " MU unused"))
           :indicate-action "Indicate action"
+          :show-decklists "Show/Hide decklists"
           :spec-count (fn [[c]] (str c " Spectator" (when (> c 1) "s")))
           :spec-view "Spectator View"
           :runner-view "Runner View"

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -1638,4 +1638,5 @@
     :worlds-2020-a :worlds-2020-b
     :worlds-2021-a :worlds-2021-b
     :worlds-2022-a :worlds-2022-b
-    :worlds-2023-a :worlds-2023-b})
+    :worlds-2023-a :worlds-2023-b
+    :worlds-2024-a :worlds-2024-b})

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -1471,7 +1471,7 @@
       [:preconstructed.worlds-2024-a "Worlds 2024: Alex Boyd (C) vs. Dee Ruttenberg (R)"]
       [:preconstructed.worlds-2024-a-tag "Alex Boyd (C) vs. Dee Ruttenberg (R)"]
       [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
-      [:preconstructed.worlds-2024-a-ul "Worlds 2024: ??? vs. ???"]
+      [:preconstructed.worlds-2024-a-ul "Worlds 2024: Kill R+ vs. Good Stuff Lat"]
       (precon "Aruzan - 2024: Kill R+"
             {:title "NBN: Reality Plus" :side "Corp" :code 30051}
             [{:qty 2 :card "Degree Mill"}
@@ -1531,7 +1531,7 @@
     [:preconstructed.worlds-2024-b "Worlds 2024: Dee Ruttenberg (C) vs Alex Boyd (R)"]
     [:preconstructed.worlds-2024-b-tag "Dee Ruttenberg (C) vs. Alex Boyd (R)"]
     [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
-    [:preconstructed.worlds-2024-b-ul "Worlds 2024: ??? vs. ???"]
+    [:preconstructed.worlds-2024-b-ul "Worlds 2024: Loud PE vs. Deep Dive Arissana"]
     (precon "DeeR - 2024: Loud PE"
             {:title "Jinteki: Personal Evolution" :side "Corp" :code 1067}
             [{:qty 1 :card "Blood in the Water"}

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -1468,9 +1468,9 @@
 
 (def worlds-2024-deer-runs
     (matchup
-      [:preconstructed.worlds-2024-a "Worlds 2024: Aruzan (C) vs. DeeR (R)"]
-      [:preconstructed.worlds-2024-a-tag "Aruzan (C) vs. DeeR (R)"]
-      [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
+      [:preconstructed.worlds-2024-a "Worlds 2024: Alex Boyd (C) vs. Dee Ruttenberg (R)"]
+      [:preconstructed.worlds-2024-a-tag "Alex Boyd (C) vs. Dee Ruttenberg (R)"]
+      [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
       [:preconstructed.worlds-2024-a-ul "Worlds 2024: ??? vs. ???"]
       (precon "Aruzan - 2024: Kill R+"
             {:title "NBN: Reality Plus" :side "Corp" :code 30051}
@@ -1528,9 +1528,9 @@
 
 (def worlds-2024-deer-corps
   (matchup
-    [:preconstructed.worlds-2024-b "Worlds 2024: DeeR (C) vs Aruzan (R)"]
-    [:preconstructed.worlds-2024-b-tag "cableCarnage (C) vs. William Huang (R)"]
-    [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
+    [:preconstructed.worlds-2024-b "Worlds 2024: Dee Ruttenberg (C) vs Alex Boyd (R)"]
+    [:preconstructed.worlds-2024-b-tag "Dee Ruttenberg (C) vs. Alex Boyd (R)"]
+    [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
     [:preconstructed.worlds-2024-b-ul "Worlds 2024: ??? vs. ???"]
     (precon "DeeR - 2024: Loud PE"
             {:title "Jinteki: Personal Evolution" :side "Corp" :code 1067}

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -1468,7 +1468,7 @@
 
 (def worlds-2024-deer-runs
     (matchup
-      [:preconstructed.worlds-2024-a "Worlds 2023: Aruzan (C) vs. DeeR (R)"]
+      [:preconstructed.worlds-2024-a "Worlds 2024: Aruzan (C) vs. DeeR (R)"]
       [:preconstructed.worlds-2024-a-tag "Aruzan (C) vs. DeeR (R)"]
       [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
       [:preconstructed.worlds-2024-a-ul "Worlds 2024: ??? vs. ???"]
@@ -1477,7 +1477,7 @@
             [{:qty 2 :card "Degree Mill"}
              {:qty 1 :card "Oracle Thinktank"}
              {:qty 3 :card "Project Beale"}
-             {:qty 1 :card "Tomorrowʼs Headline"}
+             {:qty 1 :card "Tomorrow's Headline"}
              {:qty 3 :card "False Lead"}
              {:qty 1 :card "Orbital Superiority"}
              {:qty 3 :card "Behold!"}
@@ -1528,7 +1528,7 @@
 
 (def worlds-2024-deer-corps
   (matchup
-    [:preconstructed.worlds-2024-b "Worlds 2023: cableCarnage (C) vs. William Huang (R)"]
+    [:preconstructed.worlds-2024-b "Worlds 2024: DeeR (C) vs Aruzan (R)"]
     [:preconstructed.worlds-2024-b-tag "cableCarnage (C) vs. William Huang (R)"]
     [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
     [:preconstructed.worlds-2024-b-ul "Worlds 2024: ??? vs. ???"]

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -141,26 +141,28 @@
     [:preconstructed.worlds-2012-a-tag "Ben Marsh (C) vs. Jeremy Zwirn (R)"]
     [:preconstructed.worlds-2012-info "Worlds 2012 was played with (up to 3 copies of) the Core Set as the only legal product. Jeremy Zwirn (Building a Better World, Gabriel Santiago) took first place against Ben Marsh (Engineering the Future, Gabriel Santiago) in the first ever Netrunner World Championship."]
     [:preconstructed.worlds-2012-a-ul "Worlds 2012: Weyland vs. Criminal"]
-    (precon "Ben Marsh - 2012: Weyland"
-            {:title "Weyland Consortium: Building a Better World" :side "Corp" :code 1093}
-            [{:qty 3 :card "Priority Requisition"}
-             {:qty 3 :card "Private Security Force"}
-             {:qty 3 :card "Hostile Takeover"}
-             {:qty 2 :card "Posted Bounty"}
-             {:qty 3 :card "Ice Wall"}
+    (precon "Ben Marsh - 2012: ETF"
+            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
+            [{:qty 3 :card "Enigma"}
+             {:qty 2 :card "Heimdall 1.0"}
+             {:qty 2 :card "Tollbooth"}
+             {:qty 3 :card "Viktor 1.0"}
+             {:qty 2 :card "Ichi 1.0"}
+             {:qty 3 :card "Rototurret"}
+             {:qty 2 :card "Archer"}
+             {:qty 1 :card "Ice Wall"}
              {:qty 3 :card "Wall of Static"}
-             {:qty 3 :card "Enigma"}
-             {:qty 3 :card "Shadow"}
-             {:qty 3 :card "Archer"}
-             {:qty 3 :card "Data Raven"}
-             {:qty 3 :card "Hadrian's Wall"}
-             {:qty 3 :card "Melange Mining Corp."}
-             {:qty 1 :card "Corporate Troubleshooter"}
+             {:qty 3 :card "Adonis Campaign"}
+             {:qty 3 :card "PAD Campaign"}
+             {:qty 2 :card "Project Junebug"}
+             {:qty 2 :card "Aggressive Secretary"}
              {:qty 2 :card "Snare!"}
-             {:qty 2 :card "Archived Memories"}
-             {:qty 3 :card "Beanstalk Royalties"}
+             {:qty 1 :card "Experiential Data"}
              {:qty 3 :card "Hedge Fund"}
-             {:qty 3 :card "Scorched Earth"}])
+             {:qty 3 :card "Biotic Labor"}
+             {:qty 3 :card "Private Security Force"}
+             {:qty 3 :card "Accelerated Beta Test"}
+             {:qty 3 :card "Priority Requisition"}])
     (precon "Jeremy Z - 2012: Criminal"
             {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code 1017}
             [{:qty 2 :card "Corroder"}
@@ -189,28 +191,26 @@
     [:preconstructed.worlds-2012-b-tag "Jeremy Z (C) vs. Ben Marsh (R)"]
     [:preconstructed.worlds-2012-info "Worlds 2012 was played with (up to 3 copies of) the Core Set as the only legal product. Jeremy Zwirn (Building a Better World, Gabriel Santiago) took first place against Ben Marsh (Engineering the Future, Gabriel Santiago) in the first ever Netrunner World Championship."]
     [:preconstructed.worlds-2012-b-ul "Worlds 2012: Haas-Bioroid vs. Criminal"]
-    (precon "Jeremy Z - 2012: ETF"
-            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
-            [{:qty 3 :card "Enigma"}
-             {:qty 2 :card "Heimdall 1.0"}
-             {:qty 2 :card "Tollbooth"}
-             {:qty 3 :card "Viktor 1.0"}
-             {:qty 2 :card "Ichi 1.0"}
-             {:qty 3 :card "Rototurret"}
-             {:qty 2 :card "Archer"}
-             {:qty 1 :card "Ice Wall"}
-             {:qty 3 :card "Wall of Static"}
-             {:qty 3 :card "Adonis Campaign"}
-             {:qty 3 :card "PAD Campaign"}
-             {:qty 2 :card "Project Junebug"}
-             {:qty 2 :card "Aggressive Secretary"}
-             {:qty 2 :card "Snare!"}
-             {:qty 1 :card "Experiential Data"}
-             {:qty 3 :card "Hedge Fund"}
-             {:qty 3 :card "Biotic Labor"}
+    (precon "Jeremy Z - 2012: Weyland"
+            {:title "Weyland Consortium: Building a Better World" :side "Corp" :code 1093}
+            [{:qty 3 :card "Priority Requisition"}
              {:qty 3 :card "Private Security Force"}
-             {:qty 3 :card "Accelerated Beta Test"}
-             {:qty 3 :card "Priority Requisition"}])
+             {:qty 3 :card "Hostile Takeover"}
+             {:qty 2 :card "Posted Bounty"}
+             {:qty 3 :card "Ice Wall"}
+             {:qty 3 :card "Wall of Static"}
+             {:qty 3 :card "Enigma"}
+             {:qty 3 :card "Shadow"}
+             {:qty 3 :card "Archer"}
+             {:qty 3 :card "Data Raven"}
+             {:qty 3 :card "Hadrian's Wall"}
+             {:qty 3 :card "Melange Mining Corp."}
+             {:qty 1 :card "Corporate Troubleshooter"}
+             {:qty 2 :card "Snare!"}
+             {:qty 2 :card "Archived Memories"}
+             {:qty 3 :card "Beanstalk Royalties"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "Scorched Earth"}])
     (precon "Ben Marsh - 2012: Gabe"
             {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code 1017}
             [{:qty 3 :card "Sneakdoor Beta"}
@@ -240,7 +240,7 @@
   (matchup
     [:preconstructed.worlds-2013-a "Worlds 2013: Jens Erickson (C) vs. Andrew Veen (R)"]
     [:preconstructed.worlds-2013-a-tag "Jens Erickson (C) vs. Andrew Veen (R)"]
-    [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves."]
+    [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves. Jens Erickson (Andromeda, ETR) took first place against Andrew Veen (Kate, NBN: Making News)"]
     [:preconstructed.worlds-2013-a-ul "Worlds 2013: HB FastAdv vs. Shaper Katman"]
     (precon "Jens Erickson - 2013: Engineering the Future"
             {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
@@ -292,7 +292,7 @@
   (matchup
     [:preconstructed.worlds-2013-b "Worlds 2013: Andrew Veen (C) vs. Jens Erickson (R)"]
     [:preconstructed.worlds-2013-b-tag "Andrew Veen (C) vs. Jens Erickson (R)"]
-    [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves."]
+    [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves. Jens Erickson (Andromeda, ETR) took first place against Andrew Veen (Kate, NBN: Making News)"]
     [:preconstructed.worlds-2013-b-ul "Worlds 2013: NBN Fast Adv vs. Andy Sucker"]
     (precon "Andrew Veen - 2013: Making News"
             {:title "NBN: Making News" :side "Corp" :code 25104}
@@ -1466,6 +1466,128 @@
              {:qty 2 :card "Fermenter"}
              {:qty 1 :card "Leech"}])))
 
+(def worlds-2024-deer-runs
+    (matchup
+      [:preconstructed.worlds-2024-a "Worlds 2023: Aruzan (C) vs. DeeR (R)"]
+      [:preconstructed.worlds-2024-a-tag "Aruzan (C) vs. DeeR (R)"]
+      [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
+      [:preconstructed.worlds-2024-a-ul "Worlds 2024: ??? vs. ???"]
+      (precon "Aruzan - 2024: Kill R+"
+            {:title "NBN: Reality Plus" :side "Corp" :code 30051}
+            [{:qty 2 :card "Degree Mill"}
+             {:qty 1 :card "Oracle Thinktank"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 1 :card "Tomorrowʼs Headline"}
+             {:qty 3 :card "False Lead"}
+             {:qty 1 :card "Orbital Superiority"}
+             {:qty 3 :card "Behold!"}
+             {:qty 1 :card "Gaslight"}
+             {:qty 3 :card "Spin Doctor"}
+             {:qty 1 :card "Lady Liberty"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 3 :card "Regolith Mining License"}
+             {:qty 3 :card "Ping"}
+             {:qty 3 :card "Unsmiling Tsarevna"}
+             {:qty 2 :card "Virtual Service Agent"}
+             {:qty 3 :card "Oppo Research"}
+             {:qty 1 :card "Predictive Planogram"}
+             {:qty 2 :card "Your Digital Life"}
+             {:qty 1 :card "Sprint"}
+             {:qty 2 :card "Mindscaping"}
+             {:qty 2 :card "End of the Line"}
+             {:qty 1 :card "Pivot"}
+             {:qty 2 :card "AMAZE Amusements"}
+             {:qty 2 :card "The Holo Man"}])
+      (precon "DeeR - 2024: Deep Dive Lat"
+              {:title "Lat: Ethical Freelancer" :side "Runner" :code 26019}
+              [{:qty 3 :card "Creative Commission"}
+               {:qty 2 :card "Deep Dive"}
+               {:qty 2 :card "Diesel"}
+               {:qty 3 :card "Trick Shot"}
+               {:qty 1 :card "Bahia Bands"}
+               {:qty 3 :card "Dirty Laundry"}
+               {:qty 3 :card "Overclock"}
+               {:qty 2 :card "Sure Gamble"}
+               {:qty 2 :card "Pinhole Threading"}
+               {:qty 3 :card "Simulchip"}
+               {:qty 2 :card "Swift"}
+               {:qty 1 :card "Echelon"}
+               {:qty 1 :card "Euler"}
+               {:qty 1 :card "Gauss"}
+               {:qty 1 :card "K2CP Turbine"}
+               {:qty 1 :card "Paricia"}
+               {:qty 1 :card "Propeller"}
+               {:qty 3 :card "Self-modifying Code"}
+               {:qty 1 :card "Fermenter"}
+               {:qty 1 :card "Cupellation"}
+               {:qty 1 :card "Revolver"}
+               {:qty 1 :card "Dr. Nuka Vrolyck"}
+               {:qty 3 :card "Stoneship Chart Room"}
+               {:qty 2 :card "Telework Contract"}
+               {:qty 1 :card "DJ Fenris"}])))
+
+(def worlds-2024-deer-corps
+  (matchup
+    [:preconstructed.worlds-2024-b "Worlds 2023: cableCarnage (C) vs. William Huang (R)"]
+    [:preconstructed.worlds-2024-b-tag "cableCarnage (C) vs. William Huang (R)"]
+    [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
+    [:preconstructed.worlds-2024-b-ul "Worlds 2024: ??? vs. ???"]
+    (precon "DeeR - 2024: Loud PE"
+            {:title "Jinteki: Personal Evolution" :side "Corp" :code 1067}
+            [{:qty 1 :card "Blood in the Water"}
+             {:qty 3 :card "Fujii Asset Retrieval"}
+             {:qty 2 :card "House of Knives"}
+             {:qty 2 :card "Hybrid Release"}
+             {:qty 2 :card "Regenesis"}
+             {:qty 3 :card "Sting!"}
+             {:qty 3 :card "Cohort Guidance Program"}
+             {:qty 2 :card "Moon Pool"}
+             {:qty 3 :card "Prāna Condenser"}
+             {:qty 1 :card "Snare!"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 1 :card "Wage Workers"}
+             {:qty 3 :card "Spin Doctor"}
+             {:qty 2 :card "Anansi"}
+             {:qty 2 :card "Anemone"}
+             {:qty 3 :card "Tatu-Bola"}
+             {:qty 3 :card "Vampyronassa"}
+             {:qty 2 :card "Data Loop"}
+             {:qty 3 :card "Mindscaping"}
+             {:qty 1 :card "Hedge Fund"}
+             {:qty 1 :card "Mavirus"}
+             {:qty 1 :card "Tranquility Home Grid"}
+             {:qty 1 :card "The Holo Man"}
+             {:qty 1 :card "Crisium Grid"}])
+    (precon "Aruzan - 2024: Spree Arissana"
+            {:title "Arissana Rocha Nahu: Street Artist" :side "Runner" :code 34020}
+            [{:qty 2 :card "Burner"}
+             {:qty 3 :card "Creative Commission"}
+             {:qty 3 :card "Deep Dive"}
+             {:qty 3 :card "Diesel"}
+             {:qty 3 :card "Spec Work"}
+             {:qty 2 :card "Spree"}
+             {:qty 3 :card "Trick Shot"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 2 :card "Pinhole Threading"}
+             {:qty 2 :card "Aniccam"}
+             {:qty 3 :card "Simulchip"}
+             {:qty 1 :card "Coalescence"}
+             {:qty 1 :card "Euler"}
+             {:qty 1 :card "Gauss"}
+             {:qty 1 :card "Ika"}
+             {:qty 3 :card "Muse"}
+             {:qty 1 :card "Paricia"}
+             {:qty 1 :card "Pichação"}
+             {:qty 1 :card "Propeller"}
+             {:qty 1 :card "Self-modifying Code"}
+             {:qty 1 :card "Botulus"}
+             {:qty 2 :card "Fermenter"}
+             {:qty 1 :card "Physarum Entangler"}
+             {:qty 2 :card "Environmental Testing"}
+             {:qty 2 :card "Daily Casts"}
+             {:qty 1 :card "DJ Fenris"}
+             {:qty 1 :card "Hannah \"Wheels\" Pilintra"}])))
+
 ;; Utility
 
 (defn matchup-by-key
@@ -1498,7 +1620,9 @@
     :worlds-2022-a worlds-2022-sokka-corps
     :worlds-2022-b worlds-2022-sokka-runs
     :worlds-2023-a worlds-2023-sokka-corps
-    :worlds-2023-b worlds-2023-sokka-runs))
+    :worlds-2023-b worlds-2023-sokka-runs
+    :worlds-2024-a worlds-2024-deer-runs
+    :worlds-2024-b worlds-2024-deer-corps))
 
 (def all-matchups
   "A set of all preconstructed matchups (by key).

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -185,12 +185,18 @@
   (when precon
     [:span.format-precon-deck-names (tr (:tr-underline (matchup-by-key precon)))]))
 
-(defn game-format [{fmt :format singleton? :singleton precon :precon}]
+(defn- open-decklists-span [open-decklists]
+  (js/console.log (str "open: " open-decklists))
+  (when open-decklists
+    [:span.open-decklists (str " " (tr [:lobby.open-decklists-b] "(open decklists)"))]))
+
+(defn game-format [{fmt :format singleton? :singleton precon :precon open-decklists :open-decklists}]
   [:div {:class "game-format"}
    [:span.format-label (tr [:lobby.format "Format"]) ":  "]
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
    [precon-span precon]
    [:span.format-singleton (str (when singleton? (str " " (tr [:lobby.singleton-b "(singleton)"]))))]
+   [open-decklists-span open-decklists]
    [precon-under-span precon]])
 
 (defn- time-since

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -185,9 +185,8 @@
   (when precon
     [:span.format-precon-deck-names (tr (:tr-underline (matchup-by-key precon)))]))
 
-(defn- open-decklists-span [open-decklists]
-  (js/console.log (str "open: " open-decklists))
-  (when open-decklists
+(defn- open-decklists-span [precon open-decklists]
+  (when (and open-decklists (not precon))
     [:span.open-decklists (str " " (tr [:lobby.open-decklists-b] "(open decklists)"))]))
 
 (defn game-format [{fmt :format singleton? :singleton precon :precon open-decklists :open-decklists}]
@@ -196,7 +195,7 @@
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
    [precon-span precon]
    [:span.format-singleton (str (when singleton? (str " " (tr [:lobby.singleton-b "(singleton)"]))))]
-   [open-decklists-span open-decklists]
+   [open-decklists-span precon open-decklists]
    [precon-under-span precon]])
 
 (defn- time-since

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1301,7 +1301,7 @@
         card-name (fn [c] [:div {:text-align "left"
                                  :on-mouse-over #(card-preview-mouse-over % zoom-channel)
                                  :on-mouse-out #(card-preview-mouse-out % zoom-channel)}
-                           (render-message (subs (str (first c) "  ") 1))])]
+                           (render-message (first c))])]
     [:div
      [:table.decklists.table
       [:tbody

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1325,7 +1325,6 @@
         (let [corp-list (or (get-in @game-state [:decklists :corp]) {:- 1})
               runner-list (or (get-in @game-state [:decklists :runner]) {:- 1})]
           [:div.decklists.blue-shade
-           [:div "some text to block out some space"]
            [:br]
            [build-in-game-decklists corp-list runner-list]])))))
 

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -63,6 +63,13 @@
                               :key "Indicate action"}
      (tr [:game.indicate-action "Indicate action"])]))
 
+(defn show-decklists []
+  (when (get-in @app-state [:current-game :open-decklists])
+    [:button.show-decklists {:on-click #(do (.preventDefault %)
+                                            (swap! app-state update-in [:display-decklists] not))
+                             :key "Show Decklists"}
+     (tr [:game.show-decklists "Show/Hide decklists"])]))
+
 (defn fuzzy-match-score
   "Matches if all characters in input appear in target in order.
   Score is sum of matched indices, lower is a better match"
@@ -176,6 +183,7 @@
              :on-key-down #(command-menu-key-down-handler state %)
              :on-change #(log-input-change-handler state %)}]]]
          [indicate-action]
+         [show-decklists]
          [command-menu !input-ref state]]))))
 
 (defn log-messages []

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -21,6 +21,7 @@
    :spectatorhands
    :precon
    :gateway-type
+   :open-decklists
    :timer
    :title])
 
@@ -77,6 +78,12 @@
    [:input {:type "checkbox" :checked (:singleton @options)
             :on-change #(swap! options assoc :singleton (.. % -target -checked))}]
    (tr [:lobby.singleton "Singleton"])])
+
+(defn open-decklists [options]
+  [:label
+   [:input {:type "checkbox" :checked (:open-decklists @options)
+            :on-change #(swap! options assoc :open-decklists (.. % -target -checked))}]
+   (tr [:lobby.open-decklists "Open Decklists"])])
 
 (defn gateway-constructed-choice [fmt-state gateway-type]
   [:div
@@ -219,6 +226,7 @@
    [:h3 (tr [:lobby.options "Options"])]
    [allow-spectators options]
    [toggle-hidden-info options]
+   [open-decklists options]
    [password-input options]
    [add-timer options]
    [save-replay options]
@@ -239,6 +247,7 @@
                                 :save-replay (not= "casual" (:room @lobby-state))
                                 :singleton false
                                 :spectatorhands false
+                                :open-decklists false
                                 :timed false
                                 :timer nil})
                title (r/cursor state [:title])

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1091,7 +1091,7 @@
                         div
                             animation: fadein 0.5s
 
-                    .log-input form input, .indicate-action
+                    .log-input form input, .indicate-action, .show-decklists
                         width: 100%
 
                     .command-matches-container

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -141,6 +141,10 @@
             color: #ff571a;
             font-style: bold;
 
+        .open-decklists
+            color: #ffE31A;
+            font-style: bold;
+
         .format-label
             font-weight: bold
 


### PR DESCRIPTION
Worlds is over, so I'm adding the precon decks for 2024 (just waiting on decklist names and player preference as to screen names vs. real names).

I also added a feature for displaying/checking open decklists.

Video is in slack, but here's what it looks like in the lobby.

![open-decklists](https://github.com/user-attachments/assets/823259d7-0137-4c49-97ca-1e461ea736ce)

Closes #5584