### PR TITLE
Fix Light The Fire, validate lingering effects

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2149,7 +2149,8 @@
          :duration :end-of-run
          :req (req (and run
                         (some #{:content} (:zone target))
-                        (some #{run-server} (:zone target))))}]
+                        (some #{(first (:server (:run @state)))} (:zone target))))
+         :value true}]
     {:abilities [{:action true
                   :label "Run a remote server"
                   :cost [(->c :click 1) (->c :trash-can) (->c :brain 1)]
@@ -2160,7 +2161,7 @@
                   :async true
                   :effect (effect
                             (register-events card [successful-run-event])
-                            (register-lingering-effect card [disable-card-effect])
+                            (register-lingering-effect card disable-card-effect)
                             (make-run eid target card))}]}))
 
 (defcard "Logic Bomb"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -86,10 +86,11 @@
                          ;; while resolving another ability or promppt
                          blocking-prompt?
                          (not= side (to-keyword (:side card)))
-                         (any-effects state side :prevent-paid-ability true? card [ability ability-idx]))]
+                         ;; prevention/disabling abilities
+                         (any-effects state side :prevent-paid-ability true? card [ability ability-idx])
+                         (some? (is-disabled-reg? state card)))]
      (when blocking-prompt?
-       (toast state side (str "You cannot play abilities while other abilities are resolving.")
-              "warning"))
+       (toast state side "You cannot play abilities while other abilities are resolving." "warning"))
      (when-not cannot-play
        (do-play-ability state side eid (assoc args :ability-idx ability-idx :ability ability))))))
 

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -153,8 +153,11 @@
 
 (defn register-lingering-effect
   [state _ card ability]
+  (assert (contains? ability :type))
+  (assert (contains? ability :value))
   (let [ability (assoc
-                  (select-keys ability [:type :duration :req :value])
+                  (select-keys ability [:type :req :value])
+                  :duration (:duration ability true)
                   :card card
                   :lingering true
                   :uuid (uuid/v1))]

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3579,8 +3579,8 @@
     (play-and-score state "Nisei MK II")
     (play-from-hand state :corp "Vanilla" "HQ")
     (play-from-hand state :corp "Ichi 1.0" "HQ")
-    (rez state corp (get-ice state :hq 0))
-    (rez state corp (get-ice state :hq 1))
+    (rez state :corp (get-ice state :hq 0))
+    (rez state :corp (get-ice state :hq 1))
     (take-credits state :corp)
     (play-from-hand state :runner "John Masanori")
     (run-on state :hq)
@@ -4084,6 +4084,25 @@
       (is (changed? [(:credit (get-runner)) -8]
             (click-prompt state :runner "Server 1"))
           "Spent 8 credits to make a run on the server"))))
+
+(deftest light-the-fire-spin-doctor
+  ;; Light the Fire!
+  (do-game
+    (new-game {:corp {:hand ["Spin Doctor"]
+                      :deck [(qty "Hedge Fund" 10)]
+                      :discard ["Ice Wall" "Fire Wall" "Tyrant"]}
+               :runner {:hand ["Light the Fire!" (qty "Sure Gamble" 4)]
+                        :credits 100}})
+    (play-from-hand state :corp "Spin Doctor" "New remote")
+    (let [spin (get-content state :remote1 0)]
+      (rez state :corp spin)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Light the Fire!")
+      (card-ability state :runner (get-resource state 0) 0)
+      (click-prompt state :runner "Server 1")
+      (card-ability state :corp spin 0)
+      (is (no-prompt? state :corp) "Corp is making no decisions")
+      (is (refresh spin) "Corp is making no decisions"))))
 
 (deftest logic-bomb
   ;; Logic Bomb

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -786,8 +786,8 @@
    (get-in @state [:runner :play-area pos])))
 
 (defn rez-impl
-  ([state card] (rez-impl state card nil))
-  ([state card {:keys [expect-rez] :or {expect-rez true}}]
+  ([state side card] (rez-impl state side card nil))
+  ([state _side card {:keys [expect-rez] :or {expect-rez true}}]
    (let [card (get-card state card)]
      (is' (installed? card) (str (:title card) " is installed"))
      (is' (not (rezzed? card)) (str (:title card) " is unrezzed"))
@@ -799,8 +799,8 @@
          (is' (not (rezzed? (get-card state card))) (str (:title card) " is still unrezzed")))))))
 
 (defmacro rez
-  [state _ card & opts]
-  `(error-wrapper (rez-impl ~state ~card ~@opts)))
+  [state side card & opts]
+  `(error-wrapper (rez-impl ~state ~side ~card ~@opts)))
 
 (defn derez-impl
   [state side card]


### PR DESCRIPTION
Light The Fire! didn't have `:value true` in the `:disable-card` effect and on top of that wrapped the ability in a vector when calling `create-lingering-effect`, so it was a no-op in all cases. I removed the vector and added `:value true`, and then added light runtime validation to all `create-lingering-effect` calls by checking that the given ability contains `:type` and `:value`. (This will catch when the ability is a vector.)

Additionally, I added a check against the disabled-reg in `do-ability` to make sure that the target card isn't disabled.

Closes #8048