### PR TITLE
offer to trash like cards on install

### DIFF
--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -61,15 +61,17 @@
                                    (corp-can-pay-and-install?
                                      state side eid
                                      target-card server {:base-cost [(->c :click 1)]
-                                                    :action :corp-click-install
-                                                    :no-toast true})
+                                                         :ignore-ice-cost true
+                                                         :action :corp-click-install
+                                                         :no-toast true})
                                    (some
                                      (fn [server]
                                        (corp-can-pay-and-install?
                                          state side eid
                                          target-card server {:base-cost [(->c :click 1)]
-                                                        :action :corp-click-install
-                                                        :no-toast true}))
+                                                             :ignore-ice-cost true
+                                                             :action :corp-click-install
+                                                             :no-toast true}))
                                      (installable-servers state target-card))))))
                 :effect (req (let [{target-card :card server :server} context]
                                (corp-install

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -108,6 +108,10 @@
     (swap! state update-in [side key] (partial + delta)))
   (change-msg state side key (get-in @state [side key]) delta))
 
+(defn- change-trash-like-cards
+  [state side key val]
+  (swap! state assoc-in [side key] val))
+
 (defn change
   "Increase/decrease a player's property (clicks, credits, MU, etc.) by delta."
   [state side {:keys [key delta]}]
@@ -118,5 +122,6 @@
     :bad-publicity (change-bad-pub state delta)
     :agenda-point (change-agenda-points state side delta)
     :link (change-link state side delta)
+    :trash-like-cards (change-trash-like-cards state side key delta)
     ; else
     (change-generic state side key delta)))

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -108,10 +108,6 @@
     (swap! state update-in [side key] (partial + delta)))
   (change-msg state side key (get-in @state [side key]) delta))
 
-(defn- change-trash-like-cards
-  [state side key val]
-  (swap! state assoc-in [side key] val))
-
 (defn change
   "Increase/decrease a player's property (clicks, credits, MU, etc.) by delta."
   [state side {:keys [key delta]}]
@@ -122,6 +118,5 @@
     :bad-publicity (change-bad-pub state delta)
     :agenda-point (change-agenda-points state side delta)
     :link (change-link state side delta)
-    :trash-like-cards (change-trash-like-cards state side key delta)
     ; else
     (change-generic state side key delta)))

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -256,6 +256,7 @@
    :hand-size
    :keep
    :quote
+   :trash-like-cards
    :prompt-state
    :agenda-point
    :agenda-point-req])

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -7,6 +7,7 @@
     [game.core.card :refer [agenda? asset? condition-counter? convert-to-condition-counter  corp? event? get-card get-zone has-subtype? ice? installed? operation? program? resource? rezzed? upgrade?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [ignore-install-cost? install-additional-cost-bonus install-cost]]
+    [game.core.costs :refer [total-available-credits]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events trigger-event-simult unregister-events]]
     [game.core.effects :refer [is-disabled-reg? register-static-abilities unregister-static-abilities update-disabled-cards]]
