### PR TITLE
Qol and bugfixes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1603,26 +1603,26 @@
                 :async true
                 :cost [(->c :x-power)]
                 :keep-menu-open :while-power-tokens-left
-                :effect
-                (effect
-                  (continue-ability
-                    {:prompt "Choose an agenda in HQ to reveal"
-                     :choices {:req (req (and (agenda? target)
-                                              (<= (:agendapoints target) (cost-value eid :x-power))))}
-                     :msg (msg "reveal " (:title target) " from HQ")
-                     :async true
-                     :effect (req (wait-for (reveal state side target)
-                                            (let [title (:title target)]
-                                              (register-turn-flag!
-                                                state side
-                                                card :can-steal
-                                                (fn [state _side card]
-                                                  (if (= (:title card) title)
-                                                    ((constantly false)
-                                                     (toast state :runner "Cannot steal due to Lakshmi Smartfabrics." "warning"))
-                                                    true)))
-                                              (effect-completed state side eid))))}
-                    card nil))}]})
+                :effect (req (let [value (cost-value eid :x-power)]
+                               (continue-ability
+                                 state side
+                                 {:prompt "Choose an agenda in HQ to reveal"
+                                  :choices {:req (req (and (agenda? target)
+                                                           (<= (:agendapoints target) value)))}
+                                  :msg (msg "reveal " (:title target) " from HQ")
+                                  :async true
+                                  :effect (req (wait-for (reveal state side target)
+                                                         (let [title (:title target)]
+                                                           (register-turn-flag!
+                                                             state side
+                                                             card :can-steal
+                                                             (fn [state _side card]
+                                                               (if (= (:title card) title)
+                                                                 ((constantly false)
+                                                                  (toast state :runner "Cannot steal due to Lakshmi Smartfabrics." "warning"))
+                                                                 true)))
+                                                           (effect-completed state side eid))))}
+                                 card nil)))}]})
 
 (defcard "Launch Campaign"
   (campaign 6 2))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1949,7 +1949,7 @@
                           (in-deck? (:card %))))
                 ctx))
         relevant-cards-general #{"Labor Rights" "The Price"}
-        relevant-cards-trashed #{"I've Had Worse" "Strike Fund" "Steelskin Scarring"}
+        relevant-cards-trashed #{"I've Had Worse" "Strike Fund" "Steelskin Scarring" "Crowdfunding"}
         trigger-ability-req (req (let [res-type (get-in (get-card state card) [:special :resolution-mode])
                                        valid-cards (mapv #(get-card state %) (filter runner? context))]
                                    (and (some runner? context)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -850,8 +850,7 @@
                      state side
                      {:async true
                       :prompt (str "Choose a card to rez, paying " discount " [Credits] less")
-                      :choices {:req (req (and (every-pred installed? corp? (complement rezzed?)
-                                                           installed? (complement agenda?))
+                      :choices {:req (req (and ((every-pred installed? corp? (complement rezzed?) (complement agenda?)) target)
                                                (can-pay-to-rez? state side (assoc eid :source card)
                                                                 target {:cost-bonus (- discount)})))}
                       :effect (req (rez state side eid target {:cost-bonus (- discount)}))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3636,8 +3636,10 @@
 (defcard "The Twinning"
   {:events [{:event :spent-credits-from-card
              :req (req (let [valid-ctx? (fn [[{:keys [card] :as ctx}]] (and (runner? card)
-                                                                           (installed? card)))]
-                         (and (valid-ctx? [context]) (first-event? state side :spent-credits-from-card valid-ctx?))))
+                                                                            (installed? card)))]
+                         (and (some #(valid-ctx? [%]) targets)
+                              (first-event? state side :spent-credits-from-card valid-ctx?))))
+             :once-per-instance true
              :async true
              :msg "place a power counter on itself"
              :effect (req (add-counter state :runner eid card :power 1 {:placed true}))}

--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -96,7 +96,7 @@
           :brain-damage
           [:div (str brain-damage " " (tr [:game.brain-damage "Core Damage"]))])
          (when (= (:side @game-state) :runner)
-           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :delta (.. % -target -checked)})]
+           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :value (.. % -target -checked)})]
              [:div [:label [:input {:type "checkbox"
                                     :value true
                                     :checked trash-like-cards
@@ -119,7 +119,7 @@
          (let [{:keys [base additional]} bad-publicity]
            (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))
          (when (= (:side @game-state) :corp)
-           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :delta (.. % -target -checked)})]
+           (let [toggle-offer-trash #(send-command "set-property" {:key :trash-like-cards :value (.. % -target -checked)})]
              [:div [:label [:input {:type "checkbox"
                                     :value true
                                     :checked trash-like-cards

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -3170,7 +3170,11 @@
   ;; Lakshmi Smartfabrics - Gain power counter when rezzing a card; use counters to protect agenda in HQ
   (do-game
     (new-game {:corp {:deck ["Lakshmi Smartfabrics" "Vanilla"
-                             "Marked Accounts" "Elective Upgrade"]}})
+                             "Marked Accounts" "Elective Upgrade"]}
+               :runner {:hand ["Rezeki"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Rezeki")
+    (take-credits state :runner)
     (play-from-hand state :corp "Lakshmi Smartfabrics" "New remote")
     (let [lak (get-content state :remote1 0)]
       (rez state :corp lak)

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -7200,6 +7200,19 @@
       (click-prompt state :runner "No action")
       (is (no-prompt? state :runner) "No prompt left over"))))
 
+(deftest twinning-only-gets-one-counter-from-multiple-credit-sources
+  (do-game
+    (new-game {:runner {:hand ["The Twinning" "Public Terminal" "Prepaid VoicePAD" "Dirty Laundry"]
+                        :credits 15}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "The Twinning")
+    (play-from-hand state :runner "Public Terminal")
+    (play-from-hand state :runner "Prepaid VoicePAD")
+    (play-from-hand state :runner "Dirty Laundry")
+    (is (changed? [(get-counters (get-resource state 0) :power) 1]
+          (click-prompts state :runner "Prepaid VoicePAD" "Public Terminal" "HQ"))
+        "Only got one counter")))
+
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool
   (do-game


### PR DESCRIPTION
* I fixed lakshmi so it works again (added a unit test too) - Closes #7995
* twinning is once-per-instance now, so it interacts nicely with all the credit events firing at once (and a unit test) - Closes #8005
* Divert power was checking that a function was true, rather than it's result - whoops! - Closes #8003
* Jai wanted me to add crowdfunding to the skorpios smart interrupt list, so I did
* I just needed to change the key for the trash like cards thing - Closes #7998