### PR TITLE
Derez QOL

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -718,8 +718,7 @@
     :async true
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (effect (derez target {:source-card card})
-                    (effect-completed eid))}})
+    :effect (req (derez state side eid target {:msg-keys {:source-card card}}))}})
 
 (defcard "Eden Fragment"
   {:static-abilities [{:type :ignore-install-cost
@@ -1253,9 +1252,8 @@
                                                      (= (second (get-zone %)) zone))
                                          :max derez-count
                                          :min derez-count}
-                               :msg (msg "derez " (enumerate-str (map #(card-str state %) targets)))
-                               :effect (req (doseq [t targets]
-                                              (derez state side t {:no-msg true})))}
+                               :async true
+                               :effect (req (derez state side eid targets {:msg-keys {:source-card card}}))}
                               card nil)))})
           (ice-free-rez [state side targets card zone eid]
             (if (zero? (count targets))
@@ -2026,7 +2024,8 @@
                                            [{:event ev
                                              :unregister-once-resolved true
                                              :duration :end-of-turn
-                                             :effect (effect (derez c {:source-card card}))}])
+                                             :async true
+                                             :effect (effect (derez eid c {:msg-keys {:source-card card}}))}])
                                          (effect-completed state side eid))))}]})
 
 (defcard "Sentinel Defense Program"
@@ -2147,16 +2146,17 @@
                          :waiting-prompt true
                          :choices {:req (req (some #{target} rezzed-targets))}
                          :once :per-turn
-                         :msg (msg "derez " (card-str state target) " to gain 1 [Credits]")
                          :async true
-                         :effect (effect (derez target {:no-msg true})
-                                         (gain-credits eid 1))})
+                         :effect (req (wait-for
+                                        (derez state side target {:msg-keys {:source-card card
+                                                                             :and-then " and gain 1 [Credits]"}})
+                                        (gain-credits state side eid 1)))})
                       card nil)))}
             {:event :derez
              :req (req (and run
                             (first-run-event?
                               state side :derez
-                              (fn [[context]] (ice? (:card context))))))
+                              (fn [[context]] (some ice? (:cards context))))))
              :msg "lower strength of each installed icebreaker by 2"}]
    :leave-play (effect (update-all-icebreakers))
    :static-abilities [{:type :breaker-strength
@@ -2165,7 +2165,7 @@
                                       (has-subtype? target "Icebreaker")
                                       (<= 1 (run-event-count
                                               state side :derez
-                                              (fn [[context]] (ice? (:card context)))))))}]})
+                                              (fn [[context]] (some ice? (:cards context)))))))}]})
 
 (defcard "Sting!"
   (letfn [(count-opp-stings [state side]

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -718,7 +718,7 @@
     :async true
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (req (derez state side eid target {:msg-keys {:source-card card}}))}})
+    :effect (req (derez state side eid target))}})
 
 (defcard "Eden Fragment"
   {:static-abilities [{:type :ignore-install-cost
@@ -2025,7 +2025,7 @@
                                              :unregister-once-resolved true
                                              :duration :end-of-turn
                                              :async true
-                                             :effect (effect (derez eid c {:msg-keys {:source-card card}}))}])
+                                             :effect (effect (derez eid c))}])
                                          (effect-completed state side eid))))}]})
 
 (defcard "Sentinel Defense Program"
@@ -2148,8 +2148,7 @@
                          :once :per-turn
                          :async true
                          :effect (req (wait-for
-                                        (derez state side target {:msg-keys {:source-card card
-                                                                             :and-then " and gain 1 [Credits]"}})
+                                        (derez state side target {:msg-keys {:and-then " and gain 1 [Credits]"}})
                                         (gain-credits state side eid 1)))})
                       card nil)))}
             {:event :derez

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2938,22 +2938,25 @@
                 :effect (req (apply swap-installed state side targets))}]})
 
 (defcard "Test Ground"
-  (letfn [(derez-card [advancements]
-            (when (pos? advancements)
-              {:async true
-               :waiting-prompt true
-               :prompt "Derez a card"
-               :choices {:card #(and (installed? %)
-                                     (rezzed? %))}
-               :effect (req (derez state side target {:source-card card})
-                            (continue-ability state side (derez-card (dec advancements)) card nil))}))]
-    {:advanceable :always
-     :abilities [{:label "Derez 1 card for each advancement token"
-                  :req (req (pos? (get-counters card :advancement)))
-                  :msg (msg "derez " (quantify (get-counters card :advancement) "card"))
-                  :cost [(->c :trash-can)]
-                  :async true
-                  :effect (req (continue-ability state side (derez-card (get-counters card :advancement)) card nil))}]}))
+  {:advanceable :always
+   :abilities [{:label "Derez 1 card for each advancement token"
+                :req (req (pos? (get-counters card :advancement)))
+                :cost [(->c :trash-can)]
+                :async true
+                :effect (req (let [cards-to-pick (min (count (filter #(and (rezzed? %) (not (agenda? %))) (all-installed state :corp)))
+                                                      (get-counters card :advancement))
+                                   payment-eid eid]
+                               (continue-ability
+                                 state side
+                                 {:prompt (str "derez " cards-to-pick " cards")
+                                  :waiting-prompt true
+                                  :choices {:card (every-pred installed? rezzed? (complement agenda?))
+                                            :max cards-to-pick
+                                            :all true}
+                                  :async true
+                                  :effect (req (derez state side eid targets {:msg-keys {:source-card card
+                                                                                         :include-cost-from-eid payment-eid}}))}
+                                 card nil)))}]})
 
 (defcard "The Board"
   {:on-trash executive-trash-effect
@@ -3243,9 +3246,8 @@
                    :prompt "Choose another card to derez"
                    :choices {:not-self true
                              :card #(rezzed? %)}
-                   :msg (msg "derez itself to derez " (card-str state target))
-                   :effect (effect (derez card {:source-card card})
-                                   (derez target {:source-card card}))}]
+                   :async true
+                   :effect (req (derez state side eid [card target] {:msg-keys {:source-card card}}))}]
     {:derezzed-events [corp-rez-toast]
      :events [{:event :corp-turn-begins
                :interactive (req true)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2954,8 +2954,7 @@
                                             :max cards-to-pick
                                             :all true}
                                   :async true
-                                  :effect (req (derez state side eid targets {:msg-keys {:source-card card
-                                                                                         :include-cost-from-eid payment-eid}}))}
+                                  :effect (req (derez state side eid targets {:msg-keys {:include-cost-from-eid payment-eid}}))}
                                  card nil)))}]})
 
 (defcard "The Board"
@@ -3247,7 +3246,7 @@
                    :choices {:not-self true
                              :card #(rezzed? %)}
                    :async true
-                   :effect (req (derez state side eid [card target] {:msg-keys {:source-card card}}))}]
+                   :effect (req (derez state side eid [card target]))}]
     {:derezzed-events [corp-rez-toast]
      :events [{:event :corp-turn-begins
                :interactive (req true)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -65,7 +65,7 @@
                               zones->sorted-names]]
    [game.core.set-aside :refer [get-set-aside set-aside]]
    [game.core.shuffling :refer [shuffle! shuffle-into-deck]]
-   [game.core.tags :refer [gain-tags lose-tags]]
+   [game.core.tags :refer [gain-tags gain-tags-ability lose-tags]]
    [game.core.threat :refer [threat threat-level]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
@@ -4161,9 +4161,9 @@
                {:async true
                 :prompt "How many [Credits] do you want to spend?"
                 :choices :credit
-                :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
+                :msg (msg "make the Corp lose " target " [Credits]")
                 :effect (req (wait-for (lose-credits state :corp (make-eid state eid) target)
-                                       (gain-tags state side eid 1)))}})]})
+                                       (continue-ability state side (gain-tags-ability 1) card nil)))}})]})
 
 (defcard "VRcation"
   {:on-play

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -422,8 +422,7 @@
                                        {:choices {:req (req (some #(same-card? % target) valid-ice))
                                                   :all true}
                                         :async true
-                                        :effect (req (derez state side eid target {:msg-keys {:source-card card
-                                                                                              :include-cost-from-eid payment-eid}}))}
+                                        :effect (req (derez state side eid target {:msg-keys {:include-cost-from-eid payment-eid}}))}
                                        card nil)
                                      (do (system-msg state side (str (if (pos? amount-spent)
                                                                        (str (:latest-payment-str eid) " to use ")
@@ -1277,7 +1276,7 @@
     :choices {:card #(and (ice? %)
                           (rezzed? %))}
     :async true
-    :effect (req (derez state side eid target {:msg-keys {:source-card card}}))}})
+    :effect (req (derez state side eid target))}})
 
 (defcard "Emergent Creativity"
   (letfn [(ec [trash-cost to-trash]
@@ -1423,7 +1422,7 @@
               :card #(and (rezzed? %)
                           (ice? %))}
     :async true
-    :effect (req (derez state side eid targets {:msg-keys {:source-card card}}))}})
+    :effect (req (derez state side eid targets))}})
 
 (defcard "Exploratory Romp"
   {:makes-run true
@@ -2372,7 +2371,7 @@
                                                         (when (ice? card)
                                                           (get-card state card))))
                                                 (filter rezzed?))]
