### PR TITLE
Modified Lobby Sort

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -233,12 +233,15 @@
           (not (or user-blocked-players? players-blocked-user?))))
       lobbies)))
 
-(defn sorted-lobbies [lobbies]
-  "ideally we only sort these once"
-  (->> (map lobby-summary lobbies)
-       (sort-by :date)
-       (reverse)
-       (sort-by :started)))
+(defn sorted-lobbies
+  "Sorts `lobbies` into a list with opened games on top, and other games below.
+  Open games will be sorted oldest to newest, other games will be sorted newest to oldest."
+  [lobbies]
+  (let [grouped-lobbies (group-by :started (->> (map lobby-summary lobbies)
+                                                (sort-by :date)))
+        started (get grouped-lobbies true)
+        open (get grouped-lobbies nil)]
+    (concat open (reverse started))))
 
 (comment
   (->> (for [x (range 5 10)]

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -252,13 +252,6 @@
         {:keys [open allowing-spectators no-spectators]} grouped-lobbies]
     (concat open (reverse allowing-spectators) (reverse no-spectators))))
 
-(comment
-  (->> (for [x (range 5 10)]
-         {:date (doto (java.util.Calendar/getInstance)
-                  (.set (+ 2000 (+ (rand-int x) (rand-int x))) 1 2))
-          :started (rand-nth [true false])})
-       (summaries-for-lobbies)))
-
 (defn prepare-lobby-list
   [lobbies users]
   (let [in-order-lobbies (sorted-lobbies lobbies)]


### PR DESCRIPTION
This pull request is my proposed solution to issue #7587 

The goal of this solution is to make games that have been waiting longer more easily accessible, while also making newer games easier for spectators to access
 
This sorting solution splits the lobbies into 3 categories. Each group is individually sorted and combined in this order (top to bottom)
1. Open Lobbies - sorted with oldest on top - newest on bottom
2. Started Games Allowing Spectators - newest on top, oldest on bottom
3. Started Games Not Allowing Spectators - newest on top, oldest on bottom 

Let me know if this solution works, or if we want to take another approach to sorting lobbies. If accepted:

closes #7587 