### PR TITLE
Reveal hand when selecting cards from opponents hand

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -20,7 +20,7 @@
    [game.core.checkpoint :refer [fake-checkpoint]]
    [game.core.damage :refer [damage damage-prevent]]
    [game.core.def-helpers :refer [corp-recur corp-rez-toast defcard
-                                  reorder-choice trash-on-empty get-x-fn]]
+                                  reorder-choice trash-on-empty get-x-fn with-revealed-hand]]
    [game.core.drawing :refer [draw first-time-draw-bonus max-draw
                               remaining-draws]]
    [game.core.effects :refer [is-disabled-reg? register-lingering-effect update-disabled-cards]]
@@ -1344,18 +1344,21 @@
 
 (defcard "Ibrahim Salem"
   (let [trash-ability (fn [card-type]
-                        {:req (req (seq (filter #(is-type? % card-type) (:hand runner))))
-                         :prompt (str "Choose a " card-type " to trash")
-                         :choices (req (filter #(is-type? % card-type) (:hand runner)))
-                         :async true
-                         :effect (effect (trash eid target {:cause-card card}))
-                         :msg (msg "trash " (:title target) " from the grip")})
+                        (with-revealed-hand :runner {:event-side :corp}
+                          {:req (req (seq (filter #(is-type? % card-type) (:hand runner))))
+                           :prompt (str "Choose a " card-type " to trash")
+                           :choices {:card #(and (in-hand? %)
+                                                 (runner? %)
+                                                 (is-type? % card-type))}
+                           :async true
+                           :effect (effect (trash eid target {:cause-card card}))
+                           :msg (msg "trash " (:title target) " from the grip")}))
         choose-ability {:label "Trash 1 card in the grip of a named type"
                         :once :per-turn
                         :req (req (seq (:hand runner)))
                         :prompt "Choose a card type"
                         :choices ["Event" "Hardware" "Program" "Resource"]
-                        :msg (msg "reveal " (enumerate-str (map :title (:hand runner))))
+                        :msg (msg "choose " target)
                         :async true
                         :effect (effect (continue-ability (trash-ability target) card nil))}]
     {:additional-cost [(->c :forfeit)]
@@ -3014,33 +3017,20 @@
                                                                          :display-origin true}}))}]})
 
 (defcard "Vera Ivanovna Shuyskaya"
-  (let [select-and-trash {:async true
-                          :prompt "Choose a card to trash"
-                          :waiting-prompt true
-                          :choices (req (cancellable (:hand runner) :sorted))
-                          :msg (msg "trash " (:title target) " from the grip")
-                          :effect (effect (trash eid target {:cause-card card}))}
-        ability {:interactive (req true)
+  (let [ability {:interactive (req true)
                  :optional {:prompt "Reveal the grip and trash a card?"
                             :player :corp
                             :autoresolve (get-autoresolve :auto-fire)
-                            :yes-ability
-                            {:async true
-                             :effect (req (wait-for (reveal state side (:hand runner))
-                                                    (system-msg state :corp (str "reveal "
-                                                                (quantify (count (:hand runner)) "card")
-                                                                " from grip: "
-                                                                (enumerate-str (map :title (:hand runner)))))
-                                                    (continue-ability state side select-and-trash card nil)))}
+                            :yes-ability (with-revealed-hand :runner {:event-side :corp}
+                                           {:prompt "Choose a card to trash"
+                                            :req (req (seq (:hand runner)))
+                                            :choices {:card (every-pred in-hand? runner?)}
+                                            :async true
+                                            :msg (msg "trash " (:title target) " from the Grip")
+                                            :effect (req (trash state side eid target {:cause-card card}))})
                             :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}]
-    {:events [{:event :agenda-scored
-               :interactive (req true)
-               :async true
-               :effect (effect (continue-ability ability card nil))}
-              {:event :agenda-stolen
-               :interactive (req true)
-               :async true
-               :effect (effect (continue-ability ability card nil))}]
+    {:events [(assoc ability :event :agenda-scored)
+              (assoc ability :event :agenda-stolen)]
      :abilities [(set-autoresolve :auto-fire "Vera Ivanovna Shuyskaya")]}))
 
 (defcard "Victoria Jenkins"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4176,17 +4176,16 @@
    {:trace
     {:base 3
      :req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
-     :unsuccessful
-     (with-revealed-hand :corp {:event-side :corp :forced true}
-       {:prompt "Shuffle up to 2 cards into HQ"
-        :player :runner
-        :choices {:req (req (and (corp? target)
-                                 (in-hand? target)))
-                  :max (req (min 2 (count (:hand corp))))}
-        :msg (msg "shuffle " (enumerate-str (map :title targets)) " into R&D")
-        :effect (req (doseq [t targets]
-                       (move state :corp t :deck))
-                     (shuffle! state :corp :deck))})}}})
+     :unsuccessful (with-revealed-hand :corp {:event-side :corp :forced true}
+                     {:prompt "Shuffle up to 2 cards into R&D"
+                      :player :runner
+                      :choices {:req (req (and (corp? target)
+                                               (in-hand? target)))
+                                :max (req (min 2 (count (:hand corp))))}
+                      :msg (msg "shuffle " (enumerate-str (map :title targets)) " into R&D")
+                      :effect (req (doseq [t targets]
+                                     (move state :corp t :deck))
+                                   (shuffle! state :corp :deck))})}}})
 
 (defcard "Wildcat Strike"
   {:on-play (choose-one-helper

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -16,7 +16,7 @@
    [game.core.cost-fns :refer [install-cost play-cost rez-cost]]
    [game.core.damage :refer [damage damage-prevent]]
    [game.core.def-helpers :refer [breach-access-bonus choose-one-helper defcard offer-jack-out
-                                  reorder-choice]]
+                                  reorder-choice with-revealed-hand]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid
@@ -4172,33 +4172,21 @@
                          (register-events card (rfg-card-event target)))}]}))
 
 (defcard "White Hat"
-  (letfn [(finish-choice [choices]
-            (let [choices (filter #(not= "Done" %) choices)]
-              (when (not-empty choices)
-                {:effect (req (doseq [c choices]
-                                (move state :corp c :deck))
-                              (shuffle! state :corp :deck))
-                 :msg (str "shuffle " (enumerate-str (map :title choices)) " into R&D")})))
-          (choose-cards [choices chosen]
-            {:prompt (str "Choose a card in HQ to shuffle into R&D (" (- 2 (count chosen)) " remaining)")
-             :player :runner
-             :choices (concat choices ["Done"])
-             :not-distinct true
-             :async true
-             :effect (req (if (and (empty? chosen)
-                                   (not= "Done" target))
-                            (continue-ability state side (choose-cards (remove-once #(= % target) choices) (conj chosen target)) card nil)
-                            (continue-ability state side (finish-choice (conj chosen target)) card nil)))})]
-    {:on-play
-     {:trace
-      {:base 3
-       :req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
-       :unsuccessful
-       {:async true
-        :msg (msg "reveal " (enumerate-str (map :title (:hand corp))) " from HQ")
-        :effect (req (wait-for
-                       (reveal state side (:hand corp))
-                       (continue-ability state :runner (choose-cards (:hand corp) #{}) card nil)))}}}}))
+  {:on-play
+   {:trace
+    {:base 3
+     :req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
+     :unsuccessful
+     (with-revealed-hand :corp {:event-side :corp :forced true}
+       {:prompt "Shuffle up to 2 cards into HQ"
+        :player :runner
+        :choices {:req (req (and (corp? target)
+                                 (in-hand? target)))
+                  :max (req (min 2 (count (:hand corp))))}
+        :msg (msg "shuffle " (enumerate-str (map :title targets)) " into R&D")
+        :effect (req (doseq [t targets]
+                       (move state :corp t :deck))
+                     (shuffle! state :corp :deck))})}}})
 
 (defcard "Wildcat Strike"
   {:on-play (choose-one-helper

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -15,7 +15,7 @@
                                rez-additional-cost-bonus rez-cost]]
    [game.core.damage :refer [chosen-damage corp-can-choose-damage? damage
                              enable-corp-damage-choice]]
-   [game.core.def-helpers :refer [corp-recur defcard offer-jack-out]]
+   [game.core.def-helpers :refer [corp-recur defcard offer-jack-out with-revealed-hand]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect is-disabled?]]
    [game.core.eid :refer [effect-completed get-ability-targets is-basic-advance-action? make-eid]]
@@ -520,19 +520,11 @@
                              (pos? (count (:hand runner)))))
               :waiting-prompt true
               :prompt "Choose the first card to trash?"
-              :yes-ability
-              {:async true
-               :msg (msg "look at the grip ( "
-                         (enumerate-str (map :title (sort-by :title (:hand runner))))
-                         " ) and choose the card that is trashed")
-               :effect
-               (effect (continue-ability
-                         {:prompt "Choose 1 card to trash"
-                          :choices (req (:hand runner))
-                          :not-distinct true
-                          :msg (msg "choose " (:title target) " to trash")
-                          :effect (req (chosen-damage state :corp target))}
-                         card nil))}
+              :yes-ability (with-revealed-hand :runner {:no-event true}
+                             {:prompt "Choose 1 card to trash"
+                              :choices {:card (every-pred runner? in-hand?)}
+                              :msg (msg "choose " (:title target) " to trash")
+                              :effect (req (chosen-damage state :corp target))})
               :no-ability
               {:effect (req (system-msg state :corp (str "declines to use " (:title card))))}}}]})
 

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -16,7 +16,7 @@
    [game.core.cost-fns :refer [play-cost trash-cost]]
    [game.core.costs :refer [total-available-credits]]
    [game.core.damage :refer [damage damage-bonus]]
-   [game.core.def-helpers :refer [choose-one-helper corp-recur cost-option defcard do-brain-damage reorder-choice something-can-be-advanced? get-x-fn]]
+   [game.core.def-helpers :refer [choose-one-helper corp-recur cost-option defcard do-brain-damage reorder-choice something-can-be-advanced? get-x-fn with-revealed-hand]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid make-result]]
@@ -1028,18 +1028,12 @@
     :prompt "Choose one"
     :choices ["Event" "Hardware" "Program" "Resource"]
     :async true
+    :msg (msg "choose " target)
     :effect (req (let [type target
                        numtargets (count (filter #(= type (:type %)) (:hand runner)))]
-                   (system-msg
-                     state :corp
-                     (str "uses " (:title card) " to choose " target
-                          " and reveal "
-                          (enumerate-str (map :title (sort-by :title (:hand runner))))
-                          " from the grip"))
-                   (wait-for
-                     (reveal state side (:hand runner))
-                     (continue-ability
-                       state :corp
+                   (continue-ability
+                     state side
+                     (with-revealed-hand :runner {:event-side :corp}
                        (when (pos? numtargets)
                          {:async true
                           :prompt "How many credits do you want to pay?"
@@ -1056,8 +1050,8 @@
                                                         :choices {:card installed?}
                                                         :effect (effect (add-prop target :advance-counter c {:placed true}))}
                                                        card nil))
-                                           (effect-completed state side eid))))})
-                       card nil))))}})
+                                           (effect-completed state side eid))))}))
+                       card nil)))}})
 
 (defcard "Foxfire"
   {:on-play

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -3,11 +3,11 @@
     [clojure.string :as str]
     [game.core.access :refer [access-bonus]]
     [game.core.board :refer [all-installed]]
-    [game.core.card :refer [active? can-be-advanced? corp? faceup? get-card get-counters has-subtype? in-discard?]]
+    [game.core.card :refer [active? can-be-advanced? corp? faceup? get-card get-counters has-subtype? in-discard? runner? in-hand?]]
     [game.core.card-defs :as card-defs]
     [game.core.damage :refer [damage]]
     [game.core.eid :refer [effect-completed make-eid]]
-    [game.core.engine :refer [resolve-ability trigger-event-sync]]
+    [game.core.engine :refer [register-events resolve-ability trigger-event-sync unregister-event-by-uuid]]
     [game.core.effects :refer [is-disabled-reg?]]
     [game.core.gaining :refer [gain-credits]]
     [game.core.moving :refer [move trash]]
@@ -349,22 +349,36 @@
   (forced) via the args"
   ([target-side abi] (with-revealed-hand target-side nil abi))
   ([target-side {:keys [event-side forced skip-reveal] :as args} abi]
-   {:async true
-    :effect (req (if skip-reveal
-                   (if (get-in @state [target-side :openhand])
-                          (continue-ability state side abi card targets)
-                          (do (reveal-hand state target-side)
-                              (wait-for (resolve-ability state side abi card targets)
-                                        (conceal-hand state target-side)
-                                        (effect-completed state side eid))))
-                   (wait-for
-                     (reveal-loud state (or event-side side) card args (get-in @state [target-side :hand]))
-                     (if (get-in @state [target-side :openhand])
-                       (continue-ability state side abi card targets)
-                       (do (reveal-hand state target-side)
-                           (wait-for (resolve-ability state side abi card targets)
-                                     (conceal-hand state target-side)
-                                     (effect-completed state side eid)))))))}))
+   ;; note - if the target draws (ie with steelskin), then the hand should be unrevealed again
+   ;; this only matters if a card like buffer drive or aniccam is in play that causes a prompt
+   ;; and the server sends the paused state back with the new cards faceup
+   (letfn [(maybe-register-ev
+             [state side card was-open?]
+             (if-not was-open?
+               (let [uuid (:uuid (first (register-events state side card
+                                                         [{:event :card-moved
+                                                           :req (req (let [sidefn (if (= :corp target-side) corp? runner?)]
+                                                                       (and (sidefn (:moved-card context))
+                                                                            (in-hand? (:moved-card context)))))
+                                                           :silent (req true)
+                                                           :effect (req (conceal-hand state target-side))}])))]
+                 (fn [] (unregister-event-by-uuid state side uuid)))
+               (fn [] nil)))
+           (maybe-reveal
+             [state side eid card target-side {:keys [event-side forced skip-reveal] :as args}]
+             (if skip-reveal
+               (effect-completed state side eid)
+               (reveal-loud state (or event-side side) eid card args (get-in @state [target-side :hand]))))]
+     {:async true
+      :effect (req (wait-for
+                     (maybe-reveal state side card target-side args)
+                     (let [was-open? (get-in @state [target-side :openhand])
+                           unregister-ev-callback (maybe-register-ev state side card was-open?)]
+                       (when-not was-open? (reveal-hand state target-side))
+                       (wait-for (resolve-ability state side abi card targets)
+                                 (when-not was-open? (conceal-hand state target-side))
+                                 (unregister-ev-callback)
+                                 (effect-completed state side eid)))))})))
 
 (defmacro defcard
   [title ability]

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -1,6 +1,7 @@
 (ns game.core.revealing
   (:require
    [clojure.string :as string]
+   [game.core.eid :refer [effect-completed]]
    [game.core.engine :refer [trigger-event-sync]]
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [name-zone]]

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -24,7 +24,7 @@
 
 (defn reveal-loud
   "Trigger the event for revealing one or more cards, and also handle the log printout"
-  [state side eid card {:keys [forced and-then] :as args} & targets]
+  [state side eid card {:keys [forced and-then no-event] :as args} & targets]
   (let [cards-by-zone (group-by #(select-keys % [:side :zone]) (flatten targets))
         strs (map #(str (enumerate-str (map :title (get cards-by-zone %)))
                         " from " (name-zone (:side %) (:zone %)))
@@ -39,4 +39,6 @@
                                                (string/capitalize (name side)) " to reveal "
                                                (enumerate-str strs) follow-up))
       (system-msg state side (str "uses " (:title card) " to reveal " (enumerate-str strs) follow-up)))
-    (reveal state side eid targets)))
+    (if-not no-event
+      (reveal state side eid targets)
+      (effect-completed state side eid))))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2770,7 +2770,7 @@
         (is (:corp-phase-12 @state) "Corp is in Step 1.2")
         (card-ability state :corp ibrahim 0)
         (click-prompt state :corp card-type)
