### PR TITLE
More cards wait

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -2174,6 +2174,7 @@
                 (effect
                   (continue-ability
                     {:show-discard true
+                     :waiting-prompt true
                      :choices {:req (req (and (in-discard? target)
                                               (program? target)
                                               (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1067,6 +1067,7 @@
                   :label "Install an ice from HQ or Archives"
                   :prompt "Choose an ice to install from Archives or HQ"
                   :show-discard true
+                  :waiting-prompt true
                   :choices {:card #(and (ice? %)
                                         (or (in-hand? %)
                                             (in-discard? %)))}

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -4770,6 +4770,7 @@
         (click-card state :runner "Corroder")
         (is (changed? [(:credit (get-runner)) 0]
               (card-ability state :runner (get-hardware state 0) 0)
+              (waiting? state :corp)
               (click-card state :runner "Mantle"))
             "Mantle is installed for free")
         (is (get-program state 0) "Mantle is installed for free")))

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1294,6 +1294,7 @@
       (rez state :corp bran)
       (run-continue state)
       (card-subroutine state :corp bran 0)
+      (waiting? state :runner)
       (is (changed? [(:credit (get-corp)) 0]
             (click-card state :corp "Mausolus"))
           "Mausolus installed for free")


### PR DESCRIPTION
Bran and simulchip have waiting prompts.

Adding a blanket waiting to every prompt would be problematic because I think there would be a lot of cases where you leak hidden info. It's easy enough to just keep catching them as they get reported.

Closes #7881