### PR TITLE
fix stats area wrong side

### DIFF
--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -117,4 +117,7 @@
   (fn [player]
     [:div.panel.blue-shade.stats {:class (when (:active @player) "active-player")}
      (name-area (:user @player))
-     [stats-area player]]))
+     ;; note: react doesn't like defmulti much, and caches the first hit
+     ;; when it redoes stats - so it needs a key to re-render if sides
+     ;; change (ie playing a corp game after playing a runner game) - nbk
+     ^{:key (get-in @player [:identity :side])} [stats-area player]]))


### PR DESCRIPTION
Somehow, stackoverflow led me to this solution.

See: https://stackoverflow.com/questions/33299746/why-are-multi-methods-not-working-as-functions-for-reagent-re-frame

stats-area frame gets defined as a multi-method, and unless we give it a key to re-render on, it caches the first hit for the multimethod and feeds whatever you give it through to that.

Closes #6517