### PR TITLE
Prevent mobile sysops from moving to its own server

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -7,7 +7,7 @@
                              steal-cost-bonus]]
    [game.core.bad-publicity :refer [lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-corp card->server
-                            get-remotes server->zone server-list]]
+                            get-remotes server->zone server-list server-list-exclude]]
    [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? get-card get-counters get-zone
                            has-subtype? ice? in-discard? in-hand? installed? operation? program? resource? rezzed?
@@ -70,7 +70,7 @@
      :yes-ability
      {:prompt "Choose a server"
       :waiting-prompt true
-      :choices (req (server-list state))
+      :choices (req (server-list-exclude state [(second (:zone card))]))
       :msg (msg "move itself to " target)
       :async true
       :effect (req (let [c (move state side card

--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -159,6 +159,11 @@
   [state]
   (zones->sorted-names (get-zones state)))
 
+(defn server-list-exclude
+  "Get a list of all servers other than the ones provided"
+  [state exclude-list]
+  (zones->sorted-names (remove (set exclude-list) (get-zones state))))
+
 (defn installable-servers
   "Get list of servers the specified card can be installed in"
   [state card]

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -2087,6 +2087,8 @@
           "Ice Wall got +2 strength")
       (take-credits state :corp)
       (click-prompt state :corp "Yes")
+      (is (not-any? #(= (:value %) "Server 1") (:choices (get-prompt state :corp)))
+          "Current server is not listed as an option")
       (click-prompt state :corp "R&D")
       (is (not (no-prompt? state :corp)) "Corp has Isaac Liberdade prompt")
       (is (changed? [(get-strength (refresh tithe)) 2


### PR DESCRIPTION
Exclude the current server from options to prevent mobile sysops (i.e. Isaac Liberdade) from triggering itself in the same server.

Fixes https://github.com/mtgred/netrunner/issues/7889