### PR TITLE
Manage pools better

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -1,5 +1,6 @@
 (ns web.lobby
   (:require
+   [clojure.core.async :refer [<! go timeout]]
    [cljc.java-time.instant :as inst]
    [cljc.java-time.duration :as duration]
    [cljc.java-time.temporal.chrono-unit :as chrono]
@@ -18,7 +19,8 @@
    [web.app-state :as app-state]
    [web.mongodb :as mongodb]
    [web.stats :as stats]
-   [web.ws :as ws]))
+   [web.ws :as ws]
+   [taoensso.encore :as enc]))
 
 (read-write/print-time-literals-clj!)
 
@@ -47,28 +49,44 @@
 (defonce game-pools
   (letfn [(new-pool [x]
             {:pool (cp/threadpool 1 {:name (str "game-thread-" x)})
-             :occupants (atom 0)})] ;; note that occupants is just for load balancing purposes
+             :occupants (atom #{})})] ;; note that occupants is just for load balancing purposes
     (vec (map new-pool (range pool-size)))))
 
 (defn pool-occupants-info [] (map #(deref (:occupants %)) game-pools))
 
 (defn join-pool!
   "Returns one of the pools at random with the least occupants. Updates pool occupancy"
-  []
-  (let [pool (first (sort-by #(deref (:occupants %)) (shuffle game-pools)))]
-    (swap! (:occupants pool) inc)
+  [gameid]
+  (let [pool (first (sort-by #(-> % :occupants deref count) (shuffle game-pools)))]
+    (swap! (:occupants pool) conj gameid)
     pool))
 
 (defn leave-pool!
   "Leaves a pool. This just decrements the occupants, so we can reassign it smartly"
-  [pool]
-  (swap! (:occupants pool) dec))
+  [pool gameid]
+  (swap! (:occupants pool) disj gameid))
+
+(def pool-cleaning-frequency (enc/ms :mins 30))
+(defonce clean-pools
+  (go (while true
+        (<! (timeout pool-cleaning-frequency))
+        (let [cleaned! (atom 0)
+              lobby-ids (set (map :gameid (app-state/get-lobbies)))]
+          (doseq [pool game-pools]
+            (let [occupants @(:occupants pool)
+                  stale (set/difference occupants lobby-ids)]
+              (when (seq stale)
+                (swap! cleaned! + (count stale))
+                (swap! (:occupants pool) set/difference stale))))
+          (if (pos? @cleaned!)
+            (println "cleaned up" @cleaned! "stale pool occupants!")
+            (println "all pools are tidy!"))))))
 
 (defonce lobby-pool (cp/threadpool 1 {:name "lobbies-thread"}))
 (defmacro lobby-thread [& expr] `(cp/future lobby-pool ~@expr))
 (defmacro game-thread [lobby & expr]
   "Note: if the lobby isn't actually real, or has been nulled somehow, executing on the lobby thread is safe"
-  `(cp/future (or (get-in ~lobby [:pool :pool]) lobby-pool) ~@expr))
+  `(cp/future (get-in ~lobby [:pool :pool] lobby-pool) ~@expr))
 
 (defn validate-precon
   [format client-precon client-gateway-type]
@@ -100,7 +118,7 @@
      :corp-spectators []
      :runner-spectators []
      :messages []
-     :pool (join-pool!)
+     :pool (join-pool! gameid)
      ;; options
      :precon (validate-precon format precon gateway-type)
      :open-decklists (or open-decklists (when (validate-precon format precon gateway-type) true))
@@ -402,7 +420,7 @@
    (swap! app-state/app-state update :lobbies dissoc gameid)
    (doseq [uid (keep :uid (get-players-and-spectators lobby))]
      (clear-lobby-state uid))
-   (leave-pool! pool)
+   (leave-pool! pool gameid)
    (when (and (not skip-on-close) on-close)
      (on-close lobby))))
 

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -113,7 +113,7 @@
                      " uid: " ws-uid-count
                      " conn: " ws-conn-total
                      " }"))
-      (timbre/info (str "pool occupants: " (seq (pool-occupants-info))))
+      (timbre/info (str "pool occupants: " (seq (map count (pool-occupants-info)))))
       (timbre/info latencies)
       ;; TODO - once we've got this set up on the server, wrap it in a try/catch - only ever display
       ;; the warning once!


### PR DESCRIPTION
I made it so pools track gameids instead of just being a counter, and then we periodically (every 30 minutes) check them against the actual lobbies and fix any stale entries.

I did this because I noticed on the server log that the number of assigned pools seems to gradually climb higher than the number of lobbies, and I think it's one of:
* some lobbies crashing and not getting unregistered
* some lobbies colliding on creation and the side-effects of that being redone, so sometimes they get added twice (I think this is how atoms work?)

Anyway if that's true or not, this should handle both of those.