### PR TITLE
Custom BG in Settings no longer works #8037

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -303,7 +303,7 @@
 
 (def background-list
   [["Apex" "apex"]
-   ["Custom BG (input URL below)" "custom"]
+   ["Custom BG (input URL below)" "custom-bg"]
    ["Find The Truth" "find-the-truth"]
    ["Freelancer" "freelancer"]
    ["Monochrome" "monochrome"]


### PR DESCRIPTION
Noticed that the Custom BG url option wasn't working - Digging into the code, it seems like when the list of backgrounds was moved to the 'background-list' in src/cljs/nr/account.cljs , the value for the Custom BG was changed from "custom-bg" to just "custom" , yet the custom-bg-selected variable is still checking against "custom-bg". This mismatch prevents the custom bg url from being toggled.

Closes #8037