@@ -27,7 +28,7 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability effect req wait-for]]
-    [game.utils :refer [dissoc-in in-coll? same-card? to-keyword quantify]]
+    [game.utils :refer [dissoc-in enumerate-str in-coll? same-card? to-keyword quantify]]
     [medley.core :refer [find-first]]))
 
 (defn install-locked?
@@ -287,13 +288,14 @@
 
 (defn corp-install-cost
   [state side card server
-   {:keys [base-cost ignore-install-cost ignore-all-cost cost-bonus cached-costs] :as args}]
+   {:keys [base-cost ignore-install-cost ignore-all-cost cost-bonus cached-costs ignore-ice-cost] :as args}]
   (or cached-costs
       (let [slot (get-slot state card server args)
             dest-zone (get-in @state (cons :corp slot))
             ice-cost (if (and (ice? card)
                               (not ignore-install-cost)
                               (not ignore-all-cost)
+                              (not ignore-ice-cost)
                               (not (ignore-install-cost? state side card)))
                        (count dest-zone)
                        0)
@@ -316,7 +318,7 @@
 
 (defn- corp-install-pay
   "Used by corp-install to pay install costs"
-  [state side eid card server {:keys [action] :as args}]
+  [state side eid card server {:keys [action resolved-optional-trash] :as args}]
   (let [slot (get-slot state card server args)
         costs (corp-install-cost state side card server (dissoc args :cached-costs))
         credcost (or (value (find-first #(= :credit (:cost/type %)) costs)) 0)
@@ -324,18 +326,57 @@
         appldisc (if (and (not (zero? credcost)) (not (zero? discount)))
                    (if (>= credcost discount) discount credcost) 0)
         args (if discount (assoc args :cost-bonus (- appldisc discount)) args)
-        costs (conj costs (->c :credit (- 0 appldisc)))]
-      ;; get a functional discount and apply it to
-    (if (corp-can-pay-and-install? state side eid card server (assoc args :cached-costs costs))
-      (wait-for (pay state side (make-eid state (assoc eid :action action)) card costs)
-                (if-let [payment-str (:msg async-result)]
-                  (if (= server "New remote")
-                    (wait-for (trigger-event-simult state side :server-created nil card)
-                              (make-rid state)
-                              (corp-install-continue state side eid card server args slot payment-str))
-                    (corp-install-continue state side eid card server args slot payment-str))
-                  (effect-completed state side eid)))
-      (effect-completed state side eid))))
+        costs (conj costs (->c :credit (- 0 appldisc)))
+        corp-wants-to-trash? (and (get-in @state [:corp :trash-like-cards])
+                                  (seq (get-in @state (concat [:corp] slot)))
+                                  (not resolved-optional-trash))]
+    (if (and (not corp-wants-to-trash?) (corp-can-pay-and-install? state side eid card server (assoc args :cached-costs costs)))
+      (wait-for
+        (pay state side (make-eid state (assoc eid :action action)) card costs)
+        (if-let [payment-str (:msg async-result)]
+          (if (= server "New remote")
+            (wait-for (trigger-event-simult state side :server-created nil card)
+                      (make-rid state)
+                      (corp-install-continue state side eid card server args slot payment-str))
+            (corp-install-continue state side eid card server args slot payment-str))
+          (effect-completed state side eid)))
+      ;; NOTE - Diwan and Network Exchange both alter the cost of installs
+      ;; if it's not ice AND we can't afford it, there's nothing we can do
+      ;; Diwan will get accounted for, but Network Exchange wont (oh well) - nbk, 2025
+      (let [shortfall (- (or (value (find-first #(= :credit (:cost/type %)) costs)) 0) (total-available-credits state side eid card))
+            need-to-trash (max 0 shortfall)
+            cards-in-slot (count (get-in @state (concat [:corp] slot)))
+            possible? (and (ice? card) (>= cards-in-slot need-to-trash))]
+        (cond (and possible? (pos? need-to-trash))
+              (letfn [(trash-all-or-none [] {:prompt (str "Trash ice protecting " (name-zone :corp slot) " (minimum " need-to-trash ")")
+                                             :choices {:req (req (= (:zone target) slot))
+                                                       :max cards-in-slot}
+                                             :waiting-prompt true
+                                             :async true
+                                             :effect (req (if (>= (count targets) need-to-trash)
+                                                            (do (system-msg state side (str "trashes " (enumerate-str (map #(card-str state %) targets))))
+                                                                (wait-for
+                                                                  (trash-cards state side targets {:keep-server-alive true})
+                                                                  (corp-install-pay state side eid card server (assoc args :resolved-optional-trash true))))
+                                                            (do (toast state :corp (str "You must either trash at least " need-to-trash " ice, or trash none of them"))
+                                                                (continue-ability state side (trash-all-or-none) card targets))))
+                                             :cancel-effect (req (effect-completed state side eid))})]
+                (continue-ability state side (trash-all-or-none) card nil))
+              (and corp-wants-to-trash? (zero? need-to-trash))
+              (continue-ability
+                state side
+                {:prompt (str "Trash any number of " (if (ice? card) "ice protecting " "cards in ") (name-zone :corp slot))
+                 :choices {:req (req (= (:zone target) slot))
+                           :max cards-in-slot}
+                 :async true
+                 :waiting-prompt true
+                 :effect (req (do (system-msg state side (str "trashes " (enumerate-str (map #(card-str state %) targets))))
+                                  (wait-for
+                                    (trash-cards state side targets {:keep-server-alive true})
+                                    (corp-install-pay state side eid card server (assoc args :resolved-optional-trash true)))))
+                 :cancel-effect (req (corp-install-pay state side eid card server (assoc args :resolved-optional-trash true)))}
+                card nil)
+              :else (effect-completed state side eid))))))
 
 (defn corp-install
   "Installs a card in the chosen server. If server is nil, asks for server to install in.

--- a/src/clj/game/core/player.clj
+++ b/src/clj/game/core/player.clj
@@ -20,6 +20,7 @@
    set-aside
    set-aside-tracking
    servers
+   trash-like-cards
    click
    click-per-turn
    credit
@@ -56,6 +57,7 @@
      :credit 5
      :bad-publicity (map->BadPublicity {:base 0 :additional 0})
      :toast []
+     :trash-like-cards nil
      :hand-size (map->HandSize {:base 5 :total 5})
      :agenda-point 0 :agenda-point-req 7
      :keep false
@@ -85,6 +87,7 @@
    run-credit
    link
    tag
+   trash-like-cards
    memory
    hand-size
    agenda-point
@@ -118,6 +121,7 @@
      :toast []
      :click 0 :click-per-turn 4
      :credit 5 :run-credit 0
+     :trash-like-cards nil
      :link 0
      :tag (map->Tags {:base 0 :total 0 :is-tagged false})
      :memory {:base 4

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -32,6 +32,13 @@
     (handle-end-run state :corp nil)
     (fake-checkpoint state)))
 
+(defn set-property
+  "set properties of the game state that need to be adjustable by the frontend
+  ie: * do we want an offer to trash like cards on installs?"
+  [state side {:keys [key value]}]
+  (case key
+    :trash-like-cards (swap! state assoc-in [side :trash-like-cards] value)))
+
 (defn command-parser
   [state side {:keys [user text] :as args}]
   (let [author (or user (get-in @state [side :user]))
@@ -74,6 +81,7 @@
    "runner-ability" #'play-runner-ability
    "score" #(score %1 %2 (make-eid %1) (get-card %1 (:card %3)) nil)
    "select" #'select
+   "set-property" #'set-property
    "shuffle" #'shuffle-deck
    "start-turn" #'start-turn
    "subroutine" #'play-subroutine

--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -745,6 +745,7 @@
           :archives "Archives"
           :max-hand "Max hand size"
           :brain-damage "Core Damage"
+          :trash-like-cards "Offer to trash like cards"
           :tag-count (fn [[base additional total]] (str base (when (pos? additional) (str " + " additional)) " Tag" (if (not= total 1) "s" "")))
           :agenda-count (fn [[agenda-point]] (str agenda-point " Agenda Point" (when (not= agenda-point 1) "s")))
           :link-strength "Link Strength"

--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -67,7 +67,7 @@
 (defmethod stats-area "Runner" [runner]
   (let [ctrl (stat-controls-for-side :runner)]
     (fn [runner]
-      (let [{:keys [user click credit run-credit memory link tag
+      (let [{:keys [user click credit run-credit memory link tag trash-like-cards
                     brain-damage active]} @runner
             base-credit (- credit run-credit)
             plus-run-credit (when (pos? run-credit) (str "+" run-credit))
@@ -94,12 +94,18 @@
                        (when show-tagged [:div.warning "!"])]))
          (ctrl
           :brain-damage
-          [:div (str brain-damage " " (tr [:game.brain-damage "Core Damage"]))])]))))
+          [:div (str brain-damage " " (tr [:game.brain-damage "Core Damage"]))])
+         (when (= (:side @game-state) :runner)
+           [:div [:label [:input {:type "checkbox"
+                                  :value true
+                                  :checked trash-like-cards
+                                  :on-click #(send-command "change" {:key :trash-like-cards :delta (.. % -target -checked)})}]
+                  (tr [:game.trash-like-cards "Offer to trash like cards"])]])]))))
 
 (defmethod stats-area "Corp" [corp]
   (let [ctrl (stat-controls-for-side :corp)]
     (fn [corp]
-      (let [{:keys [user click credit bad-publicity active]} @corp
+      (let [{:keys [user click credit bad-publicity active trash-like-cards]} @corp
             icons? (get-in @app-state [:options :player-stats-icons] true)]
         [:div.stats-area
          (if icons?
@@ -110,7 +116,13 @@
             (ctrl :click [:div (tr [:game.click-count] click)])
             (ctrl :credit [:div (tr [:game.credit-count] credit -1)])])
          (let [{:keys [base additional]} bad-publicity]
-           (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))]))))
+           (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))
+         (when (= (:side @game-state) :corp)
+           [:div [:label [:input {:type "checkbox"
+                                  :value true
+                                  :checked trash-like-cards
+                                  :on-click #(send-command "change" {:key :trash-like-cards :delta (.. % -target -checked)})}]
+                  (tr [:game.trash-like-cards "Offer to trash like cards"])]])]))))
 
 (defn stats-view
   [player]

--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -100,7 +100,6 @@
              [:div [:label [:input {:type "checkbox"
                                     :value true
                                     :checked trash-like-cards
-                                    :on-key-down #(when (= "`" (.-key %)) (toggle-offer-trash %))
                                     :on-click toggle-offer-trash}]
                     (tr [:game.trash-like-cards "Offer to trash like cards"])]]))]))))
 
@@ -124,7 +123,6 @@
              [:div [:label [:input {:type "checkbox"
                                     :value true
                                     :checked trash-like-cards
-                                    :on-key-down #(when (= "`" (.-key %)) (toggle-offer-trash %))
                                     :on-click toggle-offer-trash}]
                     (tr [:game.trash-like-cards "Offer to trash like cards"])]]))]))))
 

