### PR TITLE
Issuas qol

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -846,10 +846,8 @@
                       (conceal-hand state :runner)))}))
 
 (defcard "Harmony Medtech: Biomedical Pioneer"
-  {:effect (effect (lose :agenda-point-req 1)
-                   (lose :runner :agenda-point-req 1))
-   :leave-play (effect (gain :agenda-point-req 1)
-                       (gain :runner :agenda-point-req 1))})
+  {:static-abilities [{:type :agenda-point-req
+                       :value -1}]})
 
 (defcard "Hayley Kaplan: Universal Scholar"
   {:events [{:event :runner-install
@@ -985,6 +983,9 @@
 (defcard "Issuaq Adaptics: Sustaining Diversity"
   {:effect (effect (lose :agenda-point-req (get-counters card :power)))
    :leave-play (effect (gain :agenda-point-req (get-counters card :power)))
+   :static-abilities [{:type :agenda-point-req
+                       :req (req (= :corp side))
+                       :value (req (* -1 (get-counters card :power)))}]
    :events [{:event :agenda-scored
              :interactive (req true)
              :req (req (and (->> (turn-events state side :corp-install)
@@ -997,8 +998,6 @@
                                  empty?)))
              :msg "put 1 charge counter on itself"
              :effect (req (add-counter state side card :power 1)
-                          (swap! state assoc-in [:corp :agenda-point-req]
-                                 (dec (get-in @state [:corp :agenda-point-req])))
                           (check-win-by-agenda state))}]})
 
 (defcard "Jamie \"Bzzz\" Micken: Techno Savant"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -985,7 +985,7 @@
    :leave-play (effect (gain :agenda-point-req (get-counters card :power)))
    :static-abilities [{:type :agenda-point-req
                        :req (req (= :corp side))
-                       :value (req (* -1 (get-counters card :power)))}]
+                       :value (req (- (get-counters card :power)))}]
    :events [{:event :agenda-scored
              :interactive (req true)
              :req (req (and (->> (turn-events state side :corp-install)

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -11,6 +11,7 @@
                                  runner-can-pay-and-install?]]
    [game.core.payment :refer [can-pay? ->c]]
    [game.core.play-instants :refer [can-play-instant?]]
+   [game.core.winning :refer [agenda-points-required-to-win]]
    [game.utils :refer [dissoc-in]]
    [jinteki.utils :refer [select-non-nil-keys]]
    [medley.core :refer [update-existing]]))
@@ -272,6 +273,7 @@
       (update :set-aside cards-summary state side)
       (update :prompt-state prompt-summary same-side?)
       (update :toast toast-summary same-side?)
+      (assoc :agenda-point-req (agenda-points-required-to-win state side))
       (select-non-nil-keys (into player-keys additional-keys))))
 
 (def corp-keys

--- a/src/clj/game/core/winning.clj
+++ b/src/clj/game/core/winning.clj
@@ -3,7 +3,7 @@
    [cljc.java-time.duration :as duration]
    [cljc.java-time.instant :as inst]
    [cond-plus.core :refer [cond+]]
-   [game.core.effects :refer [any-effects]]
+   [game.core.effects :refer [any-effects sum-effects]]
    [game.core.say :refer [play-sfx system-msg system-say]]
    [game.utils :refer [dissoc-in]]
    [jinteki.utils :refer [other-side]]))
@@ -79,9 +79,14 @@
     (swap! state dissoc-in [:corp :clear-win])
     (swap! state dissoc :winner :loser :winning-user :losing-user :reason :winning-deck-id :losing-deck-id :end-time)))
 
+(defn agenda-points-required-to-win
+  [state side]
+  (+ (get-in @state [side :agenda-point-req])
+     (sum-effects state side :agenda-point-req)))
+
 (defn side-win
   [state side]
-  (<= (get-in @state [side :agenda-point-req]) (get-in @state [side :agenda-point])))
+  (<= (agenda-points-required-to-win state side) (get-in @state [side :agenda-point])))
 
 (defn check-win-by-agenda
   ([state] (check-win-by-agenda state nil))

--- a/src/cljc/i18n/en.cljc
+++ b/src/cljc/i18n/en.cljc
@@ -747,6 +747,7 @@
           :brain-damage "Core Damage"
           :tag-count (fn [[base additional total]] (str base (when (pos? additional) (str " + " additional)) " Tag" (if (not= total 1) "s" "")))
           :agenda-count (fn [[agenda-point]] (str agenda-point " Agenda Point" (when (not= agenda-point 1) "s")))
+          :agenda-point-req (fn [[agenda-point-req]] (if-not (= 7 agenda-point-req) (str " (" agenda-point-req " required)") ""))
           :link-strength "Link Strength"
           :credit-count (fn [[credit run-credit]] (str credit " Credit" (if (not= credit 1) "s" "") (when (pos? run-credit) (str " (" run-credit " for run)"))))
           :click-count (fn [[click]] (str click " Click" (if (not= click 1) "s" "")))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1051,7 +1051,7 @@
                         @cards))
          [label @cards {:opts {:name name}}]]))))
 
