### PR TITLE
async validation via context-free grammar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,6 +65,7 @@
                  [integrant "0.8.0"]
                  [com.widdindustries/cljc.java-time "0.1.21"]
                  [time-literals "0.1.5"]
+                 [instaparse "1.5.0"]
                  [metosin/reitit "0.5.18"]]
 
   :test-selectors {:default (fn [m] (not (:kaocha/pending m)))}
@@ -78,7 +79,8 @@
                                   [lambdaisland/kaocha "1.68.1059"]
                                   [thheller/shadow-cljs "2.16.8"]]
                    :plugins [[lein-eftest "0.6.0"]
-                             [cider/cider-nrepl "0.47.1"]]
+                             [cider/cider-nrepl "0.47.1"]
+                             ]
                    :eftest {:report eftest.report.pretty/report
                             :fail-fast? false}
                    :source-paths ["src/clj" "src/cljs" "src/cljc" "src/css"

--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,6 @@
                  [integrant "0.8.0"]
                  [com.widdindustries/cljc.java-time "0.1.21"]
                  [time-literals "0.1.5"]
-                 [instaparse "1.5.0"]
                  [metosin/reitit "0.5.18"]]
 
   :test-selectors {:default (fn [m] (not (:kaocha/pending m)))}
@@ -75,12 +74,12 @@
                                   [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
                                   [rewrite-clj "1.1.45"]
                                   [criterium "0.4.6"]
+                                  [instaparse "1.5.0"]
                                   [integrant/repl "0.3.2"]
                                   [lambdaisland/kaocha "1.68.1059"]
                                   [thheller/shadow-cljs "2.16.8"]]
                    :plugins [[lein-eftest "0.6.0"]
-                             [cider/cider-nrepl "0.47.1"]
-                             ]
+                             [cider/cider-nrepl "0.47.1"]]
                    :eftest {:report eftest.report.pretty/report
                             :fail-fast? false}
                    :source-paths ["src/clj" "src/cljs" "src/cljc" "src/css"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1585,7 +1585,8 @@
                 :req (req (pos? (get-counters card :agenda)))
                 :msg (msg "add " (:title target) " to HQ from R&D")
                 :choices (req (cancellable (:deck corp) :sorted))
-                :cancel-effect (effect (system-msg (str "declines to use " (:title card))))
+                :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
+                                       (effect-completed eid))
                 :effect (effect (shuffle! :deck)
                                 (move target :hand))}]})
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -350,6 +350,7 @@
                 :cost [(->c :trash-from-deck 1) (->c :agenda 1)]
                 :once :per-turn
                 :msg "add 1 card from Archives to HQ"
+                :async true
                 :effect (effect (continue-ability (corp-recur) card nil))}]})
 
 (defcard "Bellona"
@@ -630,7 +631,8 @@
              :psi {:req (req (= :hq (target-server context))
                              (first-event? state side :successful-run
                                            #(= :hq (target-server (first %)))))
-                   :not-equal {:effect (effect (register-lingering-effect
+                   :not-equal {:async true
+                               :effect (effect (register-lingering-effect
                                                  card
                                                  {:type :corp-choose-hq-access
                                                   :duration :end-of-run
@@ -703,9 +705,11 @@
     :waiting-prompt true
     :prompt "Choose a card to derez"
     :choices {:card #(rezzed? %)}
+    :async true
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (effect (derez target {:source-card card}))}})
+    :effect (effect (derez target {:source-card card})
+                    (effect-completed eid))}})
 
 (defcard "Eden Fragment"
   {:static-abilities [{:type :ignore-install-cost
@@ -865,8 +869,7 @@
                                     :msg "add 1 card in HQ to the top of R&D"
                                     :choices {:card #(and (in-hand? %)
                                                           (corp? %))}
-                                    :effect (effect (move target :deck {:front true})
-                                                    (effect-completed eid))}
+                                    :effect (effect (move target :deck {:front true}))}
                                    card nil))))}]})
 
 (defcard "Fly on the Wall"
@@ -1044,6 +1047,7 @@
                 :msg "do 1 net damage"
                 :req (req (:run @state))
                 :once :per-run
+                :async true
                 :effect (effect (damage eid :net 1 {:card card}))}]})
 
 (defcard "Hybrid Release"
@@ -1497,6 +1501,7 @@
   {:on-score {:interactive (req true)
               :req (req (pos? (count (:scored runner))))
               :msg (msg "do " (count (:scored runner)) " net damage")
+              :async true
               :effect (effect (damage eid :net (count (:scored runner)) {:card card}))}})
 
 (defcard "Post-Truth Dividend"
@@ -1534,6 +1539,7 @@
                 :req (req tagged)
                 :cost [(->c :click 1)]
                 :keep-menu-open :while-clicks-left
+                :async true
                 :effect (effect (damage eid :meat 1 {:card card}))
                 :msg "do 1 meat damage"}]})
 
@@ -1802,7 +1808,8 @@
                                      (update-all-agenda-points state)
                                      (check-win-by-agenda state side)
                                      (effect-completed state side eid)))
-              :cancel-effect (effect (system-msg (str "declines to use " (:title card))))}})
+              :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
+                                     (effect-completed state side eid))}})
 
 (defcard "Regulatory Capture"
   {:advancement-requirement (req (- (min 4 (count-bad-pub state))))})
