### PR TITLE
Load i18n ftl files from uberjar or local directory

### DIFF
--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -129,7 +129,7 @@
   (load-quotes!))
 
 (defmethod ig/init-key :web/i18n [_ _opts]
-  (i18n/load-dictionary! "resources/public/i18n"))
+  (i18n/load-dictionary! "public/i18n"))
 
 (defmethod ig/halt-key! :web/i18n [_ _opts]
   (reset! i18n/fluent-dictionary nil))


### PR DESCRIPTION
This PR amends ftl loading to support loading from an uberjar as well as the filesystem.  This allows packaging and serving ftl files from within a docker-ized deployment such as in `docker/Dockerfile.prod`, just as we do with CSS and other static assets.  (Except card images which are not bundled in the uberjar.)

I have tested this both locally with `lein run` and via `docker compose` on a private server.

As I've written this with the aid of AI tools and am not very fluent in Clojure, please do consider this change thoughtfully before merging.