### PR TITLE
Forced encounter fix

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1154,7 +1154,7 @@
   {:events [{:event :subroutines-broken
              :optional
              {:req (req
-                     (let [pred (every-pred :all-subs-broken :outermost :during-run)]
+                     (let [pred (every-pred :all-subs-broken :outermost :during-run :on-attacked-server)]
                        (and (pred context)
                             (get-card state (:ice context))
                             (first-event? state side :subroutines-broken #(pred (first %))))))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -185,8 +185,7 @@
 (defn all-subs-broken?
   [ice]
   (let [subroutines (:subroutines ice)]
-    (and (seq subroutines)
-         (every? :broken subroutines))))
+    (every? :broken subroutines)))
 
 (defn any-subs-broken-by-card?
   [ice card]

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -539,6 +539,7 @@
   [state ice broken-subs breaker]
   {:outermost (when-let [server-ice (:ices (card->server state ice))] (same-card? ice (last server-ice)))
    :during-run (some? (:run @state))
+   :on-attacked-server (= (get-in @state [:run :server]) [(second (:zone ice))])
    :all-subs-broken (all-subs-broken? ice)
    :broken-subs broken-subs
    ;; enough info to backtrack and find breakers without bloating the gamestate

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -10,7 +10,7 @@
     [game.core.engine :refer [checkpoint end-of-phase-checkpoint register-pending-event pay queue-event resolve-ability trigger-event trigger-event-simult]]
     [game.core.flags :refer [can-run? cards-can-prevent? clear-run-register! get-prevent-list prevent-jack-out]]
     [game.core.gaining :refer [gain-credits]]
-    [game.core.ice :refer [active-ice? get-current-ice get-run-ices update-ice-strength reset-all-ice reset-all-subs! set-current-ice]]
+    [game.core.ice :refer [active-ice? break-subs-event-context get-current-ice get-run-ices update-ice-strength reset-all-ice reset-all-subs! set-current-ice]]
     [game.core.mark :refer [is-mark?]]
     [game.core.payment :refer [build-cost-string build-spend-msg can-pay? merge-costs ->c]]
     [game.core.prompts :refer [clear-run-prompts clear-wait-prompt show-run-prompts show-prompt show-wait-prompt]]
@@ -334,10 +334,15 @@
                                 (checkpoint state side eid)))))})
 
 (defn encounter-ice
+  ;; note: as far as I can tell, this deliberately leaves on open eid (the run eid).
+  ;; Attempting to change that breaks a very large number of tests, so I'm leaving this
+  ;; note here to remind me when I look at this later. -nbk, 2025
   [state side eid ice]
   (swap! state update :encounters conj {:eid eid
                                         :ice ice})
   (check-auto-no-action state)
+  ;; step 6.9.3a: The encounter begins. Conditions relating to the Runner encountering
+  ;; this ice are met (this is on-encounter effects, etc)
   (let [on-encounter (:on-encounter (card-def ice))
         applied-encounters (get-effects state nil :gain-encounter-ability ice)
         all-encounters (map #(preventable-encounter-abi % ice) (remove nil? (conj applied-encounters on-encounter)))]
@@ -349,8 +354,16 @@
                           (make-eid state)
                           {:cancel-fn (fn [state]
                                         (should-end-encounter? state side ice))})
-              (when (should-end-encounter? state side ice)
-                (encounter-ends state side eid)))))
+              (if (should-end-encounter? state side ice)
+                (encounter-ends state side eid)
+                ;; step 6.9.3b: if there are no subroutines on the ice,
+                ;; the runner is considered to have broken all the subroutines on this ice.
+                ;; This should fire an event, so it can get picked up with cards like hippo
+                ;; or knifed.
+                (when-let [c-ice (get-current-ice state)]
+                  (when (and (same-card? c-ice ice) (zero? (count (:subroutines c-ice))))
+                    (wait-for (trigger-event-simult state side :subroutines-broken nil (break-subs-event-context state c-ice [] (get-in @state [:runner :basic-action-card]))))))))))
+
 
 (defmethod start-next-phase :encounter-ice
   [state side _]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -375,9 +375,11 @@
                (if (and (not (:run @state))
                         (empty? (:encounters @state)))
                  (forced-encounter-cleanup state :runner eid)
-                 (do (when (and new-state (= new-state (get-in @state [:run :phase])))
-                       (set-phase state old-state))
-                     (effect-completed state side eid)))))))
+                 (do
+                   (when (and new-state (= new-state (get-in @state [:run :phase])))
+                     (set-phase state old-state))
+                   (set-current-ice state)
+                   (effect-completed state side eid)))))))
 
 (defmethod continue :encounter-ice
   [state side _]

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2678,6 +2678,27 @@
       (click-prompt state :runner "End the run")
       (is (no-prompt? state :runner) "No Hippo prompt on later ice")))
 
+(deftest hippo-interaction-with-konjin
+  (do-game
+    (new-game {:corp {:hand ["Ice Wall" "Konjin"]}
+               :runner {:hand ["Hippo" "Eater"] :credits 15}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Konjin" "R&D")
+    (rez state :corp (get-ice state :hq 0))
+    (rez state :corp (get-ice state :rd 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Hippo")
+    (play-from-hand state :runner "Eater")
+    (run-on state :rd)
+    (run-continue state :encounter-ice)
+    (is (= "Choose an amount to spend for Konjin" (:msg (prompt-map :corp))) "Psi Game")
+    (click-prompt state :corp "0 [Credits]")
+    (click-prompt state :runner "1 [Credits]")
+    (is (= "Choose a piece of ice" (:msg (prompt-map :corp))) "Prompt to choose Ice")
+    (click-card state :corp "Ice Wall")
+    (auto-pump-and-break state (get-program state 0))
+    (is (no-prompt? state :runner) "Not prompted to use hippo (we're not on the attacked server)")))
+
 (deftest hippocampic-mechanocytes
   ;; Hippocampic Mechanocytes
   (do-game

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2697,7 +2697,10 @@
     (is (= "Choose a piece of ice" (:msg (prompt-map :corp))) "Prompt to choose Ice")
     (click-card state :corp "Ice Wall")
     (auto-pump-and-break state (get-program state 0))
-    (is (no-prompt? state :runner) "Not prompted to use hippo (we're not on the attacked server)")))
+    (is (no-prompt? state :runner) "Not prompted to use hippo (we're not on the attacked server)")
+    (run-continue state :encounter-ice)
+    (click-prompt state :runner "Yes")
+    (is (= "Konjin" (-> (get-corp) :discard first :title)) "Trashed konjin with hippo (you have 'broken all subs' when the encounter phase ends)")))
 
 (deftest hippocampic-mechanocytes
   ;; Hippocampic Mechanocytes


### PR DESCRIPTION
Resets the current ice after a forced encounter ends. I think it gets muddied up when the other ice is trashed otherwise somehow, but this seems to fix it.

I also made breaking ice track if it was on the attacked server in the event it sends out, which lets us enforce that restriction on hippo.

Closes #7895
Closes #7894
Closes #7880