### PR TITLE
Don't play flashbacks unless clicking  on them in hand

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -221,6 +221,7 @@
                       (playable? card))
                  (and (= "discard" (first zone))
                       (= "Operation" type)
+                      (:flashback-fake-in-hand card)
                       (:flashback-playable card))))
         (if (= "Operation" type)
           (send-play-command (card-for-click card) shift-key-held)


### PR DESCRIPTION
This should stop you from being able to click on the copy that's in archives to play it like a normal operation :skull: 