### PR TITLE
Stinson ignores all costs

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -371,7 +371,8 @@
                 :effect (effect (play-instant eid (-> target
                                                       (assoc :rfg-instead-of-trashing true)
                                                       (assoc-in [:special :rfg-when-trashed] true))
-                                              {:ignore-cost true}))}]})
+                                              {:no-additional-cost true
+                                               :ignore-cost true}))}]})
 
 (defcard "Calibration Testing"
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -702,6 +702,17 @@
       (click-prompt state :corp (find-card "IPO" (:discard (get-corp))))
       (is (find-card "IPO" (:rfg (get-corp))) "IPO is removed from game"))))
 
+(deftest stinson-ignores-all-costs
+  (do-game
+    (new-game {:corp {:hand ["Bryan Stinson"] :discard ["Ultraviolet Clearance"]}})
+    (play-from-hand state :corp "Bryan Stinson" "HQ")
+    (rez state :corp (get-content state :hq 0))
+    (is (changed? [(:click (get-corp)) -1
+                  (:credit (get-corp)) 10]
+          (card-ability state :corp (get-content state :hq 0) 0)
+          (click-prompt state :corp "Ultraviolet Clearance"))
+        "Gained 10c in one click (ignoring the req and extra 2 clicks)")))
+
 (deftest calibration-testing
   ;; Calibration Testing - advanceable / non-advanceable
   (do-game


### PR DESCRIPTION
Stinson only had keys for ignoring the base cost. I guess we changed the instant system at some point.

Closes #7837