-(defn scored-view [scored agenda-point me?]
+(defn scored-view [scored agenda-point agenda-point-req me?]
   (let [size (count @scored)
         ctrl (if me? stat-controls (fn [key content] content))]
     [:div.panel.blue-shade.scored.squeeze
@@ -1063,7 +1063,8 @@
                     @scored))
      [label @scored {:opts {:name (tr [:game.scored-area "Scored Area"])}}]
      [:div.stats-area
-      (ctrl :agenda-point [:div (tr [:game.agenda-count] @agenda-point)])]]))
+      (ctrl :agenda-point [:div (tr [:game.agenda-count] @agenda-point)
+                           (tr [:game.agenda-point-req (if-not (= 7 agenda-point-req) (str " (" agenda-point-req " required)") "")] @agenda-point-req)])]]))
 
 (defn run-arrow [run]
   [:div.run-arrow [:div {:class (cond
@@ -2191,6 +2192,8 @@
                  op-scored (r/cursor game-state [op-side :scored])
                  me-agenda-point (r/cursor game-state [me-side :agenda-point])
                  op-agenda-point (r/cursor game-state [op-side :agenda-point])
+                 me-agenda-point-req (r/cursor game-state [me-side :agenda-point-req])
+                 op-agenda-point-req (r/cursor game-state [op-side :agenda-point-req])
                  ;; servers
                  corp-servers (r/cursor game-state [:corp :servers])
                  runner-rig (r/cursor game-state [:runner :rig])
@@ -2242,9 +2245,9 @@
                  [:div.left-inner-leftpane
                   [:div
                    [stats-view opponent]
-                   [scored-view op-scored op-agenda-point false]]
+                   [scored-view op-scored op-agenda-point op-agenda-point-req false]]
                   [:div
-                   [scored-view me-scored me-agenda-point true]
+                   [scored-view me-scored me-agenda-point me-agenda-point-req true]
                    [stats-view me]]]
 
                  [:div.right-inner-leftpane

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -6,6 +6,7 @@
    [game.core.card :refer :all]
    [game.core.mark :refer [is-mark?]]
    [game.core.servers :refer [unknown->kw zone->name]]
+   [game.core.winning :refer [agenda-points-required-to-win]]
    [game.test-framework :refer :all]
    [game.utils :as utils]))
 
@@ -2423,7 +2424,7 @@
       (take-credits state :runner)
       (score-agenda state :corp hok)
       (is (= 0 (get-counters (refresh issuaq) :power)) "Issuaq has no power counters")
-      (is (= 7 (:agenda-point-req (get-corp))) "Corp still requires 7 points to win"))))
+      (is (= 7 (agenda-points-required-to-win state :corp)) "Corp still requires 7 points to win"))))
 
 (deftest issuaq-adaptics-single-score
   ;; Issuaq Adaptics - Adjust point requirement when a single agenda is scored
@@ -2438,7 +2439,7 @@
       (play-from-hand state :corp "Seamless Launch")
       (click-card state :corp pk)
       (score state :corp (refresh pk))
-      (is (= 6 (:agenda-point-req (get-corp))) "Corp Agenda point requirement reduced by 1")
+      (is (= 6 (agenda-points-required-to-win state :corp)) "Corp Agenda point requirement reduced by 1")
       (is (= 1 (get-counters (refresh issuaq) :power)) "Issuaq Adaptics has 1 power counter"))))
 
 (deftest issuaq-adaptics-multiple-score
@@ -2459,7 +2460,7 @@
         (click-card state :corp pk2)
         (score state :corp (refresh pk1))
         (score state :corp (refresh pk2))
-        (is (= 5 (:agenda-point-req (get-corp))) "Corp Agenda point requirement reduced by 2")
+        (is (= 5 (agenda-points-required-to-win state :corp)) "Corp Agenda point requirement reduced by 2")
         (is (= 2 (get-counters (refresh issuaq) :power)) "Issuaq Adaptics has 2 power counters"))))
 
 (deftest jemison-astronautics-sacrifice-audacity-success


### PR DESCRIPTION
I made the card text agenda point reqs (issuaq, harmony) into static abilities, and the rules ones (draft format, etc) can stay as they are.

I also made it so that you can see changed agenda point requirements on the frontend (they only show up when it's not 7 points to win)

![agenda-point-req](https://github.com/user-attachments/assets/552805f4-b5a1-473a-a493-a762dec1031a)

Closes #7962