@@ -1962,10 +1969,11 @@
                                          (effect-completed state side eid))))}]})
 
 (defcard "Sentinel Defense Program"
-  {:events [{:event :pre-resolve-damage
-             :req (req (and (= target :brain)
-                            (pos? (last targets))))
+  {:events [{:event :damage
+             :req (req (and (pos? (:amount context))
+                            (= (:damage-type context) :brain)))
              :msg "do 1 net damage"
+             :async true
              :effect (effect (damage eid :net 1 {:card card}))}]})
 
 (defcard "Show of Force"
@@ -2200,6 +2208,7 @@
    :on-access {:psi {:req (req (not installed))
                      :not-equal
                      {:msg "prevent itself from being stolen"
+                      :async true
                       :effect (effect (register-run-flag!
                                         card :can-steal
                                         (fn [_ _ c] (not (same-card? c card))))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -475,6 +475,7 @@
                :prompt "Draw 2 cards?"
                :player :corp
                :yes-ability {:msg "draw 2 cards"
+                             :async true
                              :effect (effect (draw eid 2))}}}})
 
 (defcard "Capital Investors"
@@ -709,6 +710,7 @@
                 :waiting-prompt true
                 :choices {:card #(and (ice? %)
                                       (get-counters % :advancement))}
+                :async true
                 :effect (effect
                           (continue-ability
                             (let [from-ice target]
@@ -1469,6 +1471,7 @@
     {:abilities [ability]
      :leave-play cleanup
      :events [{:event :corp-spent-click
+               :async true
                :effect (req (let [{:keys [action value ability-idx]} context
                                   bac-cid (get-in @state [:corp :basic-action-card :cid])
                                   cause (if (keyword? action)
@@ -1481,8 +1484,9 @@
                                   clicks-spent (+ (get-in card [:seen-this-turn cause] 0) value)
                                   card (update! state side (assoc-in card [:seen-this-turn cause] clicks-spent))]
                               ; can be >= 3 because :once :per-turn on ability
-                              (when (>= clicks-spent 3)
-                                (resolve-ability state side ability card nil))))}
+                              (if (>= clicks-spent 3)
+                                (resolve-ability state side eid ability card nil)
+                                (effect-completed state side eid))))}
               {:event :corp-turn-ends
                :effect cleanup}]}))
 
@@ -1490,8 +1494,10 @@
   {:derezzed-events [corp-rez-toast]
    :flags {:corp-phase-12 (req true)}
    :abilities [{:msg "look at the top card of the stack"
+                :async true
                 :effect (effect (continue-ability
                                   {:prompt (req (->> runner :deck first :title (str "The top card of the stack is ")))
+                                   :waiting-prompt true
                                    :choices ["OK"]}
                                   card nil))}
                {:async true
@@ -1557,6 +1563,7 @@
                      :choices {:req (req (and (agenda? target)
                                               (<= (:agendapoints target) (cost-value eid :x-power))))}
                      :msg (msg "reveal " (:title target) " from HQ")
+                     :async true
                      :effect (req (wait-for (reveal state side target)
                                             (let [title (:title target)]
                                               (register-turn-flag!
@@ -1938,6 +1945,7 @@
                   :prompt "Draw 1 card?"
                   :yes-ability
                   {:msg "draw 1 card"
+                   :async true
                    :effect (effect (draw :corp eid 1))}}}]
     {:events [(-> ability
                   (assoc :event :runner-lose-tag)
@@ -2173,12 +2181,14 @@
                 :async true
                 :req (req true)
                 :effect (req (add-counter state side card :power 1)
-                             (gain-credits state :corp eid 3)
-                             (damage-prevent state :corp :net 1))}
+                             (wait-for (gain-credits state :corp 3)
+                                       (damage-prevent state :corp :net 1)
+                                       (effect-completed state side eid)))}
                {:action true
                 :msg (msg "deal " (get-counters card :power) " net damage")
                 :label "deal net damage"
                 :cost [(->c :click 2) (->c :trash-can)]
+                :async true
                 :effect (effect (damage eid :net (get-counters card :power) {:card card}))}]})
 
 (defcard "Primary Transmission Dish"
@@ -2255,6 +2265,7 @@
                           :choices {:card #(and (ice? %)
                                                 (not (rezzed? %)))}
                           :msg (msg "rez " (:title target))
+                          :waiting-prompt true
                           :effect (req (let [agenda (last (:rfg corp))
                                              ap (:agendapoints agenda 0)]
                                          (wait-for (rez state side target {:no-warning true :cost-bonus (* ap -2)})
@@ -2264,6 +2275,7 @@
     {:abilities [{:label "Forfeit agenda to rez up to 3 pieces of ice with a 2 [Credit] discount per agenda point"
                   :req (req (pos? (count (:scored corp))))
                   :cost [(->c :forfeit)]
+                  :async true
                   :effect (req (continue-ability state side (rez-ice 1) card nil))}]}))
 
 (defcard "Raman Rai"
@@ -2435,6 +2447,7 @@
         ability {:once :per-turn
                  :req (req (:corp-phase-12 @state))
                  :label "Remove 1 counter (start of turn)"
+                 :async true
                  :effect (req (add-counter state side card :power -1)
                               (if (zero? (get-counters (get-card state card) :power))
                                 (wait-for (trash state side card {:cause-card card})
@@ -3204,6 +3217,7 @@
                 :label "Gain 3 [Credits]"
                 :msg "gain 3 [Credits]"
                 :keep-menu-open :while-power-tokens-left
+                :async true
                 :effect (req (gain-credits state side eid 3))}
                {:action true
                 :cost [(->c :click 1) (->c :power 5)]

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -165,6 +165,7 @@
                 :req (req (not-empty (:deck runner)))
                 :cost [(->c :click)]
                 :msg "draw 1 card"
+                :async true
                 :effect (req (trigger-event state side :runner-click-draw {:card (-> @state side :deck (nth 0))})
                              (swap! state update-in [:stats side :click :draw] (fnil inc 0))
                              (play-sfx state side "click-card")

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1638,7 +1638,7 @@
                            ["Done"])
                 :async true
                 :effect
-                (req (letfn [(log-and-trash-cards [cards]
+                (req (letfn [(log-and-trash-cards [cards eid]
                                (system-msg state side
                                            (str "uses " (get-title card)
                                                 " to trash "
@@ -1646,14 +1646,14 @@
                                                 " from the top of the stack"))
                                (trash-cards state side eid cards {:unpreventable true :cause-card card}))]
                        (if (= target "Done")
-                         (log-and-trash-cards top-ten)
+                         (log-and-trash-cards top-ten eid)
                          (let [number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck))]
                            (wait-for (runner-install state side (make-eid state {:source card :source-type :runner-install})
                                                      target {:cost-bonus -5
                                                              :msg-keys {:display-origin true
                                                                         :install-source card}})
                                      (if (= number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck)))
-                                       (log-and-trash-cards (remove #(same-card? % target) top-ten))
+                                       (log-and-trash-cards (remove #(same-card? % target) top-ten) eid)
                                        (do (system-msg state side "does not have to trash cards because the stack was shuffled")
                                            (effect-completed state side eid))))))))}
                card nil))})

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2311,7 +2311,8 @@
                                                                              " from the heap into the stack, and draws 1 card"))
                                               (shuffle! state :runner :deck)
                                               (draw state :runner eid 1))}
-                                {:effect (effect
+                                {:async true
+                                 :effect (effect
                                            (do (system-msg state :runner "shuffles the stack and draws 1 card")
                                                (shuffle! state :runner :deck)
                                                (draw state :runner eid 1)))})
@@ -3765,6 +3766,7 @@
    :events [{:event :run-ends
              :req (req this-card-run)
              :msg "take 1 core damage"
+             :async true
              :effect (effect (damage eid :brain 1 {:unpreventable true
                                                    :card card}))}]})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4078,8 +4078,7 @@
 
 (defcard "Uninstall"
   {:on-play
-   {:async true
-    :change-in-game-state (req (some #(and (not (facedown? %))
+   {:change-in-game-state (req (some #(and (not (facedown? %))
                                      (or (hardware? %) (program? %)))
                                (all-installed state :runner)))
     :choices {:card #(and (installed? %)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -329,13 +329,15 @@
                                (move state side c :hand)))}
                {:label "Add all hosted cards to the grip"
                 :trash-icon true
-                :effect (req (doseq [c (:hosted card)]
-                               (move state side c :hand))
-                             (continue-ability
-                               state side
-                               {:cost [(->c :trash-can)]
-                                :msg "add all hosted cards to the grip"}
-                               (get-card state card) nil))}]})
+                :async true
+                :effect (req (let [hosted-cards (:hosted card)]
+                               (doseq [c hosted-cards]
+                                 (move state side c :hand))
+                               (continue-ability
+                                 state side
+                                 {:cost [(->c :trash-can)]
+                                  :msg (msg "add " (quantify (count hosted-cards) "hosted card") " to the grip")}
+                                 card nil)))}]})
 
 (defcard "Boomerang"
   (auto-icebreaker
@@ -560,6 +562,7 @@
                                          (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                    [(->c :credit (install-cost state side target))])))}
                 :cost [(->c :trash-can)]
