### PR TITLE
fixed ui for issuaq

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -275,7 +275,6 @@
       (update :set-aside cards-summary state side)
       (update :prompt-state prompt-summary same-side?)
       (update :toast toast-summary same-side?)
-      (assoc :agenda-point-req (agenda-points-required-to-win state side))
       (select-non-nil-keys (into player-keys additional-keys))))
 
 (def corp-keys
@@ -321,6 +320,7 @@
   (let [corp-player? (= side :corp)
         install-list (:install-list corp)]
     (-> (player-summary corp state side corp-player? corp-keys)
+        (assoc :agenda-point-req (agenda-points-required-to-win state :corp))
         (update :deck deck-summary corp-player? corp)
         (update :hand hand-summary state corp-player? :corp corp)
         (update :discard discard-summary state corp-player? side corp)
@@ -351,6 +351,7 @@
   (let [runner-player? (= side :runner)
         runnable-list (:runnable-list runner)]
     (-> (player-summary runner state side runner-player? runner-keys)
+        (assoc :agenda-point-req (agenda-points-required-to-win state :runner))
         (update :deck deck-summary runner-player? runner)
         (update :hand hand-summary state runner-player? :runner runner)
         (update :discard prune-cards)


### PR DESCRIPTION
Didn't realize that `:side` on `player-summary` was the side looking at the stat rather than the player being inspected. Whoops.