### PR TITLE
fix derez action

### DIFF
--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -213,7 +213,6 @@
                           (if (sequential? cards)
                             (flatten cards)
                             [cards])))]
-     (println cards)
      (if-not (seq cards)
        (effect-completed state side eid)
        (do (doseq [c cards]

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -208,9 +208,12 @@
   "Derez a number of corp cards."
   ([state side eid cards] (derez state side eid cards nil))
   ([state side eid cards {:keys [suppress-checkpoint no-event no-msg msg-keys] :as args}]
-   (let [cards (if (sequential? cards)
-                 (filterv #(and (get-card state %) (rezzed? %)) (flatten cards))
-                 [cards])]
+   (let [cards (vec (keep #(let [c (get-card state %)]
+                             (and (rezzed? c) c))
+                          (if (sequential? cards)
+                            (flatten cards)
+                            [cards])))]
+     (println cards)
      (if-not (seq cards)
        (effect-completed state side eid)
        (do (doseq [c cards]


### PR DESCRIPTION
Data ward issue was just acme. 

When we passed a single card in, we weren't calling `get-card` on it.

Thanks to nin for investigating this one :)

Closes #8052