### PR TITLE
draft ids reworked/cleaned up

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -52,7 +52,7 @@
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->name is-central? is-remote? name-zone
                               target-server zone->name]]
-   [game.core.shuffling :refer [shuffle! shuffle-into-deck]]
+   [game.core.shuffling :refer [shuffle! shuffle-into-deck shuffle-cards-into-deck!]]
    [game.core.tags :refer [gain-tags lose-tags]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
@@ -723,9 +723,11 @@
              :player :corp
              :req (req (and (not (:disabled card))
                             (not (is-disabled? state side card))
-                            (has-most-faction? state :corp "Weyland Consortium")
-                            (some ice? (all-installed state side))))
-             :prompt "Choose a piece of ice to place 1 advancement token on"
+                            (has-most-faction? state :corp "Weyland Consortium")))
+             ;; TODO - ncigs change
+             ;; :change-in-game-state {:silent true
+             ;;                        :req (req (seq (filter ice? (all-installed state :corp))))}
+             :prompt "Choose a piece of ice to place 1 advancement counter on"
              :choices {:card #(and (installed? %)
                                    (ice? %))}
              :msg (msg "place 1 advancement token on " (card-str state target))
@@ -980,6 +982,7 @@
   {:events (let [inf {:req (req (and (not (:disabled card))
                                      (not (is-disabled? state side card))
                                      (has-most-faction? state :corp "NBN")))
+                      :interactive (req true)
                       :msg "give the Runner 1 tag"
                       :async true
                       :effect (effect (gain-tags :corp eid 1))}]
@@ -1015,7 +1018,6 @@
              :req (req (and (has-most-faction? state :runner "Shaper")
                             (first-event? state side :runner-install)))
              :msg "draw 1 card"
-             :once :per-turn
              :async true
              :effect (effect (draw eid 1))}]})
 