-                            (derez state :runner eid rezzed-ice {:msg-keys {:source-card card}})))}]})
+                            (derez state :runner eid rezzed-ice)))}]})
 
 (defcard "Legwork"
   {:makes-run true
@@ -4315,7 +4314,7 @@
                                                      (req
                                                        (system-msg state :corp (str "rezzes " (card-str state chosen-ice) ", ignoring all costs"))
                                                        (rez state :corp eid chosen-ice {:ignore-cost :all-costs}))}}}])
-                                  (derez state side eid target {:msg-keys {:source-card card}})))}
+                                  (derez state side eid target)))}
                           card nil)
                         (effect-completed state side eid))))}]
      :on-play {:async true

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -48,7 +48,7 @@
    [game.core.memory :refer [available-mu]]
    [game.core.moving :refer [as-agenda flip-facedown forfeit mill move
                              swap-ice trash trash-cards]]
-   [game.core.payment :refer [can-pay? ->c]]
+   [game.core.payment :refer [can-pay? ->c cost-value]]
    [game.core.play-instants :refer [play-instant]]
    [game.core.prevention :refer [damage-name prevent-damage preventable? prevent-up-to-n-tags prevent-up-to-n-damage]]
    [game.core.prompts :refer [cancellable clear-wait-prompt]]
@@ -404,32 +404,33 @@
 (defcard "Brute-Force-Hack"
   {:on-play
    {:async true
-    :effect
-    (req (let [affordable-ice
-               (seq (filter
-                      identity
-                      (for [ice (all-installed state :corp)
-                            :when (and (ice? ice)
-                                       (rezzed? ice))
-                            :let [cost (rez-cost state side ice)]]
-                        (when (can-pay? state side eid card nil [(->c :credit cost)])
-                          [(:cid ice) cost]))))
-               eid (assoc eid :x-cost true)]
-           (continue-ability
-             state side
-             {:prompt "How many credits do you want to spend?"
-              :choices :credit
-              :msg (msg "spends " target " [Credit] on Brute-Force-Hack")
-              :async true
-              :effect (effect (continue-ability
-                                {:choices {:card #(and (rezzed? %)
-                                                       (some (fn [c] (and (= (first c)
-                                                                             (:cid %))
-                                                                          (<= (second c) target)))
-                                                             affordable-ice))}
-                                 :effect (effect (derez target {:source-card card}))}
-                                card nil))}
-             card nil)))}})
+    ;; TODO - can we just give the ability an `:x-cost` tag instead of this dereffing?
+    :effect (req (resolve-ability
+                   state side (assoc eid :x-cost true)
+                   {:prompt "How many credits do you want to spend?"
+                    :cost [(->c :x-credits)]
+                    :async true
+                    :effect (req (let [payment-eid eid
+                                       amount-spent (cost-value eid :x-credits)
+                                       valid-ice (filter #(and (rezzed? %)
+                                                               (ice? %)
+                                                               (<= (rez-cost state :corp % nil) amount-spent))
+                                                         (all-installed state :corp))]
+                                   (if (seq valid-ice)
+                                     (continue-ability
+                                       state side
+                                       {:choices {:req (req (some #(same-card? % target) valid-ice))
+                                                  :all true}
+                                        :async true
+                                        :effect (req (derez state side eid target {:msg-keys {:source-card card
+                                                                                              :include-cost-from-eid payment-eid}}))}
+                                       card nil)
+                                     (do (system-msg state side (str (if (pos? amount-spent)
+                                                                       (str (:latest-payment-str eid) " to use ")
+                                                                       "uses ")
+                                                                     (:title card) " to do nothing"))
+                                         (effect-completed state side eid)))))}
+                   card nil))}})
 
 (defcard "Build Script"
   {:on-play
@@ -1275,7 +1276,8 @@
     :change-in-game-state (req (some (every-pred ice? rezzed?) (all-installed state :corp)))
     :choices {:card #(and (ice? %)
                           (rezzed? %))}
-    :effect (effect (derez target {:source-card card}))}})
+    :async true
+    :effect (req (derez state side eid target {:msg-keys {:source-card card}}))}})
 
 (defcard "Emergent Creativity"
   (letfn [(ec [trash-cost to-trash]
@@ -1420,9 +1422,8 @@
     :choices {:max 3
               :card #(and (rezzed? %)
                           (ice? %))}
-    :msg (msg "derez " (enumerate-str (map :title targets)))
-    :effect (req (doseq [c targets]
-                   (derez state side c {:no-msg true})))}})
+    :async true
+    :effect (req (derez state side eid targets {:msg-keys {:source-card card}}))}})
 
 (defcard "Exploratory Romp"
   {:makes-run true
@@ -2365,15 +2366,13 @@
              :async true
              :effect (req (make-run state side eid target (get-card state card)))}
    :events [{:event :run-ends
+             :async true
              :effect (req (let [rezzed-ice (->> (run-events target :rez)
                                                 (keep (fn [[{:keys [card]}]]
                                                         (when (ice? card)
                                                           (get-card state card))))
                                                 (filter rezzed?))]
-                            (doseq [ice rezzed-ice]
-                              (derez state :runner ice {:no-msg true}))
-                            (when (seq rezzed-ice)
-                              (system-msg state :runner (str "uses " (:title card) " to derez " (enumerate-str (map :title rezzed-ice)))))))}]})
+                            (derez state :runner eid rezzed-ice {:msg-keys {:source-card card}})))}]})
 
 (defcard "Legwork"
   {:makes-run true
@@ -4313,11 +4312,10 @@
                                        :prompt (str "Rez " (card-str state chosen-ice) ", ignoring all costs?")
                                        :yes-ability {:async true
                                                      :effect
-                                                     (req 
+                                                     (req
                                                        (system-msg state :corp (str "rezzes " (card-str state chosen-ice) ", ignoring all costs"))
                                                        (rez state :corp eid chosen-ice {:ignore-cost :all-costs}))}}}])
