### PR TITLE
Explicit reveals

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3608,7 +3608,14 @@
                     :effect (effect (gain-credits :runner eid (rez-cost state side (get-card state (:card context)))))}])))}})
 
 (defcard "Spark of Inspiration"
-  (letfn [(install-program [state side eid card revealed-card rev-str]
+  (letfn [(shuffle-back [revealed-cards]
+            {:async true
+             :effect (req (wait-for
+                            (reveal-loud state side card
+                                         {:and-then "shuffle the Stack"} revealed-cards)
+                            (shuffle! state side :deck)
+                            (effect-completed state side eid)))})
+          (install-program [state side eid card revealed-card revealed-cards]
             (if (can-pay? state side (assoc eid :source card :source-type :runner-install)
                           revealed-card nil
                           [(->c :credit (install-cost state side revealed-card {:cost-bonus -10}))])
@@ -3618,47 +3625,35 @@
                  {:prompt (str "Install " (:title revealed-card) " paying 10 [Credits] less?")
                   :waiting-prompt true
                   :yes-ability
-                  {:msg (msg "reveal " rev-str " from the top of the stack")
-                   :async true
-                   :effect (req (wait-for (runner-install
-                                            state side
-                                            (make-eid state {:source card :source-type :runner-install})
-                                            revealed-card {:cost-bonus -10
-                                                           :msg-keys {:install-source card
-                                                                        :display-origin true}})
-                                          (shuffle! state side :deck)
-                                          (system-msg state side "shuffles the Stack")
-                                          (effect-completed state side eid)))}
-                  :no-ability
-                  {:msg (msg "reveal " rev-str " from the top of the stack")
-                   :effect (effect (shuffle! :deck)
-                                   (system-msg "shuffles the Stack"))}}}
+                  {:async true
+                   :effect (req (wait-for
+                                  (reveal-loud state side card nil revealed-cards)
+                                  (wait-for
+                                    (runner-install
+                                      state side
+                                      (make-eid state {:source card :source-type :runner-install})
+                                      revealed-card {:cost-bonus -10
+                                                     :msg-keys {:install-source card
+                                                                :display-origin true}})
+                                    (shuffle! state side :deck)
+                                    (system-msg state side "shuffles the Stack")
+                                    (effect-completed state side eid))))}
+                  :no-ability (shuffle-back revealed-cards)}}
                 card nil)
-              (continue-ability ;;can't afford to install it somehow
-                state side
-                {:msg (msg "reveal " rev-str " from the top of the stack")
-                 :effect (effect (shuffle! :deck)
-                                 (system-msg "shuffles the Stack"))}
-                card nil)))
-          (spark-search-fn [state side eid card remainder rev-str]
+              ;;can't afford to install it somehow
+              (continue-ability state side (shuffle-back revealed-cards) card nil)))
+          (spark-search-fn [state side eid card remainder revealed-cards]
             (if (not-empty remainder)
               (let [revealed-card (first remainder)
                     rest-of-deck (rest remainder)
-                    rev-str (if (= "" rev-str)
-                              (:title revealed-card)
-                              (str rev-str ", " (:title revealed-card)))]
+                    revealed-cards (conj revealed-cards revealed-card)]
                 (if (program? revealed-card)
-                  (install-program state side eid card revealed-card rev-str)
-                  (spark-search-fn state side eid card rest-of-deck rev-str)))
-              (continue-ability
-                state side
-                {:msg (msg "reveal " rev-str " from the top of the stack")
-                 :effect (effect (shuffle! :deck)
-                                 (system-msg "shuffles the Stack"))}
-                card nil)))]
+                  (install-program state side eid card revealed-card revealed-cards)
+                  (spark-search-fn state side eid card rest-of-deck revealed-cards)))
+              (continue-ability state side (shuffle-back revealed-cards) card nil)))]
     {:on-play {:async true
                :change-in-game-state (req (seq (:deck runner)))
-               :effect (effect (spark-search-fn eid card (:deck runner) ""))}}))
+               :effect (effect (spark-search-fn eid card (:deck runner) []))}}))
 
 (defcard "Spear Phishing"
   {:makes-run true

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -429,6 +429,7 @@
    :encounters
    :end-turn
    :gameid
+   :last-revealed
    :log
    :mark
    :options

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -20,7 +20,9 @@
 (defn reveal
   "Trigger the event for revealing one or more cards."
   [state side eid & targets]
-  (apply trigger-event-sync state side eid (if (= :corp side) :corp-reveal :runner-reveal) (flatten targets)))
+  (let [cards (flatten targets)]
+    (swap! state assoc :last-revealed cards)
+    (apply trigger-event-sync state side eid (if (= :corp side) :corp-reveal :runner-reveal) cards)))
 
 (defn reveal-loud
   "Trigger the event for revealing one or more cards, and also handle the log printout"

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -60,6 +60,8 @@
     ;; Fix for Hayley triggers
     (swap! state assoc :turn-events nil)
     (swap! state assoc-in [side :turn-started] true)
+    ;; clear out last-revealed so cards don't stick around all game
+    (swap! state assoc :last-revealed [])
 
     ;; Functions to set up state for undo-turn functionality
     (doseq [s [:runner :corp]] (swap! state dissoc-in [s :undo-turn]))

--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -739,6 +739,7 @@
           :play-area "Play Area"
           :current "Current"
           :scored-area "Scored Area"
+          :last-revealed "Last Revealed"
           :archives "Archives"
           :max-hand "Max hand size"
           :brain-damage "Core Damage"

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -2272,7 +2272,7 @@
                     [button-pane {:side me-side :active-player active-player :run run :encounters encounters
                                   :end-turn end-turn :runner-phase-12 runner-phase-12
                                   :corp-phase-12 corp-phase-12 :corp corp :runner runner
-                                  :me            me :opponent opponent :prompt-state prompt-state}])]]
+                                  :me me :opponent opponent :prompt-state prompt-state}])]]
 
                 [:div.me
                  [hand-view me-side me-hand me-hand-size me-hand-count prompt-state true]]]]

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -2152,7 +2152,7 @@
        :reagent-render
        (fn []
         (when (and @corp @runner @side true)
-          (let [me-side (if (= :spectator @side)
+           (let [me-side (if (= :spectator @side)
                           (or (spectate-side) :corp)
                           @side)
                  op-side (utils/other-side me-side)
@@ -2248,6 +2248,7 @@
                         op-set-aside (r/cursor game-state [op-side :set-aside])
                         op-current (r/cursor game-state [op-side :current])
                         op-play-area (r/cursor game-state [op-side :play-area])
+                        last-revealed (r/cursor game-state [:last-revealed])
                         me-rfg (r/cursor game-state [me-side :rfg])
                         me-set-aside (r/cursor game-state [me-side :set-aside])
                         me-current (r/cursor game-state [me-side :current])
@@ -2262,7 +2263,8 @@
                      [play-area-view op-user (tr [:game.play-area "Play Area"]) op-play-area]
                      [play-area-view me-user (tr [:game.play-area "Play Area"]) me-play-area]
                      [rfg-view op-current (tr [:game.current "Current"]) false]
-                     [rfg-view me-current (tr [:game.current "Current"]) false]])
+                     [rfg-view me-current (tr [:game.current "Current"]) false]
+                     [rfg-view last-revealed (tr [:game.last-revealed "Last Revealed"]) false]])
                   (when (or (not= @side :spectator)
                             (and (spectator-view-hidden?) (spectate-side)))
                     [button-pane {:side me-side :active-player active-player :run run :encounters encounters


### PR DESCRIPTION
Whenever a set of cards get revealed, it gets placed in the top left corner. 
We then clear it out at the start of the turn so one reveal doesn't stick around for a whole game in something like celebrity gift palana.

[explicit-reveal.webm](https://github.com/user-attachments/assets/9863c0e8-e063-4290-af48-e6c927a54501)

I tweaked rfg-view to optionally pass on if the cards are unclickable, and set it to do so for the "most recently revealed" section.

I also made it so cards which are unclickable are also undraggable.

Then I fixed one of my pet peeves because it was in the same spot - the set-aside view no longer pops the expanded menu open/shut when you click on cards.

Closes #7872
Closes #6630