### PR TITLE
added util fns - play-from-hand-with-prompt, click-prompts

### DIFF
--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -2225,7 +2225,7 @@
   (do-game
      (new-game {:runner {:deck [(qty "Dirty Laundry" 2)]}})
      (take-credits state :corp)
-     (play-from-hand-with-prompt state :runner "Dirty Laundry" "Archives")
+     (play-from-hand-with-prompts state :runner "Dirty Laundry" "Archives")
      (run-continue state)
      (is (= 8 (:credit (get-runner))) "Gained 5 credits")
      (play-from-hand state :runner "Dirty Laundry")

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -2225,8 +2225,7 @@
   (do-game
      (new-game {:runner {:deck [(qty "Dirty Laundry" 2)]}})
      (take-credits state :corp)
-     (play-from-hand state :runner "Dirty Laundry")
-     (click-prompt state :runner "Archives")
+     (play-from-hand-with-prompt state :runner "Dirty Laundry" "Archives")
      (run-continue state)
      (is (= 8 (:credit (get-runner))) "Gained 5 credits")
      (play-from-hand state :runner "Dirty Laundry")

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -214,11 +214,7 @@
                       :hand ["Ad Blitz" "Launch Campaign"]
                       :discard ["Pop-up Window"]}})
     (play-from-hand state :corp "Ad Blitz")
-    (click-prompt state :corp "2")
-    (click-card state :corp "Launch Campaign")
-    (click-prompt state :corp "New remote")
-    (click-card state :corp "Pop-up Window")
-    (click-prompt state :corp "Server 1")
+    (click-prompts state :corp "2" "Launch Campaign" "New remote" "Pop-up Window" "Server 1")
     (is (zero? (count (:hand (get-corp)))) "Corp should have no cards in HQ")
     (is (= ["Ad Blitz"] (->> (get-corp) :discard (map :title))) "Corp should have only Ad Blitz in Archives")))
 
@@ -3223,10 +3219,11 @@
           (play-from-hand state :corp "Oppo Research")
           (is (not (no-prompt? state :runner)) "Runner prompted to avoid tag")
           (card-ability state :runner (get-resource state 0) 0)