-                                  (derez state side target {:source-card card})
-                                  (effect-completed state side eid)))}
+                                  (derez state side eid target {:msg-keys {:source-card card}})))}
                           card nil)
                         (effect-completed state side eid))))}]
      :on-play {:async true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -484,8 +484,7 @@
               :yes-ability
               {:async true
                :cost [(->c :remove-from-game)]
-               :effect (req (derez state side eid target {:msg-keys {:source-card card
-                                                                     :include-cost-from-eid eid}}))}}}]})
+               :effect (req (derez state side eid target {:msg-keys {:include-cost-from-eid eid}}))}}}]})
 
 (defcard "Carnivore"
   {:static-abilities [(mu+ 1)]
@@ -2072,6 +2071,7 @@
   {:abilities [{:action true
                 :cost [(->c :click 1)(->c :x-credits)]
                 :label "Derez a piece of ice rezzed this turn"
+                ;; TODO - once elevation is out and the ncigs changes are in, add an ncigs catch for if the player just wastes their money
                 :once :per-turn
                 :async true
                 :effect (req (let [payment-eid eid
@@ -2082,8 +2082,7 @@
                                                            (= :this-turn (:rezzed target))
                                                            (<= (rez-cost state :corp target nil) spent-credits)))}
                                   :async true
-                                  :effect (req (derez state side eid target {:msg-keys {:source-card card
-                                                                                        :include-cost-from-eid payment-eid}}))}
+                                  :effect (req (derez state side eid target {:msg-keys {:include-cost-from-eid payment-eid}}))}
                                  card nil)))}]})
 
 (defcard "Security Chip"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -484,8 +484,8 @@
               :yes-ability
               {:async true
                :cost [(->c :remove-from-game)]
-               :effect (effect (derez target {:source-card card})
-                               (effect-completed eid))}}}]})
+               :effect (req (derez state side eid target {:msg-keys {:source-card card
+                                                                     :include-cost-from-eid eid}}))}}}]})
 
 (defcard "Carnivore"
   {:static-abilities [(mu+ 1)]
@@ -2070,20 +2070,21 @@
 
 (defcard "Rubicon Switch"
   {:abilities [{:action true
-                :cost [(->c :click 1)]
+                :cost [(->c :click 1)(->c :x-credits)]
                 :label "Derez a piece of ice rezzed this turn"
                 :once :per-turn
                 :async true
-                :prompt "How many credits do you want to spend?"
-                :choices :credit
-                :effect (effect (continue-ability
-                                  (let [spent-credits target]
-                                    {:choices {:card #(and (ice? %)
-                                                           (= :this-turn (:rezzed %))
-                                                           (<= (:cost %) target))}
-                                     :effect (effect (derez target {:source-card card}))
-                                     :msg (msg "spend " spent-credits "[Credits] and derez " (:title target))})
-                                  card nil))}]})
+                :effect (req (let [payment-eid eid
+                                   spent-credits (cost-value eid :x-credits)]
+                               (continue-ability
+                                 state side
+                                 {:choices {:req (req (and (ice? target)
+                                                           (= :this-turn (:rezzed target))
+                                                           (<= (rez-cost state :corp target nil) spent-credits)))}
+                                  :async true
+                                  :effect (req (derez state side eid target {:msg-keys {:source-card card
+                                                                                        :include-cost-from-eid payment-eid}}))}
+                                 card nil)))}]})
 
 (defcard "Security Chip"
   {:abilities [{:label "Add [Link] strength to a non-Cloud icebreaker until the end of the run"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1150,7 +1150,7 @@
                                                             (make-eid state eid)
                                                             (offer-jack-out) card nil)
                                            (wait-for
-                                             (derez state side card {:msg-keys {:source-card card}})
+                                             (derez state side card)
                                              (encounter-ends state side eid)))))}]})
 
 (defcard "Changeling"
@@ -1190,11 +1190,11 @@
    :events [{:event :runner-turn-ends
              :req (req (rezzed? card))
              :async true
-             :effect (req (derez state side eid card {:msg-keys {:source-card card}}))}
+             :effect (req (derez state side eid card))}
             {:event :corp-turn-ends
              :req (req (rezzed? card))
              :async true
-             :effect (req (derez state side eid card {:msg-keys {:source-card card}}))}]
+             :effect (req (derez state side eid card))}]
    :subroutines [end-the-run]})
 
 (defcard "Chiyashi"
@@ -2020,7 +2020,7 @@
                                    (effect-completed eid))
             :async true
             :effect (req (wait-for
-                           (derez state side target {:msg-keys {:source-card card}})
+                           (derez state side target)
                            (system-msg state side "prevents the runner from using printed abilities on bioroid ice for the rest of the turn")
                            (register-lingering-effect
                              state side card
@@ -2301,8 +2301,7 @@
                                   :duration :end-of-run
                                   :async true
                                   :effect (req (wait-for (derez state side new-ice {:suppress-checkpoint true
-                                                                                    :msg-keys {:source-card card
-                                                                                               :and-then " and trash itself"}})
+                                                                                    :msg-keys {:and-then " and trash itself"}})
                                                          (trash state side eid card {:cause :subroutine})))}])
                               (effect-completed state side eid))))}]})
 
