### PR TITLE
Add autoresolve optional to you some may abilities

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -3236,7 +3236,8 @@
                                 (strength-pump (->c :credit 1 {:stealth 1}) 7 :end-of-encounter)]}))
 
 (defcard "Takobi"
-  {:events [{:event :subroutines-broken
+  {:special {:auto-place-counter :always}
+   :events [{:event :subroutines-broken
              :optional {:req (req (:all-subs-broken target))
                         :prompt (msg "Place 1 power counter on " (:title card) "?")
                         :autoresolve (get-autoresolve :auto-place-counter)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -860,6 +860,7 @@
              :interactive (req true)
              :optional {:prompt "Place 1 virus counter?"
                         :req (req (has-subtype? (:card context) "Virus"))
+                        :waiting-prompt true
                         :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability {:msg (msg "place 1 virus counter on " (card-str state (:card context)))
                                       :async true
@@ -1536,23 +1537,12 @@
                                  (effect-completed state side eid)))}]}))
 
 (defcard "Find the Truth"
-  {:implementation "Corporation can click Find the Truth for explicit card reveals"
-   :events [{:event :post-runner-draw
+  {:events [{:event :post-runner-draw
              :msg (msg "reveal that they drew "
                        (enumerate-str (map :title runner-currently-drawing)))
              :async true
              :effect (req (let [current-draws runner-currently-drawing]
-                            (reveal state side eid current-draws)
-                            ;; If the corp wants explicit reveals from FTT, then show a prompt with
-                            ;; the card names in it
-                            (when  (= (get-in (get-card state card) [:special :explicit-reveal])
-                                      :yes)
-                              (continue-ability
-                               state :corp
-                               {:prompt (msg "The runner reveals that they drew "
-                                             (enumerate-str (map :title current-draws)))
-                                :choices ["OK"]}
-                               card nil))))}
+                            (reveal state side eid current-draws)))}
             {:event :successful-run
              :interactive (get-autoresolve :auto-peek (complement never?))
              :silent (get-autoresolve :auto-peek never?)
@@ -1563,15 +1553,7 @@
                         :yes-ability {:prompt (req (->> corp :deck first :title (str "The top card of R&D is ")))
                                       :msg "look at the top card of R&D"
                                       :choices ["OK"]}}}]
-   :abilities [(set-autoresolve :auto-peek "Find the Truth looking at the top card of R&D")]
-   :corp-abilities [{:label "Explicitly reveal drawn cards"
-                     :prompt "Explicitly reveal cards the Runner draws?"
-                     :choices ["Yes" "No"]
-                     :effect (effect (update! (assoc-in card [:special :explicit-reveal](keyword (str/lower-case target))))
-                                     (toast (str "From now on, " (:title card) " will "
-                                                 (when (= target "No") "Not")
-                                                 "explicitly reveal cards the Runner draws")
-                                            "info"))}]})
+   :abilities [(set-autoresolve :auto-peek "Find the Truth looking at the top card of R&D")]})
 
 (defcard "First Responders"
   {:abilities [{:cost [(->c :credit 2)]
@@ -1961,7 +1943,8 @@
                                 (effect-completed state side eid))))}]})
 
 (defcard "Kasi String"
-  {:events [{:event :run-ends
+  {:special {:auto-place-counter :always}
+   :events [{:event :run-ends
              :optional
              {:req (req (and (first-event? state :runner :run-ends #(is-remote? (:server (first %))))
                              (not (:did-steal target))
@@ -2254,7 +2237,8 @@
                   {:prompt (req (->> runner :deck first :title (str "The top card of the stack is ")))
                    :msg "look at the top card of the stack"
                    :choices ["OK"]}}}]
-    {:flags {:runner-turn-draw true
+    {:special {:auto-fire :always}
+     :flags {:runner-turn-draw true
              :runner-phase-12 (req (some #(card-flag? % :runner-turn-draw true) (all-active-installed state :runner)))}
      :events [(assoc ability :event :runner-turn-begins)]
      :abilities [ability (set-autoresolve :auto-fire "Motivation")]}))
@@ -2522,15 +2506,20 @@
               (assoc ability :event :runner-spent-credits)]}))
 
 (defcard "PAD Tap"
-  {:events [{:event :corp-credit-gain
-             :req (req (and (not= (:action context) :corp-click-credit)
-                            (= 1 (->> (turn-events state :corp :corp-credit-gain)
-                                      (remove (fn [[context]]
-                                                (= (:action context) :corp-click-credit)))
-                                      count))))
-             :msg "gain 1 [Credits]"
-             :async true
-             :effect (effect (gain-credits :runner eid 1))}]
+  {:special {:auto-fire :always}
+   :events [{:event :corp-credit-gain
+             :optional {:prompt "Gain 1 [Credit]?"
+                        :req (req (and (not= (:action context) :corp-click-credit)
+                                       (= 1 (->> (turn-events state :corp :corp-credit-gain)
+                                                 (remove (fn [[context]]
+                                                           (= (:action context) :corp-click-credit)))
+                                                 count))))
+                        :waiting-prompt true
+                        :autoresolve (get-autoresolve :auto-fire)
+                        :yes-ability {:msg "gain 1 [Credits]"
+                                      :async true
+                                      :effect (effect (gain-credits :runner eid 1))}}}]
+   :abilities [(set-autoresolve :auto-fire "PAD Tap")]
    :corp-abilities [{:action true
                      :label "Trash PAD Tap"
                      :async true
@@ -2785,7 +2774,8 @@
                                        (draw state side eid 1)))}]})
 
 (defcard "Psych Mike"
-  {:events [{:event :run-ends
+  {:special {:auto-fire :always}
+   :events [{:event :run-ends
              :optional {:req (req (and (= :rd (target-server context))
                                        (first-successful-run-on-server? state :rd)
                                        (pos? (total-cards-accessed target :deck))))

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -145,7 +145,9 @@
                     cost-paid (merge-costs-paid (:cost-paid eid) (:cost-paid async-result))
                     eid (assoc eid :cost-paid cost-paid :source-type :ability)]
                 (if payment-str
-                  (complete-play-instant state side eid moved-card payment-str ignore-cost)
+                  (do
+                    (update! state side (assoc moved-card :special (:special (card-def moved-card))))
+                    (complete-play-instant state side eid moved-card payment-str ignore-cost))
                   ;; could not pay the card's price; put it back and mark the effect as being over.
                   (let [returned-card (move state side moved-card original-zone)]
                     (continue-ability
@@ -153,11 +155,11 @@
                       {:msg (msg "reveal that they are unable to play " (:title card))
                        :cost (when (:base-cost args) [(:base-cost args)])
                        :async true
-                       :effect (req (update! state :runner (-> returned-card
-                                               (dissoc :seen)
-                                               (assoc
-                                                 :cid (:cid card)
-                                                 :previous-zone (:previous-zone card))))
+                       :effect (req (update! state side (-> returned-card
+                                                            (dissoc :seen)
+                                                            (assoc
+                                                              :cid (:cid card)
+                                                              :previous-zone (:previous-zone card))))
                                     (reveal state side eid card))}
                       card nil)))))))
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -8373,7 +8373,6 @@
         (run-continue state)
         (card-ability state :runner corr 0)
         (click-prompt state :runner "End the run")
-        (click-prompt state :runner "Yes")
         (run-continue state)
         (is (= 1 (get-counters (refresh tako) :power)) "Counter gained from breaking all subs"))))
 

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3732,7 +3732,6 @@
       (dotimes [_ 3]
         (run-empty-server state "Server 1")
         (click-prompt state :runner "No action")
-        (click-prompt state :runner "Yes")
         (take-credits state :runner)
         (take-credits state :corp))
       (take-credits state :runner)
@@ -3769,7 +3768,6 @@
       (take-credits state :corp)
       (run-empty-server state "Server 1")
       (click-prompt state :runner "No action")
-      (click-prompt state :runner "Yes")
       (is (= 1 (get-counters (get-resource state 0) :power)) "Kasi String should have 1 power counter on itself")))
 
 (deftest kati-jones
@@ -5353,7 +5351,6 @@
       (let [credits (:credit (get-runner))]
         (run-empty-server state "R&D")
         (click-prompt state :runner "No action")
-        (click-prompt state :runner "Yes")
         (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card"))
       (let [credits (:credit (get-runner))]
         (run-empty-server state "R&D")
@@ -5366,13 +5363,14 @@
         (run-continue state)
         (dotimes [_ 5]
           (click-prompt state :runner "No action"))
-        (click-prompt state :runner "Yes")
         (is (= (+ credits 5) (:credit (get-runner))) "Psych Mike should give 5 credits for DDM accesses"))
         (run-empty-server state "HQ")
         (click-prompt state :runner "No action")
     (is (not (last-log-contains? state "Psych Mike to gain 0")) "No log should be printed")
       (take-credits state :runner)
       (take-credits state :corp)
+      (card-ability state :runner (get-resource state 0) 0)
+      (click-prompt state :runner "Ask")
       (let [credits (:credit (get-runner))]
         (run-empty-server state "R&D")
         (click-prompt state :runner "No action")
@@ -5406,7 +5404,6 @@
         (click-prompt state :runner "Unrezzed upgrade")
         (click-prompt state :runner "No action")
         (click-prompt state :runner "No action")
-        (click-prompt state :runner "Yes")
         (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card"))))
 
 (deftest reclaim-basic-behavior


### PR DESCRIPTION
I picked out a few optional abilities that we didn't actually make optional, and just added autoresolves to them (they're automatically set to true on play/rez).
* PAD Tap
* Death and Taxes
* TechnoCo
* Personalized Portal

I also picked out a few cards that basically only say "you may" to stop players getting game losses if they forget/cards that you basically always want to click "Yes" for, and make them just autoresolve by default.
* Kasi String
* Takobi
* Psych Mike

Additionally, I removed the explicit reveal feature from Always be running because that's baked into the game UI now (revealed cards show up in the top left corner)