### PR TITLE
Fix card images not loading when there's multiple images to pick

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -64,7 +64,7 @@
       (let [art-urls (get-image-path images (keyword lang) (keyword res) (keyword (first art)))
             chosen-art (nth art-urls (second art))]
         [chosen-art])
-      (get-image-path images (keyword lang) (keyword res) (keyword art)))))
+      (first (get-image-path images (keyword lang) (keyword res) (keyword art))))))
 
 
 (defonce button-channel (chan))


### PR DESCRIPTION
I recreated the production issue by copying all my images from `resources/img/cards/en/default/stock` into `/resources/img/cards/overrides/sg/en/default/stock` and then doing a `lein fetch`. Then I applied this fix and it worked. 

I deleted the override images and refetched and it still works so I believe we are always getting back a list of card back choices and it only happens to work in most cases currently because that list usually just has 1 element.