### PR TITLE
rephrase trash interrupt prompt for clarity

### DIFF
--- a/src/clj/game/core/prevention.clj
+++ b/src/clj/game/core/prevention.clj
@@ -280,7 +280,7 @@
                    (str "Prevent any of " (count (get-in @state [:prevent :trash :remaining])) " cards from being trashed?"))
                  "Choose an interrupt")) ;; note - for corp, this is only marilyn campaign
      :waiting "your opponent to resolve trash prevention triggers"
-     :option (fn [state remainder] (str "Allow " (quantify (count (get-in @state [:prevent :trash :remaining])) "card") " to be trashed"))}))
+     :option (fn [state remainder] (str "Continue trashing " (quantify (count (get-in @state [:prevent :trash :remaining])) "card")))}))
 
 (defn resolve-trash-prevention
   [state side eid targets {:keys [unpreventable game-trash cause cause-card] :as args}]

--- a/test/clj/game/core/rules_test.clj
+++ b/test/clj/game/core/rules_test.clj
@@ -700,7 +700,7 @@
     (click-prompt state :runner "No action")
     (run-empty-server state "HQ")
     (play-from-hand state :runner "Apocalypse")
-    (is (= #{"Shuffle Marilyn Campaign into R&D" "Allow 3 cards to be trashed"}
+    (is (= #{"Shuffle Marilyn Campaign into R&D" "Continue trashing 3 cards"}
            (into #{} (prompt-titles :corp)))
         "Corp only has the marilyn interrupt")
     (click-prompt state :corp "Shuffle Marilyn Campaign into R&D")


### PR DESCRIPTION
Per the Slack discussion, this rephrases the prompt during trash interrupts from "Allow" to "Continue" to make it clear that one of the choices declines the interrupt.