-        (click-prompt state :corp (find-card card-name (:hand (get-runner))))
+        (click-card state :corp card-name)
         (end-phase-12 state :corp)
         (is (= (inc i) (-> (get-runner) :discard count)))))))
 
@@ -6357,19 +6357,19 @@
     (play-and-score state "15 Minutes")
     (is (last-log-contains? state "Sure Gamble, Hippo, and Endurance") "Revealed Runner grip")
     (is (changed? [(count (:hand (get-runner))) -1]
-          (click-prompt state :corp "Hippo"))
+          (click-card state :corp "Hippo"))
         "Hippo was discarded")
     (is (= 1 (count (:discard (get-runner)))))
     (play-and-score state "15 Minutes")
     (is (changed? [(count (:hand (get-runner))) -1]
-          (click-prompt state :corp "Sure Gamble"))
+          (click-card state :corp "Sure Gamble"))
         "Sure Gamble was discarded")
     (is (= 2 (count (:discard (get-runner)))))
     (take-credits state :corp)
     (run-empty-server state "Server 2")
     (click-prompt state :runner "Steal")
     (is (changed? [(count (:hand (get-runner))) -1]
-          (click-prompt state :corp "Endurance"))
+          (click-card state :corp "Endurance"))
         "Endurance was discarded")
     (is (= 3 (count (:discard (get-runner)))))))
 

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -7554,23 +7554,22 @@
     (is (waiting? state :runner) "Runner is waiting for Corp to boost")
     (click-prompt state :corp "0")
     (click-prompt state :runner "4")
