### PR TITLE
Subroutines have labels

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1457,6 +1457,7 @@
 
 (defcard "Datapike"
   {:subroutines [{:async true
+                  :label "Runner must pay 2 [Credits]. If they cannot, end the run"
                   :effect (req (wait-for (pay state :runner (make-eid state eid) card (->c :credit 2))
                                          (if (:cost-paid async-result)
                                            (do (system-msg state :runner (:msg async-result))
@@ -3056,6 +3057,7 @@
                   :choices {:card #(and (ice? %)
                                         (in-hand? %))}
                   :prompt "Choose a piece of ice to install from HQ"
+                  :label "install ice from HQ, ignoring all costs"
                   :effect (effect (corp-install eid target (zone->name (target-server run)) {:ignore-all-cost true
                                                                                              :msg-keys {:install-source card
                                                                                                         :display-origin true}}))}]})

--- a/test/clj/game/core/abilities_test.clj
+++ b/test/clj/game/core/abilities_test.clj
@@ -61,16 +61,22 @@
           :when (not-empty (card-def card))]
     (is (core/has-trash-ability? card) (str (:title card) " needs either :cost [(->c :trash-can)] or :trash-icon true"))))
 
-(deftest label
-  (doseq [[title abilities]
+(defn- x-has-labels
+  [x-key x-name]
+  (doseq [[title cards-with-x]
           (->> @all-cards
                vals
                (sort-by (juxt :type :title))
                (map (juxt :title card-def))
-               (filter (comp :abilities second)))
-          [idx ability] (map-indexed (fn [idx itm] [idx itm]) (:abilities abilities))]
-    (is (string? (or (:label ability) (:msg ability)))
-        (str title ": Ability " (inc idx) " doesn't have an appropriate label"))))
+               (filter (comp x-key second)))
+          [idx x] (map-indexed (fn [idx itm] [idx itm]) (x-key cards-with-x))]
+    (is (string? (or (:label x) (:msg x))) (str title ": " x-name " " (inc idx) " doen't have an appropriate label"))))
+
+(deftest abilities-have-labels
+  (x-has-labels :abilities "Ability")
+  (x-has-labels :corp-abilities "Runner Ability")
+  (x-has-labels :runner-abilities "Corp Ability")
+  (x-has-labels :subroutines "Subroutine"))
 
 (defn generate-label
   [card]


### PR DESCRIPTION
I extended the abilities-have-labels test to cover corp-abilities, runner-abilities and subroutines.

This caught out that minelayer and datapike had some unlabelled subroutines (whoops, good thing nobody played those cards).

Closes #7946