### PR TITLE
disable typing events

### DIFF
--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -1,6 +1,5 @@
 (ns nr.gameboard.log
   (:require
-   [cljc.java-time.instant :as inst]
    [clojure.string :as string]
    [jinteki.utils :refer [command-info]]
    [nr.angel-arena.log :as angel-arena-log]

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -51,15 +51,13 @@
   [s]
   (r/with-let [typing (r/cursor game-state [:typing])]
     (let [typing? (boolean (seq (:msg @s)))]
-      ;; note - temporarily disable to see if it impacts performance
-      ;; (when (and (not (:replay @game-state))
-      ;;            ;; only send if the typing state is different
-      ;;            (or (and (not @typing) typing?)
-      ;;                (and (not typing?) @typing))
-      ;;            (not-spectator?))
-      ;;   (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
-      ;;                               :typing typing?}])))))
-      )))
+      (when (and (not (:replay @game-state))
+                 ;; only send if the typing state is different
+                 (or (and (not @typing) typing?)
+                     (and (not typing?) @typing))
+                 (not-spectator?))
+        (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
+                                    :typing typing?}])))))
 
 (defn indicate-action []
   (when (not-spectator?)
@@ -145,7 +143,8 @@
   (reset-command-menu state)
   (swap! state assoc :command-matches (-> e .-target .-value (find-command-matches commands)))
   (swap! state assoc :msg (-> e .-target .-value))
-  (send-typing state))
+  ;;(send-typing state)
+  )
 
 (defn command-menu [!input-ref state]
   (when (show-command-menu? @state)
@@ -184,7 +183,7 @@
              :autoComplete "off"
              :ref #(reset! !input-ref %)
              :value (:msg @state)
-             :on-blur #(send-typing (atom nil))
+             ;;:on-blur #(send-typing (atom nil))
              :on-key-down #(command-menu-key-down-handler state %)
              :on-change #(log-input-change-handler state %)}]]]
          [indicate-action]

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -1,5 +1,6 @@
 (ns nr.gameboard.log
   (:require
+   [cljc.java-time.instant :as inst]
    [clojure.string :as string]
    [jinteki.utils :refer [command-info]]
    [nr.angel-arena.log :as angel-arena-log]
@@ -49,12 +50,16 @@
   "Send a typing event to server for this user if it is not already set in game state AND user is not a spectator"
   [s]
   (r/with-let [typing (r/cursor game-state [:typing])]
-    (let [text (:msg @s)]
-      (when (and (not (:replay @game-state))
-                 (not @typing)
-                 (not-spectator?))
-        (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
-                                    :typing (boolean (seq text))}])))))
+    (let [typing? (boolean (seq (:msg @s)))]
+      ;; note - temporarily disable to see if it impacts performance
+      ;; (when (and (not (:replay @game-state))
+      ;;            ;; only send if the typing state is different
+      ;;            (or (and (not @typing) typing?)
+      ;;                (and (not typing?) @typing))
+      ;;            (not-spectator?))
+      ;;   (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
+      ;;                               :typing typing?}])))))
+      )))
 
 (defn indicate-action []
   (when (not-spectator?)


### PR DESCRIPTION
Probably the best way to diagnose this is to just disable typing events for a patch or two and see if that changes anything, so I just commented out the part that sends them.

Right now we're getting like, 5k+ typing events every 5 minute frame, which is a lot considering sente itself dispatches from a single thread.

I think other things to try are tracking time on the frontend and limiting it to one typing event every 10 seconds, but then maybe we get stuck on typing permanently, who knows :eyes: 