### PR TITLE
swap sides command

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -432,15 +432,9 @@
                       (do (toast state (other-side side) "your opponent does not wish to swap sides")
                           (swap! state assoc-in [side :command-info :ignore-swap-sides] true))
                       (= target "Accept")
-                      (let [old-runner (get-in @state [:runner :user])
-                            old-runner-options (get-in @state [:runner :options])]
-                        (system-msg state side "accepts the request to swap sides. Players swap sides")
-                        (lobby-command {:command :swap-sides
-                                        :gameid (:gameid @state)})
-                        (swap! state assoc-in [:runner :user] (get-in @state [:corp :user]))
-                        (swap! state assoc-in [:runner :options] (get-in @state [:corp :options]))
-                        (swap! state assoc-in [:corp :user] old-runner)
-                        (swap! state assoc-in [:corp :options] old-runner-options))))}
+                      (do (system-msg state side "accepts the request to swap sides. Players swap sides")
+                          (lobby-command {:command :swap-sides
+                                          :gameid (:gameid @state)}))))}
       nil nil)))
 
 (defn parse-command

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -49,7 +49,7 @@
            {:eid (select-keys eid [:eid])
             :card card
             :prompt-type :waiting
-            :msg (str "Waiting for " 
+            :msg (str "Waiting for "
                       (if (true? waiting-prompt)
                         (str (side-str side) " to make a decision")
                         waiting-prompt))}))

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -288,6 +288,9 @@
    {:name "/swap-installed"
     :usage "/swap-installed"
     :help "Swap the position of two installed non-ice (Corp only)"}
+   {:name "/swap-sides"
+    :usage "/swap-sides"
+    :help "Request to swap sides with your opponent"}
    {:name "/tag"
     :has-args :required
     :usage "/tag n"

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1869,8 +1869,7 @@
          [:div.button-pane {:on-mouse-over #(card-preview-mouse-over % zoom-channel)
                             :on-mouse-out  #(card-preview-mouse-out % zoom-channel)}
           (cond
-            (and @prompt-state
-                 (not= "run" @prompt-type))
+            (and @prompt-state (not= "run" (get-in @prompt-state [:prompt-type])))
             [prompt-div me @prompt-state]
             (or @run
                 @encounters)


### PR DESCRIPTION
Added a command that allows you to swap sides with your opponent. This is primarily intended for teaching/learn to play, and also for debugging, but there's no reason players can't have fun with it either.

It requires both sides to consent, and you can just click "don't ask me again" if you like.