### PR TITLE
Select prompts index by eid

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -224,6 +224,7 @@
    :prompt-type
    :show-discard
    :selectable
+   :eid
    ;; traces
    :player
    :base

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -109,11 +109,11 @@
            (or (map? card)
                (string? card)))
       (if (map? card)
-        (core/process-action "select" state side {:card card})
+        (core/process-action "select" state side {:card card :eid (:eid (get-prompt state side))})
         (let [all-cards (core/get-all-cards state)
               matching-cards (filter #(= card (core/get-title %)) all-cards)]
           (if (= (count matching-cards) 1)
-            (core/process-action "select" state side {:card (first matching-cards)})
+            (core/process-action "select" state side {:card (first matching-cards) :eid (:eid (get-prompt state side))})
             (is' (= 1 (count matching-cards))
                  (str "Expected to click card [ " card
                       " ] but found " (count matching-cards)


### PR DESCRIPTION
Closes #8163 (by removing the breaking condition, it wasn't eids, it was always pulling the topmost prompt, which was sometimes wrong)

I'm 99% sure this was the cause of #7985, so Closes #7985

I'm 99% sure this was the cause of #7830, so closes #7830

I'm 99% sure this was also the cause of #7255, so closes #7255

There's a chance it could have been the cause of the following issues:
#8042