+                :async true
                 :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:msg-keys {:install-source card
                                                                                                                          :display-origin true
                                                                                                                          :include-cost-from-eid eid}}))}]})
@@ -2180,6 +2183,7 @@
                                               (program? target)
                                               (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                         [(->c :credit (install-cost state side target {:cost-bonus -3}))])))}
+                     :async true
                      :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3
                                                                                                                    :msg-keys {:display-origin true
                                                                                                                               :install-source card
@@ -2231,6 +2235,7 @@
    :events [{:event :successful-trace
              :req (req run)
              :msg "suffer 1 core damage"
+             :async true
              :effect (effect (damage eid :brain 1 {:card card}))}]
    :interactions {:pay-credits {:req (req (and (= :ability (:source-type eid))
                                                (has-subtype? target "Icebreaker")))
@@ -2262,6 +2267,7 @@
                {:label "Look at the top card of R&D"
                 :msg "look at the top card of R&D"
                 :cost [(->c :trash-can)]
+                :async true
                 :effect (effect (continue-ability
                                   {:prompt (req (->> corp :deck first :title (str "The top card of R&D is ")))
                                    :choices ["OK"]}
@@ -2338,6 +2344,7 @@
                          (when second-card (str "Install " (:title second-card)))
                          "No install"]
                :msg (msg "reveal " rev-str " from the top of the stack")
+               :async true
                :effect (req (if-not (= target "No install")
                               (wait-for (runner-install
                                           state side
@@ -2370,8 +2377,8 @@
                 (continue-ability
                   state side
                   {:msg (msg "reveal " rev-str " from the top of the stack")
-                  :effect (effect (shuffle! :deck)
-                                  (system-msg "shuffles the Stack"))}
+                   :effect (effect (shuffle! :deck)
+                                   (system-msg "shuffles the Stack"))}
                   card nil)
                 (install-choice state side eid card rev-str first-card nil))))]
     {:abilities [{:cost [(->c :trash-can)]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1881,10 +1881,11 @@
      :yes-ability {:async true
                    :effect (req (trigger-event state side :searched-stack)
                                 (shuffle! state :runner :deck)
-                                (when-let [c (some #(when (= (:title %) (:title card)) %)
+                                (if-let [c (some #(when (= (:title %) (:title card)) %)
                                                    (:deck runner))]
                                   (runner-install state side eid c {:msg-keys {:install-source card
-                                                                               :display-origin true}})))}}}})
+                                                                               :display-origin true}})
+                                  (effect-completed state side eid)))}}}})
 
 (defcard "Ramujan-reliant 550 BMI"
   {:interactions {:prevent [{:type #{:net :brain}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1616,6 +1616,7 @@
                                                                                (in-hand? %)
                                                                                (is-type? % cardtype))}
                                                          :msg (msg "trash " (:title target) " from the Grip")
+                                                         :async true
                                                          :effect (req (trash state side eid target {:cause :subroutine}))})
                                                       card nil))}])))}
      :subroutines [sub

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1275,9 +1275,11 @@
                                               trash-installed-sub
                                               (= target "Take 2 tags")
                                               {:msg (msg "force the Runner to " (decapitalize target))
+                                               :async true
                                                :effect (effect (gain-tags :runner eid 2 {:unpreventable true}))}
                                               (= target "Suffer 3 net damage")
                                               {:msg (msg "force the Runner to " (decapitalize target))
+                                               :async true
                                                :effect (req (pay state :runner eid card [(->c :net 3)]))})
                                             card targets))}
                                card nil))}]})
