### PR TITLE
Updated defcard Macro for More Expressive Use

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1352,13 +1352,13 @@
                                 (reveal state side topcard)
                                 (system-msg state :runner (str "reveals " topcard
                                                                " from the top of R&D"))
-                                (continue-ability state side (force-draw topcard) card nil))))}}}])
-  {:events [{:event :successful-run
-             :req (req (= :rd (target-server context)))
-             :async true
-             :interactive (req true)
-             :waiting-prompt true
-             :effect (effect (continue-ability rvl card nil))}]})
+                                (continue-ability state side (force-draw topcard) card nil))))}}}]
+    {:events [{:event :successful-run
+               :req (req (= :rd (target-server context)))
+               :async true
+               :interactive (req true)
+               :waiting-prompt true
+               :effect (effect (continue-ability rvl card nil))}]}))
 
 (defcard "Euler"
   (auto-icebreaker {:abilities [(break-sub 0 1 "Code Gate" {:req (req (= :this-turn (installed? card)))})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -700,7 +700,7 @@
              :effect (effect (add-counter eid card :virus 1 nil))}]
    :abilities [(break-sub
                  [(->c :virus 1)] 1 "All"
-                {:req (req (same-card? current-ice (:host card)))})]})
+                 {:req (req (same-card? current-ice (:host card)))})]})
 
 (defcard "Brahman"
   (auto-icebreaker {:abilities [(break-sub 1 2 "All")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -691,16 +691,16 @@
                    (strength-pump 3 3 :end-of-encounter {:cost-bonus discount-fn})]})))
 
 (defcard "Botulus"
-  (auto-icebreaker
-    (trojan
-      {:implementation "[Erratum] Program: Virus - Trojan"
-       :data {:counter {:virus 1}}
-       :events [{:event :runner-turn-begins
-                 :async true
-                 :effect (effect (add-counter eid card :virus 1 nil))}]
-       :abilities [(break-sub
-                     [(->c :virus 1)] 1 "All"
-                     {:req (req (same-card? current-ice (:host card)))})]})))
+  auto-icebreaker
+  trojan
+  {:implementation "[Erratum] Program: Virus - Trojan"
+   :data {:counter {:virus 1}}
+   :events [{:event :runner-turn-begins
+             :async true
+             :effect (effect (add-counter eid card :virus 1 nil))}]
+   :abilities [(break-sub
+                 [(->c :virus 1)] 1 "All"
+                {:req (req (same-card? current-ice (:host card)))})]})
 
 (defcard "Brahman"
   (auto-icebreaker {:abilities [(break-sub 1 2 "All")
@@ -1318,14 +1318,13 @@
                                 (strength-pump 3 2)]}))
 
 (defcard "Egret"
-  (trojan
-    {:rezzed true}
-    {:implementation "[Erratum] Program: Trojan"
-     :on-install {:msg (msg "make " (card-str state (:host card))
-                            " gain Barrier, Code Gate and Sentry subtypes")}
-     :static-abilities [{:type :gain-subtype
-                         :req (req (same-card? target (:host card)))
-                         :value ["Barrier" "Code Gate" "Sentry"]}]}))
+  (trojan {:rezzed true})
+  {:implementation "[Erratum] Program: Trojan"
+   :on-install {:msg (msg "make " (card-str state (:host card))
+                          " gain Barrier, Code Gate and Sentry subtypes")}
+   :static-abilities [{:type :gain-subtype
+                       :req (req (same-card? target (:host card)))
+                       :value ["Barrier" "Code Gate" "Sentry"]}]})
 
 (defcard "Endless Hunger"
   {:implementation "ETR restriction not implemented"
@@ -1353,13 +1352,13 @@
                                 (reveal state side topcard)
                                 (system-msg state :runner (str "reveals " topcard
                                                                " from the top of R&D"))
-                                (continue-ability state side (force-draw topcard) card nil))))}}}]
-    {:events [{:event :successful-run
-               :req (req (= :rd (target-server context)))
-               :async true
-               :interactive (req true)
-               :waiting-prompt true
-               :effect (effect (continue-ability rvl card nil))}]}))
+                                (continue-ability state side (force-draw topcard) card nil))))}}}])
+  {:events [{:event :successful-run
+             :req (req (= :rd (target-server context)))
+             :async true
+             :interactive (req true)
+             :waiting-prompt true
+             :effect (effect (continue-ability rvl card nil))}]})
 
 (defcard "Euler"
   (auto-icebreaker {:abilities [(break-sub 0 1 "Code Gate" {:req (req (= :this-turn (installed? card)))})

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -323,11 +323,18 @@
                                  (unregister-ev-callback)
                                  (effect-completed state side eid)))))})))
 
+; (defcard title transformers* body)
+; Define a card to be returned from card-def. The definition consists of the
+; title (a string), 0 or more transformers and a body (an expression, usually
+; a map). Each tranformer should be a symbol or a list, symbols are wrapped
+; in lists and then the last transformer has the body inserted at the end,
+; then the second last has the result inserted as its last item and so on.
 (defmacro defcard
-  [title ability]
+  [title body & more]
   `(do (swap! card-defs-cache dissoc ~title)
        (defmethod card-defs/defcard-impl ~title [~'_]
          (or (get @card-defs-cache ~title)
-             (let [ability# (add-default-abilities ~title ~ability)]
+             (let [ability# (->> ~@(reverse (cons body more))
+                                 (add-default-abilities ~title))]
                (swap! card-defs-cache assoc ~title ability#)
                ability#)))))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -323,13 +323,13 @@
                                  (unregister-ev-callback)
                                  (effect-completed state side eid)))))})))
 
-; (defcard title transformers* body)
-; Define a card to be returned from card-def. The definition consists of the
-; title (a string), 0 or more transformers and a body (an expression, usually
-; a map). Each tranformer should be a symbol or a list, symbols are wrapped
-; in lists and then the last transformer has the body inserted at the end,
-; then the second last has the result inserted as its last item and so on.
 (defmacro defcard
+  "Define a card to be returned from card-def. The definition consists of the
+  title (a string), 0 or more transformers and a body (an expression, usually
+  a map). Each tranformer should be a symbol or a list, symbols are wrapped
+  in lists and then the last transformer has the body inserted at the end,
+  then the second last has the result inserted as its last item and so on."
+  {:arglists '([title ability] [title transformers* ability])}
   [title body & more]
   `(do (swap! card-defs-cache dissoc ~title)
        (defmethod card-defs/defcard-impl ~title [~'_]


### PR DESCRIPTION
Argumented the `defcard` macro so the body/ability can be given in multiple parts. The doesn't reduce the amount of code you actually need to write for most card definitions, but allows for better organization, removing the need for nesting and ")" counting.

The macro now consists of the existing template section, that has very little macro logic in it but adds a lot of boiler plate code, and a new ability section, that does more computation to get the body. Because a similar standard macro exists, that part is pretty small.

The logical signature of the macro is `(defcard title transformers* body)`. If you don't use any transformers this does the exact same things as before. But you can put in transformers and they will wrap up the body. I think this makes some of the helpers a bit more readable. (See the diff for examples.)

I considered adding some more short-hands that you could use in the macro, but most could just be written as a function that you use as a transformer. Even something like a let binding can be used as a transformer. Only exception to that was trying to make the suffix of the body that is the map explicit, but in the end that doesn't save you much more than the `{}` and is pretty confusing. So I stuck with this minimal for, which also kept the implementation small enough it went inline pretty cleanly.