-    (click-prompt state :runner (find-card "Ice Wall" (:hand (get-corp))))
-    (click-prompt state :runner (find-card "Enigma" (:hand (get-corp))))
-    (is (= #{"Ice Wall" "Enigma"} (->> (get-corp) :deck (map :title) (into #{}))))))
+    (click-card state :runner  "Ice Wall")
+    (click-card state :runner "Enigma")
+    (is-deck? state :corp ["Ice Wall" "Enigma"])))
 
 (deftest white-hat-single-card-selected
   ;; White Hat - can shuffle back just a single card
   (do-game
-    (new-game {:corp {:hand ["Ice Wall" "Ice Wall"]}
+    (new-game {:corp {:hand ["Ice Wall" "Enigma"]}
                :runner {:hand ["White Hat"]}})
     (take-credits state :corp)
     (run-empty-server state :archives)
     (play-from-hand state :runner "White Hat")
     (click-prompt state :corp "0")
     (click-prompt state :runner "4")
-    (is (= "Choose a card in HQ to shuffle into R&D (2 remaining)" (:msg (prompt-map :runner))))
-    (click-prompt state :runner (find-card "Ice Wall" (:hand (get-corp))))
-    (is (= "Choose a card in HQ to shuffle into R&D (1 remaining)" (:msg (prompt-map :runner))))
+    (is (= "Shuffle up to 2 cards into R&D" (:msg (prompt-map :runner))))
+    (click-card state :runner "Ice Wall")
     (click-prompt state :runner "Done")
     (is (no-prompt? state :runner))))
 

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -5438,9 +5438,8 @@
       (core/move state :runner (find-card "Kati Jones" (:discard (get-runner))) :hand)
       (play-from-hand state :corp "Neural EMP")
       (click-prompt state :corp "Yes")
-      (let [kati (find-card "Kati Jones" (:hand (get-runner)))]
-        (click-prompt state :corp kati) ; Chronos Protocol takes precedence over Ribs on Corp turn
-        (is (= 2 (count (:discard (get-runner)))) "Card chosen by Corp for first net damage")))))
+      (click-card state :corp "Kati Jones") ; Chronos Protocol takes precedence over Ribs on Corp turn
+      (is (= 2 (count (:discard (get-runner)))) "Card chosen by Corp for first net damage"))))
 
 (deftest titanium-ribs-vs-damage-stat
   (do-game

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2157,8 +2157,7 @@
       (click-prompt state :corp "Program")
       (card-subroutine state :corp ef 0)
       (is (= 0 (count (:discard (get-runner)))) "Heap is empty")
-      (is (= 2 (count (prompt-buttons :corp))) "Only options: Corroder and Done")
-      (click-prompt state :corp "Corroder")
+      (click-card state :corp "Corroder")
       (is (not (find-card "Corroder" (:hand (get-runner)))) "Corroder got trashed")
       (is (= 1 (count (:discard (get-runner)))) "Corroder in heap")
       (card-subroutine state :corp ef 0)
@@ -2953,7 +2952,7 @@
       (click-prompt state :corp "3") ; boost to trace strength 5
       (click-prompt state :runner "0")
       (click-prompt state :corp "Yes")
-      (click-prompt state :corp (find-card "Sure Gamble" (:hand (get-runner))))
+      (click-card state :corp "Sure Gamble")
       (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage"))))
 
 (deftest gold-farmer-subroutine-test

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -973,25 +973,24 @@
   (do-game
       (new-game {:corp {:id "Chronos Protocol: Selective Mind-mapping"
                         :hand [(qty "Neural EMP" 2)]}
-                 :runner {:deck [(qty "Imp" 3)]}})
+                 :runner {:deck ["Imp" "Ika" "Inti"]}})
       (take-credits state :corp)
       (damage state :corp :net 1)
       (click-prompt state :corp "Yes")
-      (let [imp (find-card "Imp" (:hand (get-runner)))]
-        (click-prompt state :corp imp)
-        (is (= 1 (count (:discard (get-runner)))))
-        (damage state :corp :net 1)
-        (is (no-prompt? state :corp) "No choice on second net damage")
-        (is (= 2 (count (:discard (get-runner)))))
-        (run-empty-server state "Archives")
-        (take-credits state :runner)
-        (core/move state :runner (find-card "Imp" (:discard (get-runner))) :hand)
-        (play-from-hand state :corp "Neural EMP")
-        (click-prompt state :corp "No")
-        (is (= 2 (count (:discard (get-runner)))) "Damage dealt after declining ability")
-        (play-from-hand state :corp "Neural EMP")
-        (is (no-prompt? state :corp) "No choice after declining on first damage")
-        (is (= 3 (count (:discard (get-runner))))))))
+      (click-card state :corp "Imp")
+      (is (= 1 (count (:discard (get-runner)))))
+      (damage state :corp :net 1)
+      (is (no-prompt? state :corp) "No choice on second net damage")
+      (is (= 2 (count (:discard (get-runner)))))
+      (run-empty-server state "Archives")
+      (take-credits state :runner)
+      (core/move state :runner (find-card "Imp" (:discard (get-runner))) :hand)
+      (play-from-hand state :corp "Neural EMP")
+      (click-prompt state :corp "No")
+      (is (= 2 (count (:discard (get-runner)))) "Damage dealt after declining ability")
+      (play-from-hand state :corp "Neural EMP")
+      (is (no-prompt? state :corp) "No choice after declining on first damage")
+      (is (= 3 (count (:discard (get-runner)))))))
 
 (deftest chronos-protocol-selective-mind-mapping-with-obokata-pay-4-net-damage-to-steal-only-3-damage-left-after-chronos-no-trigger-of-damage-prevent
     ;; with Obokata: Pay 4 net damage to steal. Only 3 damage left after Chronos. No trigger of damage prevent.
@@ -1006,7 +1005,7 @@
       (run-empty-server state "Server 1")
       (click-prompt state :runner "Pay to steal")
       (click-prompt state :corp "Yes")
-      (click-prompt state :corp (find-card "Inti" (:hand (get-runner))))
+      (click-card state :corp "Inti")
       (is (no-prompt? state :runner) "Feedback Filter net damage prevention opportunity not given")
       (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")))
 

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -927,7 +927,7 @@
       (new-game {:corp {:id "Chronos Protocol: Selective Mind-mapping"
                         :deck [(qty "Hedge Fund" 5)]
                         :hand ["Complete Image" "Priority Requisition"]}
-                 :runner {:hand [(qty "Sure Gamble" 5)]}})
+                 :runner {:hand ["Ika" (qty "Sure Gamble" 4)]}})
       (play-from-hand state :corp "Priority Requisition" "New remote")
       (take-credits state :corp)
       (run-empty-server state :remote1)
