### PR TITLE
Alt art grouping

### DIFF
--- a/src/clj/tasks/images.clj
+++ b/src/clj/tasks/images.clj
@@ -66,7 +66,7 @@
    (let [filename (.getName f)]
      (if (str/includes? filename "-")
        (add-flip-card-image db base-path lang resolution art-set filename)
-       (let [code (first (str/split filename #"\."))
+       (let [code (first (str/split filename #"[a-zA-Z]*\."))
              k (str/join "." ["images" (name lang) (name resolution) (name art-set)])
              prev-k-root (if (= :stock art-set) code (name art-set))
              prev-k (str/join "." ["images" (name lang) (name resolution) prev-k-root])

--- a/src/clj/tasks/images.clj
+++ b/src/clj/tasks/images.clj
@@ -43,10 +43,15 @@
   (println "Removing old images from db cards")
   (mc/update db card-collection {} {$unset {:faces 1}} {:multi true})
   (mc/update db card-collection {} {$unset {:images 1}} {:multi true}))
+;; note: this should select a period, perhaps preceeded by an alphabetic string,
+;; so long as it either has front,back,or some numbers behind it
+;; the excess dots are because the lookbehind needs to be fixed width
+;; but this ensures we don't split on "front.", and instead split on "." for multi-faced cards
+(def ^:cost image-select-regex #"(?<=(.tank|house|ewery|front|.back|....[0123456789]))[a-zA-Z]*\.")
 
 (defn- add-flip-card-image
   [db base-path lang resolution art-set filename]
-  (let [code-face (first (str/split filename #"\."))
+  (let [code-face (first (str/split filename image-select-regex))
         code-face-split (str/split code-face #"-")
         code (first code-face-split)
         face (second code-face-split)
@@ -66,7 +71,7 @@
    (let [filename (.getName f)]
      (if (str/includes? filename "-")
        (add-flip-card-image db base-path lang resolution art-set filename)
-       (let [code (first (str/split filename #"[a-zA-Z]*\."))
+       (let [code (first (str/split filename image-select-regex))
              k (str/join "." ["images" (name lang) (name resolution) (name art-set)])
              prev-k-root (if (= :stock art-set) code (name art-set))
              prev-k (str/join "." ["images" (name lang) (name resolution) prev-k-root])

--- a/src/clj/tasks/images.clj
+++ b/src/clj/tasks/images.clj
@@ -72,8 +72,8 @@
              prev-k (str/join "." ["images" (name lang) (name resolution) prev-k-root])
              path (str/join "/" [base-path (name lang) (name resolution) (name art-set) filename])]
          (when-not (some #(= % code) cards-to-skip)
-           (mc/update db card-collection {:code code} {$set {k path}})
-           (mc/update db card-collection {:previous-versions {$elemMatch {:code code}}} {$set {prev-k path}})))))))
+           (mc/update db card-collection {:code code} {$addToSet {k path}})
+           (mc/update db card-collection {:previous-versions {$elemMatch {:code code}}} {$addToSet {prev-k path}})))))))
 
 (defn- add-alt-images
   "All all images in the specified alt directory"

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -199,14 +199,23 @@
   [card]
    (let [lang (get-in @app-state [:options :language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
-         art (if (keyword? (:art card)) (:art card) :stock)]
-     (get-image-path (:images card) (keyword lang) (keyword res) art)))
+         art (if (keyword? (:art card)) (:art card) :stock)
+         art-index (get card :art-index 0)]
+     [(nth (get-image-path (:images card) (keyword lang) (keyword res) art) art-index)]))
 
 (defn- alt-version-from-string
   "Given a string name, get the keyword version or nil"
   [setname]
   (when-let [alt (find-first #(= setname (:name %)) (:alt-info @app-state))]
     (keyword (:version alt))))
+
+(defn- card-arts-for-key
+  [card key]
+  (let [lang (get-in @app-state [:options :language] "en")
+        res (get-in @app-state [:options :card-resolution] "default")]
+    (if-let [arts (get-in card [:images (keyword lang) (keyword res) key])]
+      (vec (map-indexed (fn [idx item] (assoc card :art key :art-index idx)) arts))
+      [(assoc card :art "" :art-index 0)])))
 
 (defn- expand-alts
   [only-version acc card]
@@ -225,7 +234,7 @@
               (show-alt-art? true))
        (->> filtered-images
             (concat [""])
-            (map #(if % (assoc card :art %) card))
+            (mapcat #(card-arts-for-key card %))
             (map #(if (not= "" (:art %)) (dissoc % :previous-versions) %))
             (concat acc))
        (conj acc card))))
@@ -286,10 +295,11 @@
         art (:art card)
         code-kw (keyword (:future-version card (:code card)))
         alts (:alt-arts (:options @app-state))
+        alt-index (get card :art-index 0)
         new-alts (cond
-                   (keyword? art) (assoc alts code-kw (name art))
+                   (keyword? art) (assoc alts code-kw [(name art) alt-index])
                    is-old-card (assoc alts code-kw (:code card))
-                   :else (dissoc alts code-kw))] ; remove the key entirely if the newest card is selected
+                   :else (dissoc alts code-kw))]
     (swap! app-state assoc-in [:options :alt-arts] new-alts)
     (nr.account/post-options "/profile" (partial post-response))))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -59,7 +59,11 @@
               "stock")
         card (if (or (:face card) (:images card)) card (get @all-cards (get-title card)))
         images (image-or-face card)]
-    (get-image-path images (keyword lang) (keyword res) (keyword art))))
+    (if (sequential? art)
+      (let [art-urls (get-image-path images (keyword lang) (keyword res) (keyword (first art)))
+            chosen-art (nth art-urls (second art))]
+        [chosen-art])
+      (get-image-path images (keyword lang) (keyword res) (keyword art)))))
 
 
 (defonce button-channel (chan))


### PR DESCRIPTION
The regex will probably need to be adjusted for alt versions of flip cards, but that's a bridge that can be crossed later.

The output on mongo looks like this, for a case with two versions of overclock in the same folder:
![db-output_000](https://github.com/user-attachments/assets/1187df4b-9f2e-4c3e-90a6-0800693a2e5c)

Closes #8004 