### PR TITLE
subliminal no longer oversteps it's eid

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2900,9 +2900,9 @@
               :yes-ability
               {:msg "reveal and add itself to HQ"
                :async true
-               :effect (req (wait-for (reveal state side (make-eid state eid) card))
-                            (move state side card :hand)
-                            (effect-completed state side eid))}}}]})
+               :effect (req (wait-for (reveal state side card)
+                                      (move state side card :hand)
+                                      (effect-completed state side eid)))}}}]})
 
 (defcard "Success"
   (letfn [(advance-n-times [state side eid card target n]


### PR DESCRIPTION
I noticed subliminal acted kind of funny when you played it.
Turns out there was an extra bracket jammed in there, like:
```Clojure
(wait-for (reveal ...))
(effect-competed ...)
```

I'm not writing a unit test for this one, but it doesn't break any unit tests.

Closes #6687