### PR TITLE
choose-one-prevention-click-on-cards

### DIFF
--- a/src/clj/game/core/choose_one.clj
+++ b/src/clj/game/core/choose_one.clj
@@ -34,10 +34,13 @@
                         x))
            ;; cost->str for a choice
            costed-str (fn [x]
-                        (if-not (:cost x)
-                          (:option x)
-                          (let [cs (build-cost-string (:cost x))]
-                            (if-not (:option x) cs (str cs ": " (:option x))))))
+                        (let [choice-str (if-not (:cost x)
+                                           (:option x)
+                                           (let [cs (build-cost-string (:cost x))]
+                                             (if-not (:option x) cs (str cs ": " (:option x)))))]
+                          (if (:card x)
+                            (assoc (:card x) :title choice-str)
+                            choice-str)))
            ;; converts options to choices
            choices-fn (fn [x state side eid card targets]
                         (when (payable? x state side eid card targets)
@@ -57,7 +60,7 @@
                  (if-not (seq xs)
                    (effect-completed state side eid )
                    (if (= target (costed-str (first xs)))
-                     ;; allow for resolving multiple options, like decues wild
+                     ;; allow for resolving multiple options, like deuces wild
                      (wait-for
                        (resolve-ability
                          state side (make-eid state eid)

--- a/src/clj/game/core/prevention.clj
+++ b/src/clj/game/core/prevention.clj
@@ -174,6 +174,7 @@
   "Builds a menu item for firing a prevention ability"
   [prevention key]
   {:option (or (:label prevention) (->> prevention :card :printed-title))
+   :card (:card prevention)
    :ability {:async true
              :effect (req (trigger-prevention state side eid key prevention))}})
 


### PR DESCRIPTION
completely an afterthought, but this will make it so that the choose-one-helper will highlight cards if you highlight the buttons, and then when #7974 goes through, you should be able to click on the cards to resolve the buttons like with other prompts.