### PR TITLE
buffer drive only picks relevant cards

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -468,19 +468,17 @@
                       (runner-hand-size+ (get-x-fn))]})
 
 (defcard "Buffer Drive"
-  (let [grip-or-stack-trash?
-        (fn [targets]
-          (some #(and (runner? (:card %))
-                      (or (in-hand? (:card %))
-                          (in-deck? (:card %))))
-                targets))
+  (let [grip-or-stack-trash? (fn [{:keys [card]}]
+                               (and (runner? card)
+                                    (or (in-hand? card)
+                                        (in-deck? card))))
         triggered-ability
         {:once-per-instance true
          :req (req
-                (and (grip-or-stack-trash? targets)
-                     (first-trash? state grip-or-stack-trash?)))
+                (and (some grip-or-stack-trash? targets)
+                     (first-trash? state #(some grip-or-stack-trash? %))))
          :prompt "Choose 1 trashed card to add to the bottom of the stack"
-         :choices (req (conj (sort (keep #(->> (:moved-card %) :title) targets)) "No action"))
+         :choices (req (conj (sort (keep #(->> (:moved-card %) :title) (filter grip-or-stack-trash? targets))) "No action"))
          :async true
          :effect (req (if (= "No action" target)
                         (effect-completed state side eid)

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -1363,6 +1363,19 @@
     (click-prompt state :corp "Boomerang")
     (is (not-any? #{"Boomerang"} (prompt-buttons :runner)) "No offer to install boomerang")))
 
+(deftest buffer-drive-with-light-the-fire!
+  (do-game
+    (new-game {:corp {:hand ["PAD Campaign"]}
+               :runner {:hand ["Buffer Drive" "Light the Fire!" "Ika"]}})
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Buffer Drive")
+    (play-from-hand state :runner "Light the Fire!")
+    (card-ability state :runner (get-resource state 0) 0)
+    (click-prompt state :runner "Server 1")
+    (is (= ["Ika" "No action"] (sort (prompt-buttons :runner)))
+        "No prompt to bottom light the fire!")))
+
 (deftest capstone
   ;; Capstone
   (do-game


### PR DESCRIPTION
Buffer drive would let you shuffle the Light the Fire! back :eyes:. Not anymore.