### PR TITLE
Rejig vs annicam

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3201,7 +3201,7 @@
                  :choices {:card #(and (valid-target? %)
                                        (installed? %))}
                  :effect (req (move state side target :hand)
-                              (effect-completed state side (make-result eid (:cost target))))}
+                              (complete-with-result state side eid (:cost target)))}
         put-down (fn [bonus]
                    {:async true
                     :prompt "Choose a program or piece of hardware to install"
@@ -3216,6 +3216,7 @@
                                                                        :display-origin true}}))})]
     {:on-play
      {:req (req (some valid-target? (all-installed state :runner)))
+      :async true
       :effect (req (wait-for (resolve-ability state side pick-up card nil)
                              (continue-ability state side
                                                (put-down async-result)

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -6002,6 +6002,19 @@
         (run-continue state)
         (click-prompt state :runner "Hedge Fund"))))
 
+(deftest rejig-vs-aniccam
+  ;; Rejig
+  (do-game
+    (new-game {:options {:start-as :runner}
+               :runner {:hand ["Rejig" "Aniccam"]
+                        :deck ["Ika"]}})
+    (play-from-hand state :runner "Aniccam")
+    (play-from-hand state :runner "Rejig")
+    (click-card state :runner "Aniccam")
+    (is-hand? state :runner ["Aniccam"])
+    (click-card state :runner "Aniccam")
+    (is-hand? state :runner ["Ika"])))
+
 (deftest reprise
   ;; Reprise
   (do-game

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -44,26 +44,27 @@
              '[game.cards.upgrades])))
 (load-all-cards)
 
-(defn is-hand?
+(defn is-zone-impl
+  "Is the hand exactly equal to a given set of cards?"
+  [state side zone expected]
+  (let [expected (seq (sort (flatten expected)))
+        contents (seq (sort (map :title (get-in @state [side zone]))))]
+    (is' (= expected contents) (str (name zone) " is not " expected))))
+
+(defmacro is-hand?
   "Is the hand exactly equal to a given set of cards?"
   [state side expected-hand]
-  (let [expected-hand (seq (sort (flatten expected-hand)))
-        hand (seq (sort (map :title (get-in @state [side :hand]))))]
-    (is (= expected-hand hand) (str "hand is not " expected-hand))))
+  `(error-wrapper (is-zone-impl ~state ~side :hand ~expected-hand)))
 
-(defn is-deck?
-  "Is the discard exactly equal to a given set of cards?"
+(defmacro is-deck?
+  "Is the hand exactly equal to a given set of cards?"
   [state side expected-deck]
-  (let [expected-deck (seq (sort (flatten expected-deck)))
-        deck (seq (sort (map :title (get-in @state [side :deck]))))]
-    (is (= expected-deck deck) (str "deck is not " expected-deck))))
+  `(error-wrapper (is-zone-impl ~state ~side :deck ~expected-deck)))
 
-(defn is-discard?
-  "Is the set of cards in the deck exactly equal to a given set of cards? (this is order agnostic)"
+(defmacro is-discard?
+  "Is the hand exactly equal to a given set of cards?"
   [state side expected-discard]
-  (let [expected-discard (seq (sort (flatten expected-discard)))
-        discard (seq (sort (map :title (get-in @state [side :discard]))))]
-    (is (= expected-discard discard) (str "discard is not " expected-discard))))
+  `(error-wrapper (is-zone-impl ~state ~side :discard ~expected-discard)))
 
 ;;; helper functions for prompt interaction
 (defn get-prompt


### PR DESCRIPTION
Rejigging an aniccam previously wasn't getting a draw. Turns out we just missed out an async and defined it in a weird way to make up for that.

I also changed the `is-hand?/is-deck?/is-discard?` fn's to be error-wrapped macros using the `is'` function (this is still black magic to me), so if they're wrong it'll tell us where they're being called rather than where the `is-hand?/etc` function is.