### PR TITLE
Add settings note that translations are incomplete

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -358,17 +358,18 @@
             (doall
               (for [option [{:name "English" :ref "en"}
                             {:name "中文 (Simplified)" :ref "zh-simp"}
-                            {:name "中文 (Traditional)" :ref "zh-trad"}
+                            {:name "中文 (Traditional) (Cards only)" :ref "zh-trad"}
                             {:name "Français" :ref "fr"}
-                            {:name "Deutsch" :ref "de"}
-                            {:name "Italiano" :ref "it"}
+                            {:name "Deutsch (Cards only)" :ref "de"}
+                            {:name "Italiano (Cards only)" :ref "it"}
                             {:name "日本語" :ref "ja"}
                             {:name "한국어" :ref "ko"}
                             {:name "Polski" :ref "pl"}
                             {:name "Português" :ref "pt"}
                             {:name "Русский" :ref "ru"}
                             {:name "Igpay Atinlay" :ref "la-pig"}]]
-                [:option {:value (:ref option) :key (:ref option)} (:name option)]))]]
+                [:option {:value (:ref option) :key (:ref option)} (:name option)]))]
+           [:div "Some languages are not fully translated yet. If you would like to help with translations, please contact us."]]
           [:section
            [:h3 (tr [:settings_sounds "Sounds"])]
            [:div


### PR DESCRIPTION
Some languages have card data files and ftl files and other have only card data.  This commit clarifies which are card-data-only and adds an invitation to help with translation support.  Arguably, "Cards only" should be translated as well, but I think something is better than nothing.