### PR TITLE
shadow-cljs actually rebuilds card-backs on file update

### DIFF
--- a/src/clj/tasks/update_prizes.clj
+++ b/src/clj/tasks/update_prizes.clj
@@ -50,6 +50,10 @@
                         (with-open [w (io/output-stream card-path)]
                           (.write w body)))
                   (println "Error downloading art for card-back: " title error))))))
+        ;; this forces shadow-cljs to recompile the macro which depends on this
+        (let [p (io/file "src/cljc/jinteki/prizes.cljc")]
+          (when (.exists p)
+            (.setLastModified p (System/currentTimeMillis))))
         (println "done!"))
     (println "Unable to fetch card-back prize data")))
 

--- a/src/cljc/jinteki/prizes.cljc
+++ b/src/cljc/jinteki/prizes.cljc
@@ -10,4 +10,5 @@
                         (println "Exc: " e)))
                     {})
            _ (println (str (count data) " card backs loaded"))]
-       `(def ~sym (merge ~data ~base-card-backs)))))
+       `(def ~sym (merge ~data ~base-card-backs))
+       (hash (into (sorted-map) data)))))

--- a/src/cljc/jinteki/prizes.cljc
+++ b/src/cljc/jinteki/prizes.cljc
@@ -10,5 +10,4 @@
                         (println "Exc: " e)))
                     {})
            _ (println (str (count data) " card backs loaded"))]
-       `(def ~sym (merge ~data ~base-card-backs))
-       (hash (into (sorted-map) data)))))
+       `(def ~sym (merge ~data ~base-card-backs)))))


### PR DESCRIPTION
This makes the macro yield a result which should be pinned to the contents of the data file. This forces shadow-cljs to actually reload the macro when the edn file changes.