### PR TITLE
basic functionality - swap sides command

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -564,6 +564,7 @@
                                                                  (not (ice? c))))}
                                     :effect (effect (swap-installed (first targets) (second targets)))}
                                    (make-card {:title "/swap-installed command"}) nil))
+            "/swap-sides" #(true)
             "/tag"        #(swap! %1 assoc-in [%2 :tag :base] (constrain-value value 0 1000))
             "/take-core" #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :brain (constrain-value value 0 1000)
                                                        {:card (make-card {:title "/damage command" :side %2})}))


### PR DESCRIPTION
Just adding my WIP as I go. This is intended as part of a teaching mode/new player mode, so the more experienced player can demonstrate a concept or show stuff.

* Since the command needs to manipulate the lobby, it needs to happen outside of the commands interface (in game.clj). I'll update it later to make it 1) a dedicated button and 2) not a regular command
* It needs to have double-sided consent (like undo turn)
* Right now, the stats panels on the left (where credits/etc are) don't update when sides get swapped. This is similar to starting a private game after ending another private game, with sides opposite. Fixing that bug will fix this bug - we essentially need to find a way to make those panels actually scry the gamestate for your side instead of checking some cached side in a cached view of the lobby somewhere.
* You should be able to swap back without consent (or revoke consent)
* Things should get logged

Sooner or later I'll figure this all out.