### PR TITLE
Clean Up in Quotes Code

### DIFF
--- a/src/clj/game/quotes.clj
+++ b/src/clj/game/quotes.clj
@@ -10,23 +10,20 @@
 
 (def identity-quotes (atom {}))
 
+(defn- load-quote-file [filename]
+  (let [file (io/file filename)]
+    (when (.exists file)
+      (edn/read-string (slurp file)))))
+
 (defn load-quotes! []
-  (let [quotes-corp (when (.exists (io/file quotes-corp-filename))
-                      (-> (io/file quotes-corp-filename)
-                          (slurp)
-                          (edn/read-string)))
-        quotes-runner (when (.exists (io/file quotes-runner-filename))
-                        (-> (io/file quotes-runner-filename)
-                            (slurp)
-                            (edn/read-string)))]
-    (reset! identity-quotes (merge quotes-corp quotes-runner))))
+  (reset! identity-quotes (merge (load-quote-file quotes-corp-filename)
+                                 (load-quote-file quotes-runner-filename))))
 
 (defn- choose-and-repeat [options qty]
   (when (not-empty options)
     (repeat qty (first (shuffle options)))))
 
 (defn make-quote [{player-ident :title} {opp-ident :title opp-faction :faction}]
-
   (let [generic (get-in @identity-quotes [player-ident generic-key])
         opp-faction (get-in @identity-quotes [player-ident opp-faction])
         opp-specific (get-in @identity-quotes [player-ident opp-ident])
@@ -37,5 +34,3 @@
     (if (not-empty non-blank)
       (first (shuffle non-blank))
       "NO QUOTE SRY")))
-
-


### PR DESCRIPTION
When I was learning how to update the quotes file I noticed some weird things in the code that read it. So I have done a minor bit of clean-up, proving I can do some programming in Clojure.

- Added `load-quote-file` as a helper to absorb the repeated code in `load-quotes!` (and it also removes another bit of repeated work).
- Removed some extra lines of whitespace.

I have tested it and it seems to work and I have used the conventions as I have understood them from looking at the project.