@@ -2769,11 +2768,11 @@
      :events [{:event :runner-turn-ends
                :req (req (rezzed? card))
                :async true
-               :effect (effect (derez :corp eid card {:msg-keys {:source-card card}}))}
+               :effect (effect (derez :corp eid card))}
               {:event :corp-turn-ends
                :req (req (rezzed? card))
                :async true
-               :effect (effect (derez :corp eid card {:msg-keys {:source-card card}}))}]
+               :effect (effect (derez :corp eid card))}]
      :subroutines [{:label "(Code Gate) Force the Runner to lose [Click] and 1 [Credit]"
                     :msg "force the Runner to lose [Click] and 1 [Credit]"
                     :req (req (has-subtype? card "Code Gate"))
@@ -3085,7 +3084,7 @@
                                                      (make-eid state eid)
                                                      (offer-jack-out)
                                                      card nil)
-                                    (derez state side eid card {:msg-keys {:source-card card}})))}]
+                                    (derez state side eid card)))}]
    :subroutines [{:async true
                   :label "Draw 1 card, then shuffle 1 card from HQ into R&D"
                   :effect (req (wait-for (resolve-ability
@@ -4141,7 +4140,7 @@
                     :msg "keep TMI rezzed"
                     :label "Keep TMI rezzed"
                     :unsuccessful {:async true
-                                   :effect (effect (derez eid card {:msg-keys {:source-card card}}))}}}
+                                   :effect (effect (derez eid card))}}}
    :subroutines [end-the-run]})
 
 (defcard "Tollbooth"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -453,8 +453,12 @@
              :async true
              :req (req (and (same-card? (:ice context) (:host card))
                             (:all-subs-broken context)))
-             :effect (req (wait-for (derez state side (:ice context) {:msg-keys {:source-card card} :suppress-checkpoint true})
-                                    (trash state :corp eid card {:cause-card card})))}]})
+             :effect (req (wait-for
+                            (derez state side (:ice context)
+                                   {:msg-keys {:source-card card
+                                               :and-then " and trash itself"}
+                                    :suppress-checkpoint true})
+                            (trash state :corp eid card {:cause-card card})))}]})
 
 (defcard "Biotic Labor"
   {:on-play

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -448,16 +448,13 @@
              :cancel-effect (req (do-nothing state side eid card))
              :effect (req (wait-for (rez state side target {:ignore-cost :all-costs})
                                     (install-as-condition-counter state side eid card (:card async-result))))}
-   :events [{:event :end-of-encounter
+   :events [{:event :subroutines-broken
              :condition :hosted
              :async true
              :req (req (and (same-card? (:ice context) (:host card))
-                            (empty? (remove :broken (:subroutines (:ice context))))))
-             :effect (effect (system-msg :corp
-                                         (str "derezzes " (:title (:ice context))
-                                              " and trashes Bioroid Efficiency Research"))
-                             (derez :corp (:ice context) {:source-card card})
-                             (trash :corp eid card {:unpreventable true :cause-card card}))}]})
+                            (:all-subs-broken context)))
+             :effect (req (wait-for (derez state side (:ice context) {:msg-keys {:source-card card} :suppress-checkpoint true})
+                                    (trash state :corp eid card {:cause-card card})))}]})
 
 (defcard "Biotic Labor"
   {:on-play
@@ -844,18 +841,18 @@
               :max (req (count (filter rezzed? (all-installed state :corp))))}
     :change-in-game-state (req (seq (all-installed state :corp)))
     :async true
-    :effect (req (doseq [c targets]
-                   (derez state side c {:source-card card}))
-                 (let [discount (* 3 (count targets))]
-                   (continue-ability
-                     state side
-                     {:async true
-                      :prompt (str "Choose a card to rez, paying " discount " [Credits] less")
-                      :choices {:req (req (and ((every-pred installed? corp? (complement rezzed?) (complement agenda?)) target)
-                                               (can-pay-to-rez? state side (assoc eid :source card)
-                                                                target {:cost-bonus (- discount)})))}
-                      :effect (req (rez state side eid target {:cost-bonus (- discount)}))}
-                     card nil)))}})
+    :effect (req (wait-for
+                   (derez state side targets {:msg-keys {:source-card card}})
+                   (let [discount (* 3 (count targets))]
+                     (continue-ability
+                       state side
+                       {:async true
+                        :prompt (str "Choose a card to rez, paying " discount " [Credits] less")
+                        :choices {:req (req (and ((every-pred installed? corp? (complement rezzed?) (complement agenda?)) target)
+                                                 (can-pay-to-rez? state side (assoc eid :source card)
+                                                                  target {:cost-bonus (- discount)})))}
+                        :effect (req (rez state side eid target {:cost-bonus (- discount)}))}
+                       card nil))))}})
 
 (defcard "Door to Door"
   {:events [{:event :runner-turn-begins

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -455,8 +455,7 @@
                             (:all-subs-broken context)))
              :effect (req (wait-for
                             (derez state side (:ice context)
-                                   {:msg-keys {:source-card card
-                                               :and-then " and trash itself"}
+                                   {:msg-keys {:and-then " and trash itself"}
                                     :suppress-checkpoint true})
                             (trash state :corp eid card {:cause-card card})))}]})
 
