### PR TITLE
Corrected 2 Ashes Identity Quotes

### DIFF
--- a/data/quotes-corp.edn
+++ b/data/quotes-corp.edn
@@ -117,7 +117,7 @@
   ["Humanity has no future without expansion: beyond our planets, to the stars. And yet they interfere."]
   "Shaper"
   ["How petty they are, those who would interfere with us to try and comprehend our vision. As if they could. "]}
- "GameNET: Where Dreams Are Real"
+ "GameNET: Where Dreams are Real"
  {"Anarch"
   ["Hunting these \"Runners\" is the ultimate game, and we get to make all the rules... "
    "They are analyzing our board... It won't help. The mistake is thinking we're playing the same game."]

--- a/data/quotes-runner.edn
+++ b/data/quotes-runner.edn
@@ -188,7 +188,7 @@
   "NBN"
   ["Such an astounding amount of data they collect and process. I think the professor would quite enjoy a term paper on this. Lets get to research!"]
   "Weyland Consortium" ["300% uptick in their strike force mobilisations? Oops...Did I do that?"]}
- "Hoshiko Shiro: Next Level Shut-In"
+ "Hoshiko Shiro: Untold Protagonist"
  {"Default" ["Do i have to?"]
   "Haas-Bioroid"
   ["Keiko! If we can figure out the new brain-taping algos and customize them to my rig, the immersion will be... NEXT LEVEL! "]


### PR DESCRIPTION
I found an incorrect identity name in the Ashes, so I looked through the other identities in the cycle and it turns out another one had errors. I only tested, before and after the two I updated and just looked at the others with a critical eye.

The updated identities Hoshiko Shiro: Untold Protagonist (which confuses me because it is a very popular identity and had a completely different subtitle "Next Level Shut In") GameNET: Where Dreams are Real (I hear less about that and it was just bad casing).