### PR TITLE
be smart with skorp automation

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -405,14 +405,16 @@
          :req (req (and (grip-or-stack-trash? targets)
                         (first-trash? state grip-or-stack-trash?)))
          :prompt "Choose 1 trashed card to add to the bottom of the stack"
-         :choices (req (conj (sort (map :title (map :card targets))) "No action"))
+         :choices (req (conj (sort (keep #(->> (:moved-card %) :title) targets)) "No action"))
          :async true
          :effect (req (if (= "No action" target)
                         (effect-completed state side eid)
                         (do (system-msg state side
                                         (str "uses " (:title card) " to add " target
                                              " to the bottom of the stack"))
-                            (move state side (find-card target (:discard (:runner @state))) :deck)
+                            ;; note - need to search in reverse order, to remove the NEWEST copy of the card
+                            ;; this is for interactions with the price, etc
+                            (move state side (find-card target (reverse (:discard (:runner @state)))) :deck)
                             (effect-completed state side eid))))}]
     {:events [(assoc triggered-ability :event :runner-trash)
               (assoc triggered-ability :event :corp-trash)]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1946,7 +1946,7 @@
                                             ;; 3) a program among the trashed cards
                                             (some #(->> % program?) context)
                                             ;; 4) a relevant card is trashed (Steelskin, Strike fund, I've Had Worse)
-                                            (contains? relevant-cards-trashed (map #(->> % :card :title) context)))
+                                            (some #(contains? relevant-cards-trashed %) (map #(->> % :title) context)))
                                           :else nil))))
         triggered-ability {:once :per-turn
                            :player :corp

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -8,19 +8,19 @@
    [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? faceup? get-advancement-requirement
                            get-agenda-points get-card get-counters get-title get-zone hardware? has-subtype?
-                           has-any-subtype? ice? in-discard? in-hand? in-play-area? in-rfg? installed? is-type?
+                           has-any-subtype? ice? in-discard? in-deck? in-hand? in-play-area? in-rfg? installed? is-type?
                            operation? program? resource? rezzed? runner? upgrade?]]
    [game.core.charge :refer [charge-ability]]
    [game.core.cost-fns :refer [install-cost play-cost
                                rez-additional-cost-bonus rez-cost]]
    [game.core.damage :refer [chosen-damage corp-can-choose-damage? damage
                              enable-corp-damage-choice]]
-   [game.core.def-helpers :refer [corp-recur defcard offer-jack-out with-revealed-hand]]
+   [game.core.def-helpers :refer [choose-one-helper corp-recur defcard offer-jack-out with-revealed-hand]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect is-disabled?]]
    [game.core.eid :refer [effect-completed get-ability-targets is-basic-advance-action? make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events register-once resolve-ability trigger-event]]
-   [game.core.events :refer [event-count first-event?
+   [game.core.events :refer [event-count first-event? first-trash?
                              first-successful-run-on-server? no-event? not-last-turn? run-events run-event-count turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
@@ -1913,14 +1913,64 @@
              :effect (effect (expose eid target))}]})
 
 (defcard "Skorpios Defense Systems: Persuasive Power"
-  {:implementation "Manually triggered, no restriction on which cards in Heap can be targeted. Cannot use on in progress run event"
-   :abilities [{:label "Remove a card in the Heap that was just trashed from the game"
-                :waiting-prompt true
-                :prompt "Choose a card in the Heap that was just trashed"
-                :once :per-turn
-                :choices (req (cancellable (:discard runner)))
-                :msg (msg "remove " (:title target) " from the game")
-                :effect (req (move state :runner target :rfg))}]})
+  (let [set-resolution-mode
+        (fn [x] {:label x
+                 :effect (req (update! state side (assoc-in card [:special :resolution-mode] x))
+                              (toast state :corp (str "Set Skorpios resolution to " x " mode"))
+                              (update! state side (assoc (get-card state card) :card-target x)))})
+        grip-or-stack-trash?
+        (fn [targets]
+          (some #(and (runner? %)
+                      (or (in-hand? %)
+                          (in-deck? %)))
+                targets))
+        relevant-cards-general #{"Labor Rights" "The Price"}
+        relevant-cards-corp-turn #{"I've Had Worse" "Strike Fund" "Steelskin Scarring"}
+        trigger-ability-req (req (let [res-type (get-in (get-card state card) [:special :resolution-mode])
+                                       valid-cards (mapv #(get-card state %) (filter runner? context))]
+                                   (and (some runner? context)
+                                        (cond
+                                          ;; manual: do nothing
+                                          (= res-type "Automatic") true
+                                          ;; there's either:
+                                          (= res-type "Smart")
+                                          (or
+                                            ;; 1) a relevant card resoluton
+                                            (contains? relevant-cards-general (->> runner :play-area first :title))
+                                            ;; 2) a buffer drive that may resolve
+                                            (and (contains? #{"Buffer Drive"} (map :title (all-installed state :runner)))
+                                                 (grip-or-stack-trash? context)
+                                                 (first-trash? state grip-or-stack-trash?))
+                                            ;; 3) a program among the trashed cards
+                                            (some #(->> % program?) context)
+                                            ;; 4) a relevant card on the corp turn (Steelskin, Strike fund, I've Had Worse)
+                                            (contains? relevant-cards-corp-turn (map #(->> % :card :title) context)))
+                                          :else nil))))
+        triggered-ability {:once :per-turn
+                           :player :corp
+                           :event :pre-trash-interrupt
+                           :waiting-prompt true
+                           :req trigger-ability-req
+                           :prompt "Remove a card from the game?"
+                           :choices (req (cancellable context))
+                           :msg (msg "remove " (:title target) " from the game")
+                           :effect (req (move state :runner target :rfg))}]
+    {:implementation "Switch between manual, \"smart\", and automatic resolution by using the ability on the card"
+     :events [(assoc (set-resolution-mode "Smart")
+                     :event :pre-first-turn
+                     :req (req (= side :corp)))
+              triggered-ability]
+     :abilities [(choose-one-helper
+                   {:optional true
+                    :label "Set resolution mode"}
+                   (mapv (fn [x] {:option x :ability (set-resolution-mode x)}) ["Manual" "Smart" "Automatic"]))
+                 {:label "Remove a card in the Heap that was just trashed from the game"
+                  :waiting-prompt true
+                  :prompt "Choose a card in the Heap that was just trashed"
+                  :once :per-turn
+                  :choices (req (cancellable (:discard runner)))
+                  :msg (msg "remove " (:title target) " from the game")
+                  :effect (req (move state :runner target :rfg))}]}))
 
 (defcard "Spark Agency: Worldswide Reach"
   {:events [{:event :rez

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -953,7 +953,7 @@
                  :runner {:deck [(qty "By Any Means" 2)]}})
       (take-credits state :corp)
       (play-from-hand state :runner "By Any Means")
-      (card-ability state :corp (get-in @state [:corp :identity]) 0)
+      (card-ability state :corp (get-in @state [:corp :identity]) 1)
       (click-prompt state :corp (find-card "By Any Means" (:discard (get-runner))))
       (is (= 1 (count (get-in @state [:runner :rfg]))) "By Any Means RFGed")
       (is (zero? (count (:discard (get-corp)))) "Nothing trashed yet")

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -1306,6 +1306,25 @@
           (is (find-card "I've Had Worse" (:deck (get-runner))))
           (is (find-card "Buffer Drive" (get-hardware state)))))))
 
+(deftest buffer-drive-dont-offer-duplicate-option-with-the-price
+  (do-game
+    (new-game {:runner {:discard ["Boomerang"] :deck ["Ika" "Boomerang" "Sure Gamble"] :hand ["The Price" "Buffer Drive"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Buffer Drive")
+    (play-from-hand state :runner "The Price")
+    (click-prompt state :runner "Boomerang")
+    (is (not-any? #{"Boomerang"} (prompt-buttons :runner)) "No offer to install boomerang")))
+
+(deftest buffer-drive-plays-nice-with-skorpios
+  (do-game
+    (new-game {:corp {:id "Skorpios Defense Systems: Persuasive Power"}
+               :runner {:deck ["Ika" "Boomerang" "Sure Gamble"] :hand ["The Price" "Buffer Drive"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Buffer Drive")
+    (play-from-hand state :runner "The Price")
+    (click-prompt state :corp "Boomerang")
+    (is (not-any? #{"Boomerang"} (prompt-buttons :runner)) "No offer to install boomerang")))
+
 (deftest capstone
   ;; Capstone
   (do-game

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -4724,7 +4724,7 @@
       (is (= 12 (:credit (get-runner))) "Gained 4cr")
       (is (= 12 (get-counters (get-resource state 0) :credit)) "12 cr on Temujin")))
 
-(deftest skorpios-defense-systems-persuasive-power
+(deftest skorpios-defense-systems-persuasive-power-manual-usage
   ; Remove a card from game when it moves to discard once per round
   (do-game
     (new-game {:corp {:id "Skorpios Defense Systems: Persuasive Power"
@@ -4733,11 +4733,13 @@
     (play-from-hand state :corp "Hedge Fund")
     (dotimes [_ 4] (core/move state :corp (first (:hand (get-corp))) :deck))
     (take-credits state :corp)
+    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (click-prompt state :corp "Manual")
     (play-from-hand state :runner "Lucky Find")
     (play-from-hand state :runner "The Maker's Eye")
     (is (= [:rd] (:server (get-run))))
     ; Don't allow a run-event in progress to be targeted #2963
-    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (card-ability state :corp (get-in @state [:corp :identity]) 1)
     (is (empty? (filter #(= "The Maker's Eye" (:title %)) (-> (get-corp) :prompt first :choices))) "No Maker's Eye choice")
     (click-prompt state :corp "Cancel")
     (run-continue state)
@@ -4748,11 +4750,20 @@
     (is (accessing state "Quandary"))
     (click-prompt state :runner "No action")
     (is (not (:run @state)))
-    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (card-ability state :corp (get-in @state [:corp :identity]) 1)
     (click-prompt state :corp (find-card "The Maker's Eye" (:discard (get-runner))))
     (is (= 1 (count (get-in @state [:runner :rfg]))) "One card RFGed")
-    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (card-ability state :corp (get-in @state [:corp :identity]) 1)
     (is (no-prompt? state :corp) "Cannot use Skorpios twice")))
+
+(deftest skorpios-smart-test
+  (do-game
+    (new-game {:corp {:id "Skorpios Defense Systems: Persuasive Power"}
+               :runner {:deck ["Corroder"]}})
+    (damage state :corp :brain 1)
+    (click-prompt state :corp "Corroder")
+    (is (= 1 (count (get-in @state [:runner :rfg]))) "One card RFGed")))
+
 
 (deftest spark-agency-worldswide-reach
   ;; Spark Agency - Rezzing advertisements


### PR DESCRIPTION
Closes #7944

What I settled on, for ease of use, was three options on the ID:
* Manual
* Smart
* Automatic

If it's set to manual, it must be manually triggered. This is what the id already does.

If it's set to smart, it will cut in when:
* labor rights or the price is played (frantic gets around this, it installs before trashing stuff) - if there are any other cards you think should be snuck in here, let me know
* a program is trashed
* it's a trash that would otherwise trigger buffer drive
* steelskin/strike fund/i've had worse are in the trash list (rules says I'm right, we're good to go)

If it's set to auto, it will always cut in (your opponent may find this annoying, so it's not the default).

At game start, it automatically gets set to smart mode (and the mode is displayed on the card).

Additionally, this also:
* Refactors trash-cards so that it tracks both the card trashed, and the card in the discard
* Makes buffer drive only look at cards that actually traveled to the discard pile
* Makes buffer drive search the pile in reverse order, so if you price something, and send it back, but you already had it in your discard, it gets removed from the price list properly now
* Adds a :pre-trash-interrupt into trash-cards (what skorp timing is)