@@ -935,15 +935,13 @@
       (take-credits state :runner)
       (play-from-hand state :corp "Complete Image")
       (is (-> (get-runner) :discard count zero?) "heap should be empty")
-      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (click-prompt state :corp "Ika") ;; Complete Image
       (is (not (no-prompt? state :corp)) "Corp guessed right so should have another choice")
       (click-prompt state :corp "Yes") ;; Chronos Protocol
-      (click-prompt state :corp "Sure Gamble") ;; Chronos Protocol
-      (click-prompt state :corp "Sure Gamble") ;; Complete Image
-      (click-prompt state :corp "Sure Gamble") ;; Complete Image
-      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (click-card state :corp "Ika") ;; Chronos Protocol
+      (dotimes [_ 4]
+        (click-prompt state :corp "Sure Gamble")) ;; Complete Image
       (is (not (no-prompt? state :corp)) "Even when the runner has no cards in hand, Corp must choose again")
-      (click-prompt state :corp "Sure Gamble") ;; Complete Image
       (click-prompt state :corp "Sure Gamble") ;; Complete Image
       (is (no-prompt? state :corp) "Runner is flatlined so no more choices")
       (is (= 5 (-> (get-runner) :discard count)) "heap should have 5 cards")))

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2189,7 +2189,7 @@
       (take-credits state :runner)
       (card-ability state :corp (get-content state :remote2 0) 0)
       (click-prompt state :corp "Program")
-      (click-prompt state :corp "Cache")
+      (click-card state :corp "Cache")
       (is (no-prompt? state :runner) "Dummy Box not prompting to prevent trashing from hand")))
 
 (deftest earthrise-hotel


### PR DESCRIPTION
I think this is a really nice QOL feature. I just have to root out all the cards it applies to.

Essentially, there's not much reason for us to to use lists to pick cards out of our opponents hand unless only a subset of the cards is known. It's both clunky (in our interface) and clunky (in our code).

Some of the cards/systems I can hit (these are all done and this pr is ready):
* Snoop
* Focus Group
* [Vera Ivanovna Shuyskaya](https://netrunnerdb.com/en/card/33115)
* Engram Flush
* Ibrahim Salem
* Chronos Protocol's damage effect

Demo:
![with-revealed-hands.webm](https://github.com/user-attachments/assets/59b402e3-216c-47cc-ad58-7052edc0c669)


