### PR TITLE
Allow disabling websockets in profile settings

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -61,6 +61,7 @@
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
   (swap! app-state assoc-in [:options :deckstats] (:deckstats @s))
+  (swap! app-state assoc-in [:options :disable-websockets] (:disable-websockets @s))
   (.setItem js/localStorage "sounds" (:sounds @s))
   (.setItem js/localStorage "default-format" (:default-format @s))
   (.setItem js/localStorage "lobby_sounds" (:lobby-sounds @s))
@@ -80,6 +81,7 @@
   (.setItem js/localStorage "card-back" (:card-back @s))
   (.setItem js/localStorage "card-zoom" (:card-zoom @s))
   (.setItem js/localStorage "pin-zoom" (:pin-zoom @s))
+  (.setItem js/localStorage "disable-websockets" (:disable-websockets @s))
   (post-options url (partial post-response s)))
 
 (defn add-user-to-block-list
@@ -596,6 +598,15 @@
                                                  :on-click #(remove-user-from-block-list % s)} "X" ]
                     [:span.blocked-user-name (str "  " bu)]]))]
 
+         [:section
+          [:h3  (tr [:settings.connection "Connection"])]
+          [:div
+           [:label [:input {:type "checkbox"
+                            :name "disable-websockets"
+                            :checked (:disable-websockets @s)
+                            :on-change #(swap! s assoc-in [:disable-websockets] (.. % -target -checked))}]
+            (tr [:settings.disable-websockets "Disable websockets - requires browser refresh after clicking Update Profile [Not Recommended!]"])]]]
+
      [api-keys s]
 
      [:section
@@ -634,7 +645,8 @@
                        :log-player-highlight (get-in @app-state [:options :log-player-highlight])
                        :gamestats (get-in @app-state [:options :gamestats])
                        :deckstats (get-in @app-state [:options :deckstats])
-                       :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]
+                       :blocked-users (sort (get-in @app-state [:options :blocked-users]))
+                       :disable-websockets (get-in @app-state [:options :disable-websockets])})]
 
     (go (let [response (<! (GET "/profile/email"))]
           (when (= 200 (:status response))

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -53,7 +53,8 @@
                             :log-player-highlight (get-local-value "log-player-highlight" "blue-red")
                             :sounds (= (get-local-value "sounds" "true") "true")
                             :lobby-sounds (= (get-local-value "lobby_sounds" "true") "true")
-                            :sounds-volume (str->int (get-local-value "sounds_volume" "100"))}
+                            :sounds-volume (str->int (get-local-value "sounds_volume" "100"))
+                            :disable-websockets (= (get-local-value "disable-websockets" "false") "true")}
                            (:options (js->clj js/user :keywordize-keys true)))
 
            :cards-loaded false

--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -15,7 +15,7 @@
         (sente/make-channel-socket-client!
           "/chsk"
           ?csrf-token
-          {:type :auto
+          {:type (if (get-in @app-state [:options :disable-websockets]) :ajax :auto)
            :wrap-recv-evs? false})]
     (def chsk chsk)
     (def ch-chsk ch-recv)


### PR DESCRIPTION
Seems like quite a few UK players (on BT internet provider, 33% of UK) are running into issues again where the websocket connection is getting dropped precisely every 20 seconds - this is the same behavior that was seen in summer of 2023.

Adding a setting that lets a player just disable the websocket connections completely with note that this is not recommended if otherwise working. I don't actually store this in the server as I don't think that makes sense and if someone signed in from a different machine or connection it's probably better we just assume websockets will work and require updating the setting again locally if it needs to be. This also means it will persist across different accounts on the same machine / browser session which is also probably preferable.