### PR TITLE
Don't allow auto pump and break when Unsmiling Tsarevna rez ability triggered

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -4265,6 +4265,12 @@
                                           :duration :end-of-run
                                           :req (req (same-card? card (:ice context)))
                                           :value (req (any-subs-broken? (:ice context)))})
+                                       (register-lingering-effect
+                                         state side card
+                                         {:type :cannot-auto-break-subs-on-ice
+                                          :duration :end-of-run
+                                          :req (req (same-card? card (:ice context)))
+                                          :value true})
                                        (effect-completed state side eid)))}]
     {:subroutines [(give-tags 1)
                    (do-net-damage 2)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -765,6 +765,7 @@
                                                      (not= :unrestricted ((:breakable %) state side eid current-ice [card]))
                                                      (not (:breakable % true))) ; breakable is a bool
                                                   (:subroutines current-ice)))
+              can-auto-break (not (any-effects state side :cannot-auto-break-subs-on-ice true? {:ice current-ice}))
               times-break (when (and (pos? unbroken-subs)
                                      subs-broken-at-once)
                             (if (pos? subs-broken-at-once)
@@ -786,6 +787,7 @@
                                          (when (and break-ability
                                                     (or (not (get-strength card)) pump-ability (zero? strength-diff))
                                                     no-unbreakable-subs
+                                                    can-auto-break
                                                     (pos? unbroken-subs)
                                                     (can-pay? state side eid card total-cost))
                                            [{:dynamic :auto-pump-and-break

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -8128,6 +8128,25 @@
       (click-prompt state :runner "Do 2 net damage")
       (is (no-prompt? state :runner) "Cannot break more than 1 sub"))))
 
+(deftest unsmiling-tsarevna-auto-break
+  ;; Unsmiling Tsarevna - limit auto break when rez ability fired
+  (do-game
+    (new-game {:corp {:hand [(qty "Unsmiling Tsarevna" 1)]
+                      :deck [(qty "Hedge Fund" 5)]
+                      :credits 20}
+               :runner {:hand ["Carmen"]
+                        :credits 20}})
+    (play-from-hand state :corp "Unsmiling Tsarevna" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Carmen")
+    (let [ut-hq (get-ice state :hq 0)
+          carm (get-program state 0)]
+      (run-on state :hq)
+      (rez state :corp ut-hq)
+      (click-prompt state :corp "Yes")
+      (run-continue state)
+      (is (empty? (filter #(:dynamic %) (:abilities (refresh carm)))) "No auto break dynamic ability"))))
+
 (deftest valentao-no-choice-without-tags
   (do-game
     (new-game {:corp {:hand ["Valentão"]}})


### PR DESCRIPTION
Fixes #6844

Couldn't really work out a better way to do this.

I looked at Afshar and Ahket and both those use `:breakable` functions on their subroutines and then return `:unrestricted` when the qualifying static condition is not true - but when the condition is true then the auto-break code doesn't actually care if the `:breakable: function returns true or false and decides the ice can't be auto-broken. 

I'm not sure how I'd replace the current `:cannot-break-subs-on-ice` lingering effect with a similar `:breakable` functions on subs that checks if the Corp has given the Runner 2 credits.

So instead just opted for an additional lingering "effect" which the auto-break code guards against.