### PR TITLE
carpe diem runs with its card

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -539,7 +539,7 @@
                                    :no-ability {:effect (effect (system-msg (str "declines to use " (:title card) " to make a run")))}
                                    :yes-ability {:msg (str "make a run on " (zone->name marked-server))
                                                  :async true
-                                                 :effect (effect (make-run eid marked-server))}}}
+                                                 :effect (effect (make-run eid marked-server card))}}}
                                  card nil)))))}})
 
 (defcard "CBI Raid"
@@ -3008,7 +3008,7 @@
              :async true
              :effect (req (when (<= (count (:hand runner)) 2)
                             (pump-all-icebreakers state side 2 :end-of-run))
-                          (make-run state side eid target))}})
+                          (make-run state side eid target card))}})
 
 (defcard "Quality Time"
   {:on-play

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -138,9 +138,7 @@
                                                    :req (req (>= (:click runner) 2))
                                                    :msg (msg "bypass " (card-str state (:ice context)))
                                                    :effect (req (bypass-ice state))}}}])
-                              (wait-for
-                                (make-run state :runner (make-eid state eid) :hq card)
-                                (effect-completed state side eid)))}]
+                              (make-run state side eid :hq card))}]
     {:flags {:runner-phase-12 (req true)}
      :events [{:event :runner-turn-begins
                :skippable true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1939,8 +1939,7 @@
                  :msg (msg "make a run on " target " during which no programs can be used")
                  :makes-run true
                  :async true
-                 :effect (req (wait-for (make-run state :runner (make-eid state eid) target card)
-                                        (effect-completed state side eid)))}]
+                 :effect (req (make-run state side eid target card))}]
     {:implementation "Doesn't prevent program use"
      :flags {:runner-phase-12 (req true)}
      :install-cost-bonus (req (- (get-link state)))


### PR DESCRIPTION
I noticed carpe diem didn't use the card image during the run, so I fixed that. Looks like pushing the envelope didn't either, so I fixed that too.