### PR TITLE
New player mode features

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -396,6 +396,18 @@
        :effect (effect (trash eid target {:unpreventable true}))}
       nil nil)))
 
+(defn dont-share-information
+  [state side]
+  (system-msg state side "stops playing with open information")
+  (swap! state dissoc-in [side :share-information]))
+
+(defn share-information
+  [state side]
+  (if (get-in @state [side :share-information])
+    (system-msg state side "stops playing with open information")
+    (system-msg state side "starts playing with open information"))
+  (swap! state update-in [side :share-information] not))
+
 (defn parse-command
   [state text]
   (let [[command & args] (safe-split text #" ")
@@ -437,6 +449,8 @@
                                               (make-card {:title "/disable-card command"}) nil)
             "/discard"    #(toast %1 %2 "/discard number takes the format #n")
             "/discard-random" #(move %1 %2 (rand-nth (get-in @%1 [%2 :hand])) :discard)
+            "/dont-share-information"  dont-share-information
+            "/don't-share-information" dont-share-information
             "/draw"       #(draw %1 %2 (make-eid %1) (constrain-value value 0 1000))
             "/enable-card" #(resolve-ability %1 %2
                                              {:prompt "Choose a card to enable"
@@ -520,6 +534,7 @@
             "/save-replay" command-save-replay
             "/set-mark"   #(command-set-mark %1 %2 args)
             "/score"      command-score
+            "/share-information" share-information
             "/show-hand" #(resolve-ability %1 %2
                                            {:effect (effect (system-msg (str
                                                                           (if (= :corp %2)

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -1,5 +1,6 @@
 (ns game.core.diffs
   (:require
+   [clojure.string :as str]
    [cond-plus.core :refer [cond+]]
    [differ.core :as differ]
    [game.core.board :refer [installable-servers]]
@@ -177,8 +178,15 @@
 
 (declare cards-summary)
 
+(defn- is-public-or-shared?
+  [state side card]
+  (or (is-public? card side)
+      (let [c-side (keyword (str/lower-case (:side card)))]
+        (and (installed? card)
+             (get-in @state [c-side :share-information])))))
+
 (defn card-summary [card state side]
-  (if (is-public? card side)
+  (if (is-public-or-shared? state side card)
     (-> (cond-> card
           (:host card) (-> (dissoc-in [:host :hosted])
                            (update :host card-summary state side))
@@ -302,7 +310,7 @@
 (defn hand-summary
   "Is the player's hand publicly visible?"
   [hand state same-side? side player]
-  (if (or same-side? (:openhand player))
+  (if (or same-side? (:openhand player) (:share-information player))
     (cards-summary hand state side)
     []))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -704,6 +704,7 @@
                             :on-drag-start #(handle-dragstart % card)
                             :on-drag-end #(-> % .-target js/$ (.removeClass "dragged"))
                             :on-mouse-enter #(when (or (not (or (not code) flipped facedown))
+                                                       title
                                                        (spectator-view-hidden?)
                                                        (= (:side @game-state) (keyword (lower-case side))))
                                                (put-game-card-in-channel card zoom-channel))


### PR DESCRIPTION
Slowly cracking through this.

Right now:
* Commands to disable/enable playing with open info
* Installed facedowns are visible on mouse-over via card preview (maybe they could flip faceup on mouseover? that's a problem for somebody else)