-          (click-prompt state :corp "0")
-          (click-prompt state :runner "0")
-          (click-prompt state :runner "Done")
-          (click-prompt state :corp "Yes"))
+          (click-prompts state :corp
+                         "0"
+                         {:side :runner :choice "0"}
+                         {:side :runner :choice "Done"}
+                         "Yes"))
         "Runner prevented 2 tag")))
 
 (deftest oversight-ai-rez-at-no-cost
@@ -5193,9 +5190,7 @@
         (advance state (refresh ngo) 2)
         (is (= 2 (get-counters (refresh ngo) :advancement)) "NGO Front should have 2 counters")
         (play-from-hand state :corp "Trick of Light")
-        (click-card state :corp iw)
-        (click-card state :corp ngo)
-        (click-prompt state :corp "2")
+        (click-prompts state :corp iw ngo "2")
         (is (= 2 (get-counters (refresh iw) :advancement)) "Ice Wall is now advanced")
         (is (zero? (get-counters (refresh ngo) :advancement)) "NGO Front should have 0 counters"))))
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1840,8 +1840,7 @@
                  :runner {:hand ["Chisel"]}})
       (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
-      (play-from-hand state :runner "Chisel")
-      (click-card state :runner "Ice Wall")
+      (play-from-hand-with-prompt state :runner "Chisel" "Ice Wall")
       (let [iw (get-ice state :hq 0)
             chisel (first (:hosted (refresh iw)))]
         (run-on state "HQ")
@@ -1891,8 +1890,7 @@
                  :runner {:hand ["Chisel" "Devil Charm"]}})
       (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
-      (play-from-hand state :runner "Chisel")
-      (click-card state :runner "Ice Wall")
+      (play-from-hand-with-prompt state :runner "Chisel" "Ice Wall")
       (play-from-hand state :runner "Devil Charm")
       (let [iw (get-ice state :hq 0)
             chisel (first (:hosted (refresh iw)))]

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1840,7 +1840,7 @@
                  :runner {:hand ["Chisel"]}})
       (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
-      (play-from-hand-with-prompt state :runner "Chisel" "Ice Wall")
+      (play-from-hand-with-prompts state :runner "Chisel" "Ice Wall")
       (let [iw (get-ice state :hq 0)
             chisel (first (:hosted (refresh iw)))]
         (run-on state "HQ")
@@ -1890,7 +1890,7 @@
                  :runner {:hand ["Chisel" "Devil Charm"]}})
       (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
-      (play-from-hand-with-prompt state :runner "Chisel" "Ice Wall")
+      (play-from-hand-with-prompts state :runner "Chisel" "Ice Wall")
       (play-from-hand state :runner "Devil Charm")
       (let [iw (get-ice state :hq 0)
             chisel (first (:hosted (refresh iw)))]

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -587,17 +587,7 @@
               (println title " was instead found in the opposing hand - was the wrong side used?")))
           true)
       (when-let [played (core/process-action "play" state side {:card card})]
-        (cond
-          (not choice) (is` nil "attempt to resolve nil prompt option")
-          ;; it's a select prompt - we want to click on a card
-          (prompt-is-type? state side :select)
-          (if (or (:cid choice) (string? choice))
-            (click-card state side choice)
-            (click-card state (or (:side choice) side) (:choice choice)))
-          :else
-          (if (or (:cid choice) (string? choice))
-            (click-prompt state side choice)
-            (click-prompt state (or (:side choice) side) (:choice choice))))))))
+        (click-prompts state side choice)))))
 
 (defmacro play-from-hand-with-prompt
   "Play a card from hand based on it's title, and then click a prompt

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -576,8 +576,8 @@
   ([state side title server]
    `(error-wrapper (play-from-hand-impl ~state ~side ~title ~server))))
 
-(defn play-from-hand-with-prompt-impl
-  [state side title choice]
+(defn play-from-hand-with-prompts-impl
+  [state side title choices]
   (let [card (find-card title (get-in @state [side :hand]))]
     (ensure-no-prompts state)
     (is' (some? card) (str title "is in hand"))
@@ -587,14 +587,14 @@
               (println title " was instead found in the opposing hand - was the wrong side used?")))
           true)
       (when-let [played (core/process-action "play" state side {:card card})]
-        (click-prompts state side choice)))))
+        (click-prompts-impl state side choices)))))
 
-(defmacro play-from-hand-with-prompt
-  "Play a card from hand based on it's title, and then click a prompt
+(defmacro play-from-hand-with-prompts
+  "Play a card from hand based on it's title, and then click any number of prompts
    accepts for prompt: a string, a fn, a card object"
   ([state side title] `(play-from-hand ~state ~side ~title nil))
-  ([state side title prompt]
-   `(error-wrapper (play-from-hand-with-prompt-impl ~state ~side ~title ~prompt))))
+  ([state side title & prompts]
+   `(error-wrapper (play-from-hand-with-prompts-impl ~state ~side ~title ~(vec prompts)))))
 
 ;;; Run functions
 (defn run-on-impl


### PR DESCRIPTION
I added a couple of util fns to the test framework.

`(play-from-hand-with-prompt [state side card prompt])`: play a card, then click a prompt. This plays a card, then makes a call to `click-prompts` with the given choice.

`(click-prompts [state side & prompts])`

Clicks the argument prompts, in order. They are all clicked from the given side, but you can instead pass in `{:side ... :choice ...}`.

Click-prompts intelligently examines the prompt state, to see if it's a card prompt, or a text/button prompt that's open, and chooses the correct subroutine for that (it defers to the click-card, click-prompt).

So, for example, to resolve ad blitz, you could call:
`(click-prompts state :corp "2" "Launch Campaign" "New remote" "Pop-up Window" "Server 1")`
And to resolve dirty laundry on HQ, you could call:
`(play-from-hand-with-prompt state :runner "Dirty Laundry" "HQ")`

I rewrote a couple of unit tests, just as a demo/proof of concept. I don't propose replacing everything with this, I just think it's a nice tool to have for later tests (ie for dawn cards).

As an example, the singular card that's been revealed so far is basically a bunch of stacked prompts, so it could have a very verbose set of unit tests:

![kpi](https://github.com/user-attachments/assets/aaea432b-2248-4437-bae6-15bc02c448a7)