@@ -3271,7 +3273,8 @@
                   :effect (req (doseq [c targets]
                                  (move state :corp c :deck))
                                (shuffle! state :corp :deck))
-                  :cancel-effect (effect (shuffle! :corp :deck))
+                  :cancel-effect (effect (shuffle! :corp :deck)
+                                         (effect-completed eid))
                   :msg (msg "shuffle " (quantify (count targets) "card") " from HQ into R&D")}]})
 
 (defcard "NEXT Silver"
@@ -4420,7 +4423,8 @@
                   :prompt "Choose a card to add to HQ"
                   :msg "add a card from R&D to HQ"
                   :choices (req (cancellable (:deck corp) :sorted))
-                  :cancel-effect (effect (system-msg "cancels the effect of Watchtower"))
+                  :cancel-effect (effect (system-msg "cancels the effect of Watchtower")
+                                         (effect-completed eid))
                   :effect (effect (shuffle! :deck)
                                   (move target :hand))}]})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3953,7 +3953,6 @@
 (defcard "SYNC BRE"
   {:subroutines [(tag-trace 4)
                  (trace-ability 2 {:label "Runner reduces cards accessed by 1 for this run"
-                                   :async true
                                    :msg "reduce cards accessed for this run by 1"
                                    :effect (effect (access-bonus :total -1))})]})
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -209,6 +209,7 @@
                                          :all true
                                          :card #(and (runner? %)
                                                      (in-play-area? %))}
+                               :async true
                                :effect (req (wait-for
                                               (runner-install
                                                 state side
@@ -261,6 +262,7 @@
              :psi {:req (req (= target :rd))
                    :player :runner
                    :equal {:msg "access 1 additional card"
+                           :async true
                            :effect (effect (access-bonus :rd 1)
                                            (effect-completed eid))}}}]})
 
@@ -345,6 +347,7 @@
                                                      state side
                                                      (assoc eid :source-type :runner-install) % {:no-toast true}))
                                              (:hand runner))))
+                     :async true
                      :effect (req (wait-for (runner-install state :runner
                                                             (assoc (make-eid state eid) :source card :source-type :runner-install)
                                                             (assoc-in target [:special :street-artist] true) {:msg-keys {:install-source card
@@ -356,12 +359,15 @@
                                                 :interactive (req true)
                                                 :duration :end-of-run
                                                 :req (req (some #(get-in % [:special :street-artist]) (all-installed state :runner)))
+                                                :async true
                                                 :effect (req (doseq [program (filter #(get-in % [:special :street-artist]) (all-installed state :runner))]
                                                                (if (has-subtype? program "Trojan")
-                                                                 (update! state :runner (dissoc-in program [:special :street-artist]))
+                                                                 (do (update! state :runner (dissoc-in program [:special :street-artist]))
+                                                                     (effect-completed state side eid))
                                                                  (do
                                                                    (system-msg state side (str "uses " (:title card) " to trash " (:title program)))
-                                                                   (trash-cards state side eid [program] {:cause-card card})))))}])))}
+                                                                   (trash-cards state side eid [program] {:cause-card card})))))}])
+                                            (effect-completed state side eid)))}
                     card nil))}]})
 
 (defcard "Asa Group: Security Through Vigilance"
@@ -621,6 +627,7 @@
                 :label "Look at the top 3 cards of R&D"
                 :cost [(->c :click 1) (->c :power 1)]
                 :msg "look at the top 3 cards of R&D"
+                :async true
                 :effect (req (let [top (take 3 (:deck corp))]
                                (wait-for (resolve-ability state side
                                                           {:async true
@@ -1527,6 +1534,7 @@
                              :choices {:card #(and (corp? %)
                                                    (ice? %)
                                                    (in-hand? %))}
+                             :async true
                              :effect (req (wait-for (corp-install state side target nil {:msg-keys {:install-source card
                                                                                                     :display-origin true}})
                                                     (continue-ability state side (when (< n 3) (nd (inc n))) card nil)))})]
@@ -2124,6 +2132,7 @@
     {:events [{:event :action-resolved
                :req (req (= :runner side))
                :silent (req true)
+               :async true
                :effect (req (let [current-queue (get-in card [:special :previous-actions])
                                   filtered-context (relevant-keys context)]
                               (if (and (seq current-queue)
@@ -2133,7 +2142,8 @@
                                   (if (= 3 (count new-queue))
                                     (continue-ability state side gain-click-abi card nil)
                                     (effect-completed state side eid)))
-                                (update! state side (assoc-in card [:special :previous-actions] [filtered-context])))))}
+                                (do (update! state side (assoc-in card [:special :previous-actions] [filtered-context]))
+                                    (effect-completed state side eid)))))}
               {:event :runner-turn-begins
                :silent (req true)
                :effect (req (update! state side (assoc-in card [:special :previous-actions] nil)))}]}))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1080,7 +1080,8 @@
                                         :choices {:req (req (can-be-advanced? state target))}
                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))}
                                        card nil))
