### PR TITLE
log prize import on cljs build

### DIFF
--- a/src/cljc/jinteki/prizes.cljc
+++ b/src/cljc/jinteki/prizes.cljc
@@ -8,5 +8,6 @@
                       (and res (-> res slurp clojure.edn/read-string))
                       (catch Exception e
                         (println "Exc: " e)))
-                    {})]
+                    {})
+           _ (println (str (count (-> res slurp clojure.edn/read-string)) " card backs loaded"))]
        `(def ~sym (merge ~data ~base-card-backs)))))


### PR DESCRIPTION
This just ensures the card sleeves are logged when we rebuild cljs