--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -96,11 +96,13 @@
           :brain-damage
           [:div (str brain-damage " " (tr [:game.brain-damage "Core Damage"]))])
          (when (= (:side @game-state) :runner)
-           [:div [:label [:input {:type "checkbox"
-                                  :value true
-                                  :checked trash-like-cards
-                                  :on-click #(send-command "change" {:key :trash-like-cards :delta (.. % -target -checked)})}]
-                  (tr [:game.trash-like-cards "Offer to trash like cards"])]])]))))
+           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :delta (.. % -target -checked)})]
+             [:div [:label [:input {:type "checkbox"
+                                    :value true
+                                    :checked trash-like-cards
+                                    :on-key-down #(when (= "`" (.-key %)) (toggle-offer-trash %))
+                                    :on-click toggle-offer-trash}]
+                    (tr [:game.trash-like-cards "Offer to trash like cards"])]]))]))))
 
 (defmethod stats-area "Corp" [corp]
   (let [ctrl (stat-controls-for-side :corp)]
@@ -118,11 +120,13 @@
          (let [{:keys [base additional]} bad-publicity]
            (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))
          (when (= (:side @game-state) :corp)
-           [:div [:label [:input {:type "checkbox"
-                                  :value true
-                                  :checked trash-like-cards
-                                  :on-click #(send-command "change" {:key :trash-like-cards :delta (.. % -target -checked)})}]
-                  (tr [:game.trash-like-cards "Offer to trash like cards"])]])]))))
+           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :delta (.. % -target -checked)})]
+             [:div [:label [:input {:type "checkbox"
+                                    :value true
+                                    :checked trash-like-cards
+                                    :on-key-down #(when (= "`" (.-key %)) (toggle-offer-trash %))
+                                    :on-click toggle-offer-trash}]
+                    (tr [:game.trash-like-cards "Offer to trash like cards"])]]))]))))
 
 (defn stats-view
   [player]


### PR DESCRIPTION
Added a little checkbox you can tick for if you want to (have the option to) trash like cards on any ice, server or program install.

This works for the runner side (it's the same timing that you trash programs for MU), and it works for the corp side. I also made it so you can attempt to install something in a server that's too expensive so long as it's possible to trash things from that server to price it down enough, instead of just silently failing which is what we currently do.

There's a video in slack/

Closes #7948
Closes #2054 (woah that's an old issue)
and I think it hits the last one of #6497 (other than ncigs, which is going to go out the window in a few months)