-                                 (toast state :corp (str "Unknown Jinteki Biotech: Life Imagined card: " flip) "error"))))}]})
+                                 (do (toast state :corp (str "Unknown Jinteki Biotech: Life Imagined card: " flip) "error")
+                                     (effect-completed state side eid)))))}]})
 
 (defcard "Jinteki: Personal Evolution"
   (let [ability {:async true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -3090,7 +3090,8 @@
                                             :req (req (same-card? (:host card) (:card context)))
                                             :async true
                                             :msg "gain 1 [Credit]"
-                                            :effect (effect (gain-credits eid 1))}])))))}})
+                                            :effect (effect (gain-credits eid 1))}]))
+                                      (effect-completed state side eid))))}})
 
 (defcard "Trick of Light"
   {:on-play

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -162,6 +162,7 @@
      :cost cost
      :msg (msg "increase its strength from " (get-strength card)
                " to " (+ strength (get-strength card)))
+     :async true
      :effect (effect (pump card strength)
                      (continue-ability (break-sub nil strength subtype {:repeatable false}) (get-card state card) nil))
      :pump strength}))
@@ -625,6 +626,7 @@
    :abilities [{:action true
                 :cost [(->c :click 1)]
                 :label "Host on another piece of ice"
+                :async true
                 :effect (req (let [b (get-card state card)
                                    hosted? (ice? (:host b))
                                    remote? (is-remote? (second (get-zone (:host b))))]
@@ -1214,6 +1216,7 @@
             {:event :runner-turn-begins
              :req (req (>= (get-virus-counters state card) 3))
              :msg "look at the top card of R&D"
+             :async true
              :effect (effect (continue-ability
                                {:prompt (req (->> corp :deck first :title (str "The top card of R&D is ")))
                                 :choices ["OK"]}
@@ -1502,6 +1505,7 @@
   (auto-icebreaker
     (let [abi {:label "Take 1 tag to place 2 virus counters (start of turn)"
                :once :per-turn
+               :async true
                :effect (req (wait-for (gain-tags state :runner 1)
                                       (if (not (get-in @state [:tag :tag-prevent]))
                                         (do (add-counter state side card :virus 2)
@@ -1943,6 +1947,7 @@
                                  :waiting-prompt true
                                  :yes-ability
                                  {:msg (msg "bypass " (card-str state current-ice))
+                                  :async true
                                   :effect (req
                                             (wait-for (trash state :runner (make-eid state eid) card
                                                              {:unpreventable :true
@@ -2005,7 +2010,8 @@
                                              (active-encounter? state)
                                              (<= (get-strength current-ice) (get-strength card))))
                                  :msg (msg "break " (quantify (cost-value eid :x-credits) "subroutine")
-                                             " on " (card-str state current-ice))
+                                           " on " (card-str state current-ice))
+                                 :async true
                                  :effect (effect
                                              (continue-ability
                                                (when (pos? (cost-value eid :x-credits))
@@ -2116,6 +2122,7 @@
   (let [break-abi {:label "Break X subroutines"
                    :cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
                    :break-cost [(->c :x-credits)(->c :turn-hosted-matryoshka-facedown 1)]
+                   :async true
                    :auto-break-creds-per-sub 1
                    :break 0 ;; technically not correct, but it's enough for the engine to pick up for auto-breaking
                    :break-req (req (active-encounter? state))
@@ -2503,6 +2510,7 @@
                     :heap-breaker-break :x ; number of subs broken
                     :break-req (req (and (active-encounter? state)
                                          (has-subtype? current-ice "Barrier")))
+                    :async true
                     :effect (effect (pump card (cost-value eid :x-credits))
                                     (continue-ability
                                       (break-sub nil (cost-value eid :x-credits) "Barrier" {:repeatable false})
@@ -2646,6 +2654,7 @@
                               :req (req (and (has-subtype? (:ice context) "Sentry")
                                              (rezzed? (:ice context))
                                              (pos? (count (:deck runner)))))
+                              :async true
                               :effect
                               (effect
                                 (continue-ability
@@ -3376,6 +3385,7 @@
                                   runner-draw]
                       :events [{:event :subroutines-broken
                                 :req (req (every? #(or (= (:breaker %) nil) (= (:breaker %) (:cid card))) (:subroutines (:ice context))))
+                                :async true
                                 :effect (req (continue-ability state side runner-draw card nil))}]})))
 
 (defcard "Unity"
@@ -3403,6 +3413,7 @@
     (auto-icebreaker {:abilities [{:label "Break X Code Gate subroutines"
                                    :cost [(->c :x-credits)]
                                    :break-cost [(->c :x-credits)]
+                                   :async true
                                    :once :per-run
                                    :req (req (and (break-req state side eid card targets)
                                                   (<= (get-strength current-ice) (get-strength card))))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1952,7 +1952,8 @@
                                             (wait-for (trash state :runner (make-eid state eid) card
                                                              {:unpreventable :true
                                                               :cause-card card})
-                                                      (bypass-ice state)))}}}
+                                                      (bypass-ice state)
+                                                      (effect-completed state side eid)))}}}
                                card nil))}]})
 
 (defcard "Leech"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1287,7 +1287,6 @@
   (letfn [(better-name [card-type] (if (= "hardware" card-type) "piece of hardware" card-type))
           (dummy-prevent [card-type]
             {:msg (str "prevent a " (better-name card-type) " from being trashed")
-             :async true
              :cost [(->c (keyword (str "trash-" card-type "-from-hand")) 1)]
              :effect (effect (trash-prevent (keyword card-type) 1))})]
     {:interactions {:prevent [{:type #{:trash-hardware :trash-resource :trash-program}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -711,6 +711,7 @@
                 :keep-menu-open :while-clicks-left
                 :label "Install a program from the grip"
                 :prompt "Choose a program to install"
+                :async true
                 :choices
                 {:async true
                  :req (req (and (program? target)
@@ -792,6 +793,7 @@
                                    :choices (req (iced-servers state side eid card))
                                    :msg (msg "choose " (zone->name (unknown->kw target))
                                              " and remove itself from the game")
+                                   :async true
                                    :effect (effect (continue-ability
                                                      :corp
                                                      (trash-or-bonus (rest (server->zone state target)))
@@ -998,6 +1000,7 @@
               {:event :runner-turn-begins
                :once :per-turn
                :interactive (req true)
+               :async true
                :effect
                (effect (continue-ability
                          {:msg "gain 1 [Credits]"
@@ -2660,6 +2663,7 @@
                      :choices {:card #(and (:trash %)
                                            (rezzed? %)
                                            (can-pay? state side (assoc eid :source card :source-type :ability) card nil [(->c :credit (trash-cost state :runner %))]))}
+                     :async true
                      :effect (effect
                                (continue-ability
                                  {:async true
@@ -3050,6 +3054,7 @@
 
 (defcard "Stim Dealer"
   {:events [{:event :runner-turn-begins
+             :async true
              :effect (req (if (>= (get-counters card :power) 2)
                             (do (add-counter state side card :power (- (get-counters card :power)))
                                 (damage state side eid :brain 1 {:unpreventable true :card card})
@@ -3074,6 +3079,7 @@
   (letfn [(runner-break [unbroken-subs]
             {:prompt "Choose a subroutine to resolve"
              :choices unbroken-subs
+             :async true
              :effect (req (let [sub (first (filter #(and (not (:broken %))
                                                          (= target (make-label (:sub-effect %))))
                                                    (:subroutines current-ice)))]
@@ -3295,6 +3301,7 @@
                                          (has-trash-ability? target)))}
                 :msg (msg "shuffle " (enumerate-str (map :title targets))
                           " into the stack")
+                :async true
                 :effect (req (doseq [c targets] (move state side c :deck))
                              (shuffle! state side :deck)
                              (effect-completed state side eid))}]})

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -385,7 +385,7 @@
                                    :async true
                                    :msg (msg "place an advancement token on " (card-str state target))
                                    :cost [(->c :trash-can)]
-                                   :effect (effect (add-prop target :advance-counter 1 {:placed true}))}
+                                   :effect (effect (add-prop eid target :advance-counter 1 {:placed true}))}
                                   card nil))}]})
 
 (defcard "Caprice Nisei"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -816,7 +816,7 @@
                 :req (req (and this-server
                                (pos? (count run-ices))
                                (pos? (count (:hand corp)))))
-                                :cost [(->c :trash-from-hand 1)]
+                :cost [(->c :trash-from-hand 1)]
                 :effect (effect (register-lingering-effect
                                   card
                                   {:type :ice-strength

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -88,9 +88,11 @@
              :interactive (req true)
              :psi {:req (req this-server)
                    :not-equal {:msg (msg "prevent the Runner from accessing cards other than " (:title card))
+                               :async true
                                :effect (effect (set-only-card-to-access card)
                                                (effect-completed eid))}
                    :equal {:msg (msg "prevent the Runner from accessing " (:title card))
+                           :async true
                            :effect (effect (register-run-flag!
                                              card :can-access
                                              ;; prevent access of advanced card
@@ -138,6 +140,7 @@
   {:expend {:req (req (threat-level 3 state))
             :cost [(->c :credit 1)]
             :msg "do 1 meat damage"
+            :async true
             :effect (effect (damage eid :meat 1 {:card card}))}
    :on-access {:optional
                {:req (req (rezzed? card))
@@ -190,6 +193,7 @@
                      :req (req this-server)
                      :successful
                      {:msg "prevent the Runner from accessing cards other than Ash 2X3ZB9CY"
+                      :async true
                       :effect (effect (set-only-card-to-access card)
                                       (effect-completed eid))}}}]})
 
@@ -330,6 +334,7 @@
                             (some #(and (ice? %)
                                         (not (same-card? % (:card context))))
                                   (all-active-installed state :corp))))
+             :async true
              :effect (req
                        (let [rezzed-card (:card context)]
                          (continue-ability

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -811,8 +811,7 @@
                 :req (req (and this-server
                                (pos? (count run-ices))
                                (pos? (count (:hand corp)))))
-                :async true
-                :cost [(->c :trash-from-hand 1)]
+                                :cost [(->c :trash-from-hand 1)]
                 :effect (effect (register-lingering-effect
                                   card
                                   {:type :ice-strength

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1688,18 +1688,18 @@
                      (count (:discard (get-runner))) 3]
                     (card-subroutine state :corp (refresh ce) 2))
           "Runner suffered 3 net damage")
-      (run-continue state :movement)
+      (run-continue-until state :movement)
       (is (= 2 (count (prompt-buttons :runner))) "Runner doesn't have the option to suffer net damage")
       (is (changed? [(count-tags state) 2]
                     (click-prompt state :runner "Take 2 tags"))
           "Runner got 2 tags")
-      (is (last-log-contains? state "Cloud Eater to force the Runner to take 2 tag") "Correctly logs choice")
+      (is (last-n-log-contains? state 1 "Cloud Eater to force the Runner to take 2 tag") "Correctly logs choice")
       (run-jack-out state)
       (take-credits state :runner)
       (take-credits state :corp)
       (run-on state :hq)
       (run-continue state)
-      (run-continue state :movement)
+      (run-continue-until state :encounter-ice)
       (is (no-prompt? state :runner) "Runner has no Cloud Eater prompt if it was rezzed since the previous turn"))))
 
 (deftest congratulations

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -8725,7 +8725,7 @@
         (is (changed? [(count (:hand (get-corp))) 1]
               (click-prompt state :corp "Yes"))
             "Corp drew 1 card")
-        (is (last-log-contains? state "Corp uses Umbrella to") "Corp side msg displayed right")
+        (is (last-n-log-contains? state 2 "Corp uses Umbrella to") "Corp side msg displayed right")
         (core/continue state :corp nil)
         (run-jack-out state)
         (run-on state "R&D")

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -879,13 +879,12 @@
     ;; Corp doesn't trash, access HQ
     (do-game
       (new-game {:runner {:deck ["Climactic Showdown"]}
-                 :corp {:deck [(qty "Vanilla" 10)]}})
+                 :corp {:deck [(qty "Vanilla" 3)]
+                        :hand [(qty "Vanilla" 3)]}})
       (play-from-hand state :corp "Vanilla" "Archives")
-      (core/move state :corp (find-card "Vanilla" (:hand (get-corp))) :deck)
       (take-credits state :corp)
       (play-from-hand state :runner "Climactic Showdown")
       (take-credits state :runner)
-      (core/move state :corp (find-card "Vanilla" (:hand (get-corp))) :deck)
       (take-credits state :corp)
       (is (= "Climactic Showdown" (-> (get-runner) :rfg first :title)) "Climactic Showdown RFGed")
       (click-prompt state :runner "Archives")

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -69,7 +69,7 @@
 
 ;; TODO - can add a few more to these as errors get picked up down the line
 (def terminal-fns #{"checkpoint" "complete-with-result" "continue-ability" "corp-install" "damage" "draw" "effect-completed" "gain-credits" "resolve-ability" "runner-install"
-                    "trash" "trash-cards" "trigger-event-sync" "wait-for"})
+                    "trash" "trash-cards" "trigger-event-simult" "trigger-event-sync" "wait-for"})
 (defn should-complete?
   "Should a chunk (probably) complete an eid?"
   [chunk depth]

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -68,7 +68,8 @@
     :else nil))
 
 ;; TODO - can add a few more to these as errors get picked up down the line
-(def terminal-fns #{"effect-completed" "complete-with-result" "wait-for" "continue-ability" "damage" "draw" "gain-credits" "resolve-ability"})
+(def terminal-fns #{"checkpoint" "complete-with-result" "continue-ability" "corp-install" "damage" "draw" "effect-completed" "gain-credits" "resolve-ability" "runner-install"
+                    "trash" "trash-cards" "trigger-event-sync" "wait-for"})
 (defn should-complete?
   "Should a chunk (probably) complete an eid?"
   [chunk depth]
@@ -133,4 +134,4 @@
       (let [invalid-chunks (filter (complement validate-chunk) chunks)
             titles (map #(re-find #" \".+?\"" %) invalid-chunks)]
         (when (seq titles)
-          (is nil (str "The following cards/fns in file" fname "may be invalid (async/sync): " (str/join ", " titles))))))))
+          (is nil (str "The following cards/fns in file '" fname "' may be invalid (async/sync): " (str/join ", " titles))))))))

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -194,7 +194,7 @@
         c3 "{:async true :effect (req (case x a (effect-completed state side eid) (effect-completed state side eid)))}"]
     (is (not (validate-chunk c1)) "Case block C1 is picked up as being wrong (terminal does not complete)")
     (is (not (validate-chunk c2)) "Case block C2 is picked up as being wrong (LHS does not complete)")
-    (is (validate-chunk c3)       "Case block C3 is picked up as being right (LHS and terminal both complete)")))x
+    (is (validate-chunk c3)       "Case block C3 is picked up as being right (LHS and terminal both complete)")))
 
 (deftest async-test-cond+-is-correct?
   (let [c1 "{:async true :effect (req (cond+ [a (damage state :runner)] [:else (effect-completed state side eid)]))}"

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -57,6 +57,8 @@
   [chunk depth]
   (cond
     (and (string? chunk) (zero? depth)) :maybe
+    ;; special case for fns which defer the def elsewhere
+    (and (vector? chunk) (= 2 (count chunk)) (zero? depth)) :maybe
     (and (vector? chunk) (= (first chunk) :FN))
     (let [func-name (second chunk)]
       (if (or (contains-eid? chunk)

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -130,5 +130,7 @@
   (doseq [fname relevant-cards-files]
     (let [f (slurp (str card-base-str fname))
           chunks (stitch-and-split-card-files f)]
-      (doseq [chunk chunks]
-        (is (validate-chunk chunk) (str "invalid chunk at " chunk))))))
+      (let [invalid-chunks (filter (complement validate-chunk) chunks)
+            titles (map #(re-find #" \".+?\"" %) invalid-chunks)]
+        (when (seq titles)
+          (is nil (str "The following cards/fns in file" fname "may be invalid (async/sync): " (str/join ", " titles))))))))

--- a/test/clj/game/core/async_test.clj
+++ b/test/clj/game/core/async_test.clj
@@ -1,0 +1,118 @@
+(ns game.core.async-test
+  (:require
+   [clojure.test :refer :all]
+   [instaparse.core :as insta]
+   [clojure.string :as str]))
+
+(def scuffed-grammar
+  (insta/parser
+    "<S>=P_EXPR*
+
+     <EXPR>=<COMMENT?>(S_EXPR|TOKEN|STR)
+     <P_EXPR>=<SPACE>EXPR<SPACE>
+     <COMMENT>='#_'
+     (* note that S_EXPR cannot contain tokens or strings, to prevent left-expansion *)
+     (* from eradicating the heap *)
+     <S_EXPR>=VEC|MAP|FN|SET
+     VEC=<'['>P_EXPR*<']'>
+     MAP=<'{'>KEYPAIR*<'}'>
+     FN=<('#(' | '(' | '\\'(' )>P_EXPR*<')'>
+     SET=<'#{'>P_EXPR*<'}'>
+     <KEYPAIR>=P_EXPR P_EXPR
+
+     (* basic strings and tokens *)
+     S_TOKEN=STR|TOKEN
+     <QUOT>=<'\"'>
+     <TOKEN>=#'[^\\s()\\[\\]{}#\\\"]*'
+     <SPACE>=<#'\\s'*>
+     (* note that we dont care about the contents of strings, we can just hide them *)
+     STR=<'#'?>QUOT<('\\\"' | #'[^\"]')*>QUOT"))
+
+(def card-base-str "src/clj/game/cards/")
+(def relevant-cards-files ["basic.clj" "agendas.clj" "assets.clj" "events.clj" "hardware.clj"
+                           "ice.clj" "identities.clj" "operations.clj" "programs.clj"
+                           "resources.clj" "upgrades.clj"])
+
+(defn stitch-and-split-card-files
+  [file]
+  (let [split-file (str/split file #"(?=\(def)")
+        restitch-fn (fn [chunk]
+                      (let [lines (str/split-lines chunk)
+                            ;; special case specifically for the hydra subs, which have semicolons
+                            sans-comments (map first (map #(str/split % #"(?<!tagged);" 2) lines))]
+                        (str/join " " (map str/trim sans-comments))))
+        split-and-stitch (map restitch-fn split-file)]
+    split-and-stitch))
+
+(defn- contains-eid?
+  [chunk]
+  (some #(cond
+           (string? %) (= % "eid")
+           (vector? %) (contains-eid? %)
+           :else nil)
+        chunk))
+
+(defn completes?
+  "does a chunk complete an eid (probably)?"
+  [chunk depth]
+  (cond
+    (and (string? chunk) (zero? depth)) :maybe
+    (and (vector? chunk) (= (first chunk) :FN))
+    (let [func-name (second chunk)]
+      (if (or (contains-eid? chunk)
+              (= func-name "continue-ability"))
+        :maybe
+        (completes? (last chunk) (inc depth))))
+    :else nil))
+
+(defn is-valid-chunk?
+  ([chunk]
+   (cond
+     (not (sequential? chunk)) true
+     (= :FN (first chunk)) (every? is-valid-chunk? (rest chunk))
+     (= :VEC (first chunk)) (every? is-valid-chunk? (rest chunk))
+     (= :SET (first chunk)) (every? is-valid-chunk? (rest chunk))
+     (= [:STR] chunk) true
+     (= :MAP (first chunk)) (is-valid-chunk? (rest chunk) :MAP)
+     (sequential? chunk) (every? is-valid-chunk? chunk)
+     :else true))
+  ([chunk conditional?]
+   (cond
+     (= conditional? :MAP)
+     (do ;;(println "Make a map out of: " chunk)
+         (let [keypairs (partition 2 chunk)
+               mapped (zipmap (map first keypairs) (map second keypairs))]
+           ;; if it contains an :effect, then:
+           ;;   see if it contains :async true. If it does, effect must complete eid
+           ;;   if it does not, effect should not complete the eid
+           (if (:effect mapped)
+             ;; TODO - prompts that are async may require the cancel effect to be async too
+             (if (:async mapped)
+               (is-valid-chunk? (:effect mapped) :async)
+               (is-valid-chunk? (:effect mapped) :sync))
+             (every? is-valid-chunk? (vals mapped)))))
+     (= conditional? :async)
+     (do (let [comp (completes? chunk 0)]
+           (and comp (is-valid-chunk? chunk))))
+     (= conditional? :sync)
+     (is-valid-chunk? chunk))))
+
+(defn clean-chunks
+  "remove the empties and nils, and swaps keywords in"
+  [chunks]
+  (cond
+    (= "" chunks) nil
+    (= "true" chunks) true
+    (= "nil" chunks) :nil
+    (and (string? chunks) (str/starts-with? chunks ":")) (keyword (subs chunks 1))
+    (sequential? chunks) (filterv identity (map clean-chunks chunks))
+    :else chunks))
+
+(defn validate-chunk [chunk] (->> chunk scuffed-grammar clean-chunks is-valid-chunk?))
+
+(deftest cards-are-async-test
+  (doseq [fname relevant-cards-files]
+    (let [f (slurp (str card-base-str fname))
+          chunks (stitch-and-split-card-files f)]
+      (doseq [chunk chunks]
+        (is (validate-chunk chunk) (str "invalid chunk at " chunk))))))


### PR DESCRIPTION
I wrote a parser for our card data to try and pick out
* (some) things that are marked async but dont complete
* (some) things that complete, but are not marked async
This is added in as a unit test, and (for now) only covers the card data (I'll look at expanding it to some of the core files later maybe)

And I'm also fixing the bugs it picks up.
What I picked up so far:
* Things that were async but didn't complete: `SYNC BRE, Calibration Testing, Dummy Box, Uninstall, Helheim Servers` (I fixed all of these)
* Things that are async, but did not complete: `Brasilia Govt. Grid, Ash, Angelique, Adrian, The Back, Street Magic, Stim Dealer, PolOp, Dadiana, Climactic Showdown, Chatergee University, Utae, Umbrella, Persephone, ... and lots more - there were ~70 or so` - I fixed all those too
* For things that are async, the following is checked:
  *  The rightmost member of the `:effect` function should terminate (complete it's eid, or call a function that does), or continue to another ability (via continue-ability).
  * If the rightmost member is an `if, if-not, if-let`, then there should be two members which both terminate
  * If the rightmost member is a `when, when-not, when-let`, then we've made a mistake, because that can fail to terminate
  * All the outputs of `condp`, `cond`, `case` and `cond+` terminate, where they exist (doesn't check that an :else/fallback actually exists though - whether that's needed is unknowable by a grammar)
  * if the RHS of an effect is a def sourced from elsewhere, it's currently not validated. Maybe I'll solve that later.

This adds the instaparse package as a dev dependency - see: https://github.com/Engelberg/instaparse

Essentially this should help us pick out (most) async errors before shipping code in the future.
