### PR TITLE
Fenris fake-id is not installed

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1180,9 +1180,7 @@
                                           c (make-card c)
                                           c (assoc c
                                                    :host (dissoc card :hosted)
-                                                   :zone [:onhost]
-                                                   ;; semi hack to get deactivate to work
-                                                   :installed true)]
+                                                   :zone [:onhost])]
                                       ;; Manually host id on card
                                       (update! state side (assoc card :hosted [c]))
                                       (card-init state :runner c)

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -1,6 +1,6 @@
 (ns game.core.effects
   (:require [clj-uuid :as uuid]
-            [game.core.card :refer [get-card]]
+            [game.core.card :refer [facedown? get-card runner?]]
             [game.core.card-defs :refer [card-def]]
             [game.core.eid :refer [make-eid]]
             [game.core.board :refer [get-all-cards]]
@@ -93,7 +93,9 @@
   "Gets all cards currently disabled"
   [state]
   (let [all-cards (get-all-cards state)
-        disabled-cards (filter #(is-disabled? state nil %) all-cards)]
+        disabled-cards (filter #(or (is-disabled? state nil %)
+                                    (and (runner? %) (facedown? %)))
+                               all-cards)]
     (into {} (map (juxt :cid identity)) disabled-cards)))
 
 (defn update-disabled-cards [state]

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2011,6 +2011,25 @@
                     (click-prompt state :runner "Pay 3 [Credits] to trash"))
           "Loup triggered (see https://nullsignal.games/blog/card-text-updates-v1-2-released/ for ruling"))))
 
+(deftest dj-vs-degree-mill
+  (do-game
+    (new-game {:runner {:hand ["DJ Fenris" "Ika"]}
+               :corp {:hand ["Degree Mill"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "DJ Fenris")
+    (click-prompt state :runner "René \"Loup\" Arcemont: Party Animal")
+    (run-empty-server state :hq)
+    (is (= '("No action") (prompt-buttons :runner)) "Cannot steal degree mill with just dj")
+    (click-prompt state :runner "No action")
+    (play-from-hand state :runner "Ika")
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Pay to steal")
+    (click-card state :runner "DJ Fenris")
+    (click-card state :runner (first (:hosted (get-resource state 0)))) ;; not selected
+    (is (not (no-prompt? state :runner)) "did not confirm by picking fake agenda")
+    (click-card state :runner "Ika")
+    (is (no-prompt? state :runner) "Stole degree mill")))
+
 (deftest donut-taganes
   ;; Donut Taganes - add 1 to play cost of Operations & Events when this is in play
   (do-game


### PR DESCRIPTION
Closes #7823

We previously had the fake-id have `:installed` as a hack to make activate and deactivate work, which was required for things like apocalypse and assimilator to work.

Now it's no longer installed, and the disabled registry just automatically tags runner facedowns as being disabled. I'm assuming that wont cause any other issues, but I guess we'll see.