@@ -846,7 +845,7 @@
     :change-in-game-state (req (seq (all-installed state :corp)))
     :async true
     :effect (req (wait-for
-                   (derez state side targets {:msg-keys {:source-card card}})
+                   (derez state side targets)
                    (let [discount (* 3 (count targets))]
                      (continue-ability
                        state side

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -335,8 +335,7 @@
                                    (has-subtype? current-ice ice-type)
                                    (all-subs-broken-by-card? current-ice card)))
                     :async true
-                    :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
-                                                                               :include-cost-from-eid eid}}))}]})))
+                    :effect (req (derez state side eid current-ice {:msg-keys {:include-cost-from-eid eid}}))}]})))
 
 (defn- trash-to-bypass
   "Trash to bypass current ice
@@ -1017,8 +1016,7 @@
                 :label "derez an ice"
                 :cost [(->c :trash-can)]
                 :async true
-                :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
-                                                                           :include-cost-from-eid eid}}))}]})
+                :effect (req (derez state side eid current-ice {:msg-keys {:include-cost-from-eid eid}}))}]})
 
 (defcard "Crowbar"
   (break-and-enter "Code Gate"))
@@ -1496,8 +1494,7 @@
                                  :req (req (and (get-current-encounter state)
                                                 (has-subtype? current-ice "Sentry")))
                                  :async true
-                                 :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
-                                                                                            :include-cost-from-eid eid}}))}
+                                 :effect (req (derez state side eid current-ice {:msg-keys {:include-cost-from-eid eid}}))}
                                 (strength-pump 1 1)]}))
 
 (defcard "Flux Capacitor"
@@ -3314,7 +3311,7 @@
                       (add-counter state side card :virus 1 nil)
                       (if (and (rezzed? (get-card state (:host card)))
                                  (<= 3 (get-virus-counters state (get-card state card))))
-                        (derez state side eid (get-card state (:host card)) {:msg-keys {:source-card card}})
+                        (derez state side eid (get-card state (:host card)))
                         (effect-completed state side eid))))]
     (trojan
       {:on-install {:interactive (req true)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -334,7 +334,9 @@
                                    (rezzed? current-ice)
                                    (has-subtype? current-ice ice-type)
                                    (all-subs-broken-by-card? current-ice card)))
-                    :effect (effect (derez current-ice {:source-card card}))}]})))
+                    :async true
+                    :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
+                                                                               :include-cost-from-eid eid}}))}]})))
 
 (defn- trash-to-bypass
   "Trash to bypass current ice
@@ -1014,7 +1016,9 @@
                                (all-subs-broken? current-ice)))
                 :label "derez an ice"
                 :cost [(->c :trash-can)]
-                :effect (effect (derez current-ice {:source-card card}))}]})
+                :async true
+                :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
+                                                                           :include-cost-from-eid eid}}))}]})
 
 (defcard "Crowbar"
   (break-and-enter "Code Gate"))
@@ -1491,7 +1495,9 @@
                                  :cost [(->c :credit 6)]
                                  :req (req (and (get-current-encounter state)
                                                 (has-subtype? current-ice "Sentry")))