@@ -2106,17 +2108,21 @@
             {:event :runner-turn-ends
              :req (req (and (not (:disabled card))
                             (not (is-disabled? state side card))
-                            (has-most-faction? state :corp "Haas-Bioroid")
-                            (pos? (count (:discard corp)))))
-             :prompt "Choose a card in Archives to shuffle into R&D"
-             :choices {:card #(and (corp? %)
-                                   (in-discard? %))}
-             :player :corp
-             :show-discard true
-             :msg (msg "shuffle " (if (:seen target) (:title target) "a card")
-                       " into R&D")
-             :effect (effect (move :corp target :deck)
-                             (shuffle! :corp :deck))}]})
+                            (has-most-faction? state :corp "Haas-Bioroid")))
+             :async true
+             :effect (req (if (empty? (:discard corp))
+                            (do (shuffle-cards-into-deck! state :corp card :card [])
+                                (effect-completed state side eid))
+                            (continue-ability
+                              state side
+                              {:prompt "Choose a card in Archives to shuffle into R&D"
+                               :choices {:card #(and (corp? %)
+                                                     (in-discard? %))
+                                         :all true}
+                               :player :corp
+                               :show-discard true
+                               :effect (req (shuffle-cards-into-deck! state :corp card :corp target))}
+                              card nil)))}]})
 
 (defcard "Sunny Lebeau: Security Specialist"
   ;; No special implementation
@@ -2142,22 +2148,29 @@
                 :msg (msg "flip [their] identity")}]})
 
 (defcard "Synthetic Systems: The World Re-imagined"
-  {:events [{:event :pre-start-game
-             :effect draft-points-target}]
-   :flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
-                                    (not (is-disabled? state side card))
-                                    (has-most-faction? state :corp "Jinteki")
-                                    (<= 2 (count (filter ice? (all-installed state :corp))))))}
-   :abilities [{:prompt "Choose 2 installed pieces of ice to swap"
-                :label "swap 2 installed pieces of ice"
-                :choices {:card #(and (installed? %)
-                                      (ice? %))
-                          :max 2
-                          :all true}
-                :once :per-turn
-                :effect (req (apply swap-ice state side targets))
-                :msg (msg "swap the positions of " (card-str state (first targets))
-                          " and " (card-str state (second targets)))}]})
+  (let [abi {:prompt "Choose 2 installed pieces of ice to swap"
+             :label "swap 2 installed pieces of ice"
+             :choices {:card #(and (installed? %)
+                                   (ice? %))
+                       :max 2
+                       :all true}
+             :once :per-turn
+             :effect (req (apply swap-ice state side targets))
+             :msg (msg "swap the positions of " (card-str state (first targets))
+                       " and " (card-str state (second targets)))}]
+    {:events [{:event :pre-start-game
+               :effect draft-points-target}
+              {:events :corp-turn-begins
+               :optional {:req (req (and (has-most-faction? state :corp "Jinteki")
+                                         (<= 2 (count (filter ice? (all-installed state :corp))))))
+                          :prompt "Swap two ice?"
+                          :waiting-prompt true
+                          :yes-ability abi}}]
+     :flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
+                                      (not (is-disabled? state side card))
+                                      (has-most-faction? state :corp "Jinteki")
+                                      (<= 2 (count (filter ice? (all-installed state :corp))))))}
+     :abilities [abi]}))
 
 (defcard "Tāo Salonga: Telepresence Magician"
   (let [swap-ability
@@ -2391,13 +2404,8 @@
             {:event :runner-trash
              :interactive (req true)
              :req (req (and (has-most-faction? state :runner "Anarch")
-                            (corp? (:card target))
-                            (pos? (count (:discard runner)))
-                            (not (zone-locked? state :runner :discard))))
-             :msg (msg "shuffle " (:title (last (:discard runner))) " into the stack")
-             :effect (effect (move :runner (last (:discard runner)) :deck)
-                             (shuffle! :runner :deck)
-                             (trigger-event :searched-stack))}]})
+                            (corp? (:card target))))
+             :effect (req (shuffle-cards-into-deck! state :runner card :runner (last (:discard runner))))}]})
 
 (defcard "Zahya Sadeghi: Versatile Smuggler"
   {:events [{:event :run-ends

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -2111,7 +2111,7 @@
                             (has-most-faction? state :corp "Haas-Bioroid")))
              :async true
              :effect (req (if (empty? (:discard corp))
-                            (do (shuffle-cards-into-deck! state :corp card :card [])
+                            (do (shuffle-cards-into-deck! state :corp card [])
                                 (effect-completed state side eid))
                             (continue-ability
                               state side
@@ -2121,7 +2121,7 @@
                                          :all true}
                                :player :corp
                                :show-discard true
-                               :effect (req (shuffle-cards-into-deck! state :corp card :corp target))}
+                               :effect (req (shuffle-cards-into-deck! state :corp card [target]))}
                               card nil)))}]})
 
 (defcard "Sunny Lebeau: Security Specialist"
@@ -2405,7 +2405,7 @@
              :interactive (req true)
              :req (req (and (has-most-faction? state :runner "Anarch")
                             (corp? (:card target))))
-             :effect (req (shuffle-cards-into-deck! state :runner card :runner (last (:discard runner))))}]})
+             :effect (req (shuffle-cards-into-deck! state :runner card [(last (:discard runner))]))}]})
 
 (defcard "Zahya Sadeghi: Versatile Smuggler"
   {:events [{:event :run-ends

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -1,10 +1,12 @@
 (ns game.core.shuffling
   (:require
-   [game.core.card :refer [corp? in-discard?]]
+   [game.core.card :refer [corp? in-discard? get-card]]
    [game.core.eid :refer [effect-completed]]
    [game.core.engine :refer [trigger-event]]
+   [game.core.flags :refer [zone-locked?]]
    [game.core.moving :refer [move move-zone]]
    [game.core.say :refer [system-msg]]
+   [game.core.servers :refer [name-zone]]
    [game.macros :refer [continue-ability msg req]]
    [game.utils :refer [enumerate-str quantify]]))
 
@@ -20,6 +22,30 @@
       (swap! state assoc-in [:run :shuffled-during-access :rd] true))
     (swap! state update-in [:stats side :shuffle-count] (fnil + 0) 1)
     (swap! state update-in [side kw] shuffle)))
+
+(defn shuffle-cards-into-deck!
+  "Shuffles a given set of cards into the deck. Will print out what's happened. Will always shuffle."
+  [state from-side card shuffle-side & targets]
+  (let [targets (set (keep #(get-card state %) (flatten targets)))
+        targets (filter #(if (= (:zone %) [:discard]) (not (zone-locked? state shuffle-side :discard)) true) targets)
+        lhs (str " uses " (:title card)
+                 (when-not (= from-side shuffle-side)
+                   (str " to force the " (clojure.string/capitalize (name shuffle-side))))
+                 " to shuffle ")
+        rhs (if (= shuffle-side :corp) "Archives" "the Stack")]
+    (if (seq targets)
+      (let [cards-by-zone (group-by #(select-keys % [:side :zone]) (flatten targets))
+            strs (enumerate-str (map #(str (enumerate-str (map :title (get cards-by-zone %)))
+                                           " from " (name-zone (:side %) (:zone %)))
+                                     (keys cards-by-zone)))]
+        (doseq [t targets]
+          (when-not (= (:zone t) [:deck])
+            (move state shuffle-side t :deck)))
+        (system-msg state from-side (str lhs strs " into " rhs))
+        (shuffle! state shuffle-side :deck))
+      (do
+        (system-msg state from-side (str lhs rhs))
+        (shuffle! state shuffle-side :deck)))))
 
 (defn shuffle-into-deck
   [state side & args]


### PR DESCRIPTION
I cleaned up the draft ids a bit.

My plan is to (sooner or later) go through all the old cards and clean them up/make them consistent with our modern implementations.

I added a `shuffle-cards-into-deck!` fn in `shuffling` that takes as input:
1) state
2) acting-side
3) source card
4) side having their cards shuffled
5) `& targets`

It:
* Handles the log printout, grouping cards by their zone, and displaying if the player shuffled, or was forced to shuffle, etc
* Handles the discard being zone-locked
* handles the cards not existing anymore, or already being in the deck
* Forces a shuffle even when there are no cards to get shuffled back (ie with gatekeeper)

I'll try and use this in the future when I clean up some other cards so we can avoid writing the same stuff over and over.