-                                 :effect (effect (derez current-ice {:source-card card}))}
+                                 :async true
+                                 :effect (req (derez state side eid current-ice {:msg-keys {:source-card card
+                                                                                            :include-cost-from-eid eid}}))}
                                 (strength-pump 1 1)]}))
 
 (defcard "Flux Capacitor"
@@ -2955,7 +2961,7 @@
                :async true
                :effect (effect (gain-credits :runner eid 3))}
               {:event :derez
-               :req (req (same-card? (:card context) (:host card)))
+               :req (req (some #(same-card? % (:host card)) (:cards context)))
                ;; NOTE
                ;;   current guidance from rules is that saci doesn't get
                ;;   a payout on magnet rez, but does get one when magnet is
@@ -3306,13 +3312,12 @@
 (defcard "Tranquilizer"
   (let [action (req (wait-for
                       (add-counter state side card :virus 1 nil)
-                      (when (and (rezzed? (get-card state (:host card)))
+                      (if (and (rezzed? (get-card state (:host card)))
                                  (<= 3 (get-virus-counters state (get-card state card))))
-                        (derez state side (get-card state (:host card)) {:source-card card}))
-                      (effect-completed state side eid)))]
+                        (derez state side eid (get-card state (:host card)) {:msg-keys {:source-card card}})
+                        (effect-completed state side eid))))]
     (trojan
-      {:implementation "[Erratum] Program: Virus - Trojan"
-       :on-install {:interactive (req true)
+      {:on-install {:interactive (req true)
                     :async true
                     :effect action}
        :events [{:event :runner-turn-begins

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -482,7 +482,7 @@
                 :cost [(->c :trash-can)]
                 :async true
                 :effect (req (wait-for
-                               (derez state side current-ice {:msg-keys {:include-cost-from-eid eid :source-card card}})
+                               (derez state side current-ice {:msg-keys {:include-cost-from-eid eid}})
                                (continue-ability state side (gain-tags-ability 1) card nil)))}]})
 
 (defcard "Bank Job"
@@ -892,7 +892,7 @@
                    {:cost [(->c :credit (rez-cost state :corp (:card context))) (->c :trash-can)]
                     :async true
                     :effect (req (wait-for
-                                   (derez state :runner (:card context) {:msg-keys {:source-card card}})
+                                   (derez state :runner (:card context) {:msg-keys {:source-card card :and-then " and prevent the Corp from rezzing it for the remainder of this turn."}})
                                    (register-turn-flag!
                                      state side card :can-rez
                                      (fn [state _ card]
@@ -2207,8 +2207,7 @@
                 :label "Derez a piece of ice protecting a remote server"
                 :cost [(->c :trash-can)]
                 :async true
-                :effect (req (derez state side eid target {:msg-keys {:source-card card
-                                                                      :include-cost-from-eid eid}}))}]})
+                :effect (req (derez state side eid target {:msg-keys {:include-cost-from-eid eid}}))}]})
 
 (defcard "Miss Bones"
   {:data {:counter {:credit 12}}
@@ -2275,7 +2274,7 @@
                                       (rezzed? %))
                           :all true}
                 :async true
-                :effect (req (derez state :corp eid target {:msg-keys {:source-card card}}))}
+                :effect (req (derez state :corp (assoc eid :source card) target))}
    :uninstall
    (effect
      (continue-ability

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -74,7 +74,7 @@
                               zone->name zones->sorted-names]]
    [game.core.set-aside :refer [set-aside set-aside-for-me]]
    [game.core.shuffling :refer [shuffle!]]
-   [game.core.tags :refer [gain-tags lose-tags]]
+   [game.core.tags :refer [gain-tags gain-tags-ability lose-tags]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
    [game.core.threat :refer [threat-level]]
@@ -473,18 +473,17 @@
   {:events [{:event :encounter-ice
              :automatic :pre-bypass
              :req (req (first-run-event? state side :encounter-ice))
-             :msg "place 1 power counter on itself"
              :async true
              :effect (req (add-counter state side eid card :power 1))}]
    :abilities [{:label "Derez a piece of ice currently being encountered"
-                :msg "derez a piece of ice currently being encountered and take 1 tag"
                 :req (req (and (get-current-encounter state)
                                (rezzed? current-ice)
                                (<= (get-strength current-ice) (get-counters (get-card state card) :power))))
                 :cost [(->c :trash-can)]
                 :async true
-                :effect (effect (derez current-ice {:source-card card})
-                                (gain-tags eid 1))}]})
+                :effect (req (wait-for
+                               (derez state side current-ice {:msg-keys {:include-cost-from-eid eid :source-card card}})
+                               (continue-ability state side (gain-tags-ability 1) card nil)))}]})
 
 (defcard "Bank Job"
   {:data {:counter {:credit 8}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2270,15 +2270,16 @@
   {:on-install {:player :corp
                 :waiting-prompt true
                 :prompt "Choose a card to derez"
-                :change-in-game-state {:silent true
-                                       :req (req (some #(and (rezzed? %)
-                                                             (not (agenda? %)))
-                                                       (all-installed state :corp)))}
+                ;; :change-in-game-state {:silent true
+                ;;                        :req (req (some #(and (rezzed? %)
+                ;;                                              (not (agenda? %)))
+                ;;                                        (all-installed state :corp)))}
                 :choices {:card #(and (corp? %)
                                       (not (agenda? %))
-                                      (rezzed? %))}
+                                      (rezzed? %))
+                          :all true}
                 :async true
-                :effect (req (derez state side eid target {:msg-keys {:source-card card}}))}
+                :effect (req (derez state :corp eid target {:msg-keys {:source-card card}}))}
    :uninstall
    (effect
      (continue-ability

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2270,10 +2270,7 @@
   {:on-install {:player :corp
                 :waiting-prompt true
                 :prompt "Choose a card to derez"
-                ;; :change-in-game-state {:silent true
-                ;;                        :req (req (some #(and (rezzed? %)
-                ;;                                              (not (agenda? %)))
-                ;;                                        (all-installed state :corp)))}
+                :req (req (some #(and (rezzed? %) (not (agenda? %))) (all-installed state :corp)))
                 :choices {:card #(and (corp? %)
                                       (not (agenda? %))
                                       (rezzed? %))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1902,8 +1902,13 @@
   (let [ability {:msg "gain [Click]"
                  :once :per-turn
                  :label "Gain [Click] (start of turn)"
-                 :effect (effect (gain-clicks 1)
-                                 (update! (assoc-in card [:special :joshua-b] true)))}]
+                 :effect (req (gain-clicks state side 1)
+                              (register-events
+                                state side card
+                                [(merge (gain-tags-ability 1)
+                                        {:event :runner-turn-ends
+                                         :unregister-once-resolved true
+                                         :interactive (req true)})]))}]
     {:flags {:runner-phase-12 (req true)}
      :events [{:event :runner-turn-begins
                :skippable true
@@ -1912,13 +1917,7 @@
                           :yes-ability ability
                           :no-ability
                           {:effect (effect (system-msg (str "declines to use " (:title card) " to gain [Click]"))
-                                           (update! (assoc-in card [:special :joshua-b] false)))}}}
-              {:event :runner-turn-ends
-               :interactive (req true)
-               :req (req (get-in card [:special :joshua-b]))
-               :async true
-               :effect (effect (gain-tags eid 1))
-               :msg "gain 1 tag"}]
+                                           (update! (assoc-in card [:special :joshua-b] false)))}}}]
      :abilities [ability]}))
 
 (defcard "Juli Moreira Lee"
@@ -3251,7 +3250,7 @@
               :player :runner
               :yes-ability {:msg "give the Corp 1 bad publicity and take 1 tag"
                             :async true
-                            :effect (effect (gain-bad-publicity :corp 1)
+                            :effect (effect (gain-bad-publicity :corp 1 {:suppress-checkpoint true})
                                             (gain-tags :runner eid 1))}}}]})
 
 (defcard "Tech Trader"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -350,10 +350,11 @@
                                                                  (rezzed? %)
                                                                  (not (same-card? % rezzed-card)))}
                                            :async true
-                                           :msg (msg "derez " (card-str state target) " to give " (card-str state rezzed-card) " +3 strength for the remainder of the run")
-                                           :effect (req (derez state side (get-card state target) {:no-msg true})
-                                                        (pump-ice state side rezzed-card 3 :end-of-run)
-                                                        (effect-completed state side eid))}}}
+                                           :effect (req (wait-for (derez state side (get-card state target)
+                                                                         {:msg-keys {:source-card card
+                                                                                     :and-then (str " to give " (card-str state rezzed-card) " +3 strength for the remainder of the run")}})
+                                                                  (pump-ice state side rezzed-card 3 :end-of-run)
+                                                                  (effect-completed state side eid)))}}}
                            card nil)))}]})
 
 (defcard "Breaker Bay Grid"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -351,8 +351,7 @@
                                                                  (not (same-card? % rezzed-card)))}
                                            :async true
                                            :effect (req (wait-for (derez state side (get-card state target)
-                                                                         {:msg-keys {:source-card card
-                                                                                     :and-then (str " to give " (card-str state rezzed-card) " +3 strength for the remainder of the run")}})
+                                                                         {:msg-keys {:and-then (str " to give " (card-str state rezzed-card) " +3 strength for the remainder of the run")}})
                                                                   (pump-ice state side rezzed-card 3 :end-of-run)
                                                                   (effect-completed state side eid)))}}}
                            card nil)))}]})

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -402,7 +402,7 @@
      {:prompt "Choose a card to derez"
       :choices {:card #(rezzed? %)}
       :async true
-      :effect (effect (derez eid target))}
+      :effect (effect (derez eid target {:no-event true}))}
      nil nil)))
 
 (defn command-trash

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -401,7 +401,8 @@
      state side
      {:prompt "Choose a card to derez"
       :choices {:card #(rezzed? %)}
-      :effect (effect (derez target))}
+      :async true
+      :effect (effect (derez eid target))}
      nil nil)))
 
 (defn command-trash

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -540,15 +540,15 @@
                            (has-subtype? % "Harmonic"))}
      :async true
      ;; TODO - once derez is async, fix this
-     :effect (req (doseq [harmonic targets]
-                    (derez state side harmonic))
-                  (complete-with-result
-                    state side eid
-                    {:paid/msg (str "derezzes " (count targets)
-                                   " Harmonic ice (" (enumerate-str (map #(card-str state %) targets)) ")")
-                     :paid/type :derez
-                     :paid/value (count targets)
-                     :paid/targets targets}))}
+     :effect (req (wait-for
+                    (derez state side targets {:suppress-checkpoint true :no-msg true})
+                    (complete-with-result
+                      state side eid
+                      {:paid/msg (str "derezzes " (count targets)
+                                      " Harmonic ice (" (enumerate-str (map #(card-str state %) targets)) ")")
+                       :paid/type :derez
+                       :paid/value (count targets)
+                       :paid/targets targets})))}
     card nil))
 
 ;; TrashInstalledProgram

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -59,7 +59,7 @@
    "continue" #'continue
    "corp-ability" #'play-corp-ability
    "credit" #'click-credit
-   "derez" #(derez %1 %2 (:card %3))
+   "derez" #(derez %1 %2 (make-eid %1) (:card %3))
    "draw" #'click-draw
    "dynamic-ability" #'play-dynamic-ability
    "end-phase-12" #'end-phase-12

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -59,7 +59,7 @@
    "continue" #'continue
    "corp-ability" #'play-corp-ability
    "credit" #'click-credit
-   "derez" #(derez %1 %2 (make-eid %1) (:card %3))
+   "derez" #(derez %1 %2 (make-eid %1) (:card %3) {:no-event true})
    "draw" #'click-draw
    "dynamic-ability" #'play-dynamic-ability
    "end-phase-12" #'end-phase-12

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -144,16 +144,21 @@
 
 ;; TODO: make async
 (defn- derez-message
-  [state side eid cards {:keys [source-card] :as msg-keys}]
+  ;; note:
+  ;;  source-card - the card that's derezzing (optional)
+  ;;  and-then - text to append to the end of the message (ie derezz x` and trash itself`)
+  ;;              I suggest only using this if the rhs thing is part of the same instruction.
+  ;;  include-cost-from-eid [eid] - include the last payment str from the eid as if it was for this
+  [state side eid cards {:keys [source-card and-then] :as msg-keys}]
   (let [card-strs (enumerate-str (map #(card-str state % {:visible true}) cards))
         prepend-cost-str (get-in msg-keys [:include-cost-from-eid :latest-payment-str])
         title (or (:title source-card) (:printed-title source-card))]
     (system-msg
       state side
       (cond
-        (not source-card) (str "derezzes " card-strs)
-        prepend-cost-str (str prepend-cost-str " to use " title " to derez " card-strs)
-        :else (str "uses " title " to derez " card-strs)))))
+        (not source-card) (str "derezzes " card-strs and-then)
+        prepend-cost-str (str prepend-cost-str " to use " title " to derez " card-strs and-then)
+        :else (str "uses " title " to derez " card-strs and-then)))))
 
 (defn derez
   "Derez a number of corp cards."

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -142,16 +142,16 @@
          (complete-rez state side eid card args))
        (effect-completed state side eid)))))
 
-;; TODO: make async
 (defn- derez-message
   ;; note:
   ;;  source-card - the card that's derezzing (optional)
   ;;  and-then - text to append to the end of the message (ie derezz x` and trash itself`)
   ;;              I suggest only using this if the rhs thing is part of the same instruction.
   ;;  include-cost-from-eid [eid] - include the last payment str from the eid as if it was for this
-  [state side eid cards {:keys [source-card and-then] :as msg-keys}]
+  [state side eid cards {:keys [and-then] :as msg-keys}]
   (let [card-strs (enumerate-str (map #(card-str state % {:visible true}) cards))
         prepend-cost-str (get-in msg-keys [:include-cost-from-eid :latest-payment-str])
+        source-card (:source eid)
         title (or (:title source-card) (:printed-title source-card))]
     (system-msg
       state side
@@ -163,7 +163,7 @@
 (defn derez
   "Derez a number of corp cards."
   ([state side eid cards] (derez state side eid cards nil))
-  ([state side eid cards {:keys [source-card suppress-checkpoint no-event no-msg msg-keys] :as args}]
+  ([state side eid cards {:keys [suppress-checkpoint no-event no-msg msg-keys] :as args}]
    (let [cards (if (sequential? cards)
                  (filterv #(and (get-card state %) (rezzed? %)) (flatten cards))
                  [cards])]

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -8,7 +8,7 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.core.toasts :refer [toast]]
-    [game.macros :refer [wait-for]]
+    [game.macros :refer [req wait-for]]
     [game.utils :refer [pluralize quantify]]))
 
 (defn sum-tag-effects
@@ -60,6 +60,12 @@
      (resolve-tag state side eid {:suppress-checkpoint suppress-checkpoint
                                   :card card
                                   :n (:remaining async-result)}))))
+
+(defn gain-tags-ability [n]
+  "Take n tags"
+  {:msg (str "take " (quantify n "tag"))
+   :async true
+   :effect (req (gain-tags state side eid n))})
 
 (defn lose-tags
   "Always removes `:base` tags"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -1151,28 +1151,6 @@
         (rez state :corp jhow)
         (is (rezzed? (refresh jhow)) "Jackson Howard can be rezzed after changing zone"))))
 
-(deftest councilman-preventing-councilman-s-self-trash-prevents-the-rez-prevention-effect
-    ;; Preventing Councilman's self-trash prevents the rez prevention effect
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Chief Slee"]}
-                 :runner {:deck ["Councilman" "Fall Guy"]}})
-      (play-from-hand state :corp "Chief Slee" "New remote")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Councilman")
-      (play-from-hand state :runner "Fall Guy")
-      (take-credits state :runner)
-      (let [slee (get-content state :remote1 0)
-            councilman (get-resource state 0)
-            fall-guy (get-resource state 1)]
-        (rez state :corp slee)
-        (is (changed? [(:credit (get-runner)) -2]
-              (click-prompt state :runner "Yes")
-              (card-ability state :runner fall-guy 0)
-              (is (rezzed? (refresh slee)) "Chief Slee still rezzed")
-              (is (refresh councilman) "Councilman's trash is prevented"))
-            "Runner still pays for Councilman effect"))))
-
 (deftest counter-surveillance-trash-to-run-on-successful-run-access-cards-equal-to-tags-and-pay-that-amount-in-credits
     ;; Trash to run, on successful run access cards equal to Tags and pay that amount in credits
     (do-game


### PR DESCRIPTION
This does the following:
* makes derezzing async
* allows derezzing multiple cards at once, suppressing the event (when manually derezzing as the corp for example), and suppressing the checkpoint (ie simultaneous effects, costs)
* cleans up the code for all the cards that derez
* automatically generates text for cards being derezzed
* adds a little helper function for taking n tags (did this just because of how baklan was formatted), I used it in a few places where it made sense, and cleaned up a couple of cards (like joshua B) in doing so

This also hits one of the long-standing todos in #6729 (though I can probably close that after elevation, and make a new/updated list)