### PR TITLE
Remove deprecated reagent.dom/dom-node usage

### DIFF
--- a/src/cljs/nr/about.cljs
+++ b/src/cljs/nr/about.cljs
@@ -18,14 +18,15 @@
 
 (defn about-content [state scroll-top]
   (r/with-let [donors (r/cursor state [:donors])
-               alt-info (r/cursor app-state [:alt-info])]
+               alt-info (r/cursor app-state [:alt-info])
+               !node-ref (r/atom nil)]
     (r/create-class
       {:display-name "about-content"
-       :component-did-mount #(set-scroll-top % @scroll-top)
-       :component-will-unmount #(store-scroll-top % scroll-top)
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref scroll-top))
        :reagent-render
        (fn [_ _]
-         [:div.about.panel.content-page.blue-shade
+         [:div.about.panel.content-page.blue-shade {:ref #(reset! !node-ref %)}
           [:h3 "About"]
           [:p "This website was founded by " [:a {:href "http://twitter.com/mtgred" :target "_blank"} "@mtgred"]
            ", an avid Netrunner player from Belgium. The goal is to provide a great way to create and test Netrunner decks online."]

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -319,13 +319,14 @@
    ["Worlds 2020" "worlds2020"]])
 
 (defn account-content [_ _ scroll-top]
-  (r/create-class
-    {:display-name "account-content"
-     :component-did-mount #(set-scroll-top % @scroll-top)
-     :component-will-unmount #(store-scroll-top % scroll-top)
-     :reagent-render
-     (fn [user s _]
-       [:div#profile-form.panel.blue-shade.content-page {:ref "profile-form"}
+  (r/with-let [!node-ref (r/atom nil)]
+    (r/create-class
+      {:display-name "account-content"
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref scroll-top))
+       :reagent-render
+       (fn [user s _]
+         [:div#profile-form.panel.blue-shade.content-page {:ref #(reset! !node-ref %)}
          [:h2 (tr [:nav_settings "Settings"])]
          [:form {:on-submit #(handle-post % s)}
           [:button.float-right (tr [:settings_update-profile "Update Profile"])]
@@ -679,7 +680,7 @@
      [api-keys s]
 
      [:section
-      [:span.flash-message (:flash-message @s)]]]])}))
+      [:span.flash-message (:flash-message @s)]]]])})))
 
 (defn account []
   (let [user (r/cursor app-state [:user])

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -477,11 +477,12 @@
                   :onLoad #(-> % .-target js/$ .show)}]))])))
 
 (defn card-list-view [_ scroll-top]
-  (r/create-class
-    {
-     :display-name "card-list-view"
-     :component-did-mount #(set-scroll-top % @scroll-top)
-     :component-will-unmount #(store-scroll-top % scroll-top)
+  (r/with-let [!node-ref (r/atom nil)]
+    (r/create-class
+      {
+       :display-name "card-list-view"
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref scroll-top))
      :reagent-render
      (fn [state _]
        (let [selected (selected-set-name state)
@@ -504,11 +505,11 @@
                         (insert-alt-arts alt-filter)
                         (sort-by (sort-field (:sort-field @state)))
                         (take (* (:page @state) 28)))]
-         [:div.card-list {:on-scroll #(handle-scroll % state)}
+         [:div.card-list {:ref #(reset! !node-ref %) :on-scroll #(handle-scroll % state)}
           (doall
             (for [card cards]
               ^{:key (str (base-image-url card) "-" (:code card))}
-              [card-view card state]))]))}))
+              [card-view card state]))]))})))
 
 (defn handle-search [e state]
   (doseq [filter [:set-filter :type-filter :faction-filter]]

--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -215,11 +215,12 @@
 (fetch-all-messages)
 
 (defn message-panel [s old scroll-top]
-  (r/with-let [cards-loaded (r/cursor app-state [:cards-loaded])]
+  (r/with-let [cards-loaded (r/cursor app-state [:cards-loaded])
+               !node-ref (r/atom nil)]
     (r/create-class
       {:display-name "message-panel"
-       :component-did-mount #(set-scroll-top % @scroll-top)
-       :component-will-unmount #(store-scroll-top % scroll-top)
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref scroll-top))
        :component-did-update
        (fn []
          (when-let [msg-list (:message-list @chat-state)]
@@ -244,7 +245,8 @@
 
        :reagent-render
        (fn [s _old _scroll-top]
-         [:div.blue-shade.panel.message-list {:ref #(swap! chat-state assoc :message-list %)
+         [:div.blue-shade.panel.message-list {:ref #(do (reset! !node-ref %)
+                                                                                        (swap! chat-state assoc :message-list %))
                                               :on-scroll #(let [currElt (.-currentTarget %)
                                                                 scroll-top (.-scrollTop currElt)
                                                                 scroll-height (.-scrollHeight currElt)

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -622,16 +622,17 @@
             (= all-formats-filter @fmt-filter))))
 
 (defn decks-list [_ _ scroll-top]
-  (r/create-class
-    {:display-name "deck-collection"
-     :component-did-mount #(set-scroll-top % @scroll-top)
-     :component-will-unmount #(store-scroll-top % scroll-top)
-     :reagent-render
-     (fn [filtered-decks s _]
-       (into [:div.deck-collection]
-             (for [deck (sort-by (juxt :date :_id) > filtered-decks)]
-               ^{:key (:_id deck)}
-               [deck-entry s deck])))}))
+  (r/with-let [!node-ref (r/atom nil)]
+    (r/create-class
+      {:display-name "deck-collection"
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref scroll-top))
+       :reagent-render
+       (fn [filtered-decks s _]
+         (into [:div.deck-collection {:ref #(reset! !node-ref %)}]
+               (for [deck (sort-by (juxt :date :_id) > filtered-decks)]
+                 ^{:key (:_id deck)}
+                 [deck-entry s deck])))})))
 
 (defn deck-collection
   [state decks decks-loaded scroll-top]

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -209,27 +209,28 @@
 (defn log-messages []
   (let [log (r/cursor game-state [:log])
         corp (r/cursor game-state [:corp :user :username])
-        runner (r/cursor game-state [:runner :user :username])]
+        runner (r/cursor game-state [:runner :user :username])
+        !node-ref (r/atom nil)]
     (r/create-class
       {:display-name "log-messages"
 
        :component-did-mount
-       (fn [this]
+       (fn [_]
          (when (:update @should-scroll)
-           (let [n (rdom/dom-node this)]
+           (when-let [n @!node-ref]
              (set! (.-scrollTop n) (.-scrollHeight n)))))
 
        :component-will-update
-       (fn [this]
-         (let [n (rdom/dom-node this)]
+       (fn [_]
+         (when-let [n @!node-ref]
            (reset! should-scroll {:update (or (:send-msg @should-scroll)
                                               (scrolled-to-end? n 15))
                                   :send-msg false})))
 
        :component-did-update
-       (fn [this]
+       (fn [_]
          (when (:update @should-scroll)
-           (let [n (rdom/dom-node this)]
+           (when-let [n @!node-ref]
              (set! (.-scrollTop n) (.-scrollHeight n)))))
 
        :reagent-render
@@ -237,6 +238,7 @@
          (into [:div.messages {:class [(when (:replay @game-state)
                                          "panel-bottom")
                                        (player-highlight-option-class)]
+                               :ref #(reset! !node-ref %)
                                :on-mouse-over #(card-preview-mouse-over % zoom-channel)
                                :on-mouse-out #(card-preview-mouse-out % zoom-channel)
                                :aria-live "polite"}]

--- a/src/cljs/nr/lobby_chat.cljs
+++ b/src/cljs/nr/lobby_chat.cljs
@@ -29,11 +29,11 @@
       {:display-name "lobby-chat"
        :component-did-mount
        (fn []
-         (let [el (rdom/dom-node @message-list)]
+         (when-let [el @message-list]
            (set! (.-scrollTop el) (.-scrollHeight el))))
        :component-did-update
        (fn []
-         (let [el (rdom/dom-node @message-list)]
+         (when-let [el @message-list]
            (when (or @should-scroll
                      (scrolled-to-end? el 15))
              (swap! state assoc :should-scroll false)

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -124,16 +124,17 @@
     [stats-panel stats]))
 
 (defn game-log [_state log-scroll-top]
-  (r/create-class
-    {:display-name "stats-game-log"
-     :component-did-mount #(set-scroll-top % @log-scroll-top)
-     :component-will-unmount #(store-scroll-top % log-scroll-top)
-     :reagent-render
-     (fn [state _log-scroll-top]
-       (let [game (:view-game @state)
-             corp (get-in game [:corp :player :username])
-             runner (get-in game [:runner :player :username])]
-         [:div {:style {:overflow "auto"}}
+  (r/with-let [!node-ref (r/atom nil)]
+    (r/create-class
+      {:display-name "stats-game-log"
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @log-scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref log-scroll-top))
+       :reagent-render
+       (fn [state _log-scroll-top]
+         (let [game (:view-game @state)
+               corp (get-in game [:corp :player :username])
+               runner (get-in game [:runner :player :username])]
+           [:div {:style {:overflow "auto"} :ref #(reset! !node-ref %)}
           [:div.panel.messages {:class (player-highlight-option-class)}
            (if (seq (:log game))
              (doall (map-indexed
@@ -147,7 +148,7 @@
                               [:div.username (get-in msg [:user :username])]
                               [:div (render-message (:text msg))]]])))
                       (:log game)))
-             [:h4 (tr [:stats_no-log "No log available"])])]]))}))
+             [:h4 (tr [:stats_no-log "No log available"])])]]))})))
 
 (def faction-icon-memo (memoize faction-icon))
 
@@ -197,16 +198,17 @@
        [:h4 (tr [:stats_winner "Winner"] {:winner (tr-side winner)}) (str user-win)])]))
 
 (defn history [_state list-scroll-top _log-scroll-top]
-  (r/create-class
-    {:display-name "stats-history"
-     :component-did-mount #(set-scroll-top % @list-scroll-top)
-     :component-will-unmount #(store-scroll-top % list-scroll-top)
-     :reagent-render
-     (fn [state _list-scroll-top log-scroll-top]
-       (let [all-games (:games @state)
-             games (if (:filter-replays @state) (filter #(:replay-shared %) all-games) all-games)
-             cnt (count games)]
-         [:div.game-list
+  (r/with-let [!node-ref (r/atom nil)]
+    (r/create-class
+      {:display-name "stats-history"
+       :component-did-mount (fn [_] (set-scroll-top @!node-ref @list-scroll-top))
+       :component-will-unmount (fn [_] (store-scroll-top @!node-ref list-scroll-top))
+       :reagent-render
+       (fn [state _list-scroll-top log-scroll-top]
+         (let [all-games (:games @state)
+               games (if (:filter-replays @state) (filter #(:replay-shared %) all-games) all-games)
+               cnt (count games)]
+           [:div.game-list {:ref #(reset! !node-ref %)}
            [:div.controls
             [:button {:on-click #(swap! state update :filter-replays not)}
              (if (:filter-replays @state)
@@ -220,7 +222,7 @@
              (doall
                (for [game games]
                  ^{:key (:gameid game)}
-                 [game-row state game log-scroll-top])))]))}))
+                 [game-row state game log-scroll-top])))]))})))
 
 (defn right-panel [state list-scroll-top log-scroll-top]
   (if (:view-game @state)

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -368,16 +368,17 @@
     (gstring/format "%.0f" (* 100 (float (/ num1 num2))))))
 
 (defn set-scroll-top
-  "Set the scrollTop parameter of a reagent component"
-  [this scroll-top]
-  (let [node (rd/dom-node this)]
+  "Set the scrollTop parameter of a DOM node"
+  [node scroll-top]
+  (when node
     (set! (.-scrollTop node) scroll-top)))
 
 (defn store-scroll-top
-  "Store the scrollTop parameter of a reagent component in an atom"
-  [this scroll-top-atom]
-  (let [h (.-scrollTop (rd/dom-node this))]
-    (reset! scroll-top-atom h)))
+  "Store the scrollTop parameter of a DOM node in an atom"
+  [node scroll-top-atom]
+  (when node
+    (let [h (.-scrollTop node)]
+      (reset! scroll-top-atom h))))
 
 (defn get-image-path
   "Image search priority: Language > Art > Resolution"


### PR DESCRIPTION
Replace all uses of the deprecated `reagent.dom/dom-node` function with modern ref callback patterns to eliminate console warnings during development.

Changes:
- Updated utils.cljs functions `set-scroll-top` and `store-scroll-top` to accept DOM nodes directly instead of React component instances
- Migrated 9 components across the codebase to use ref callbacks instead of dom-node calls:
  - about.cljs: account content scrolling
  - account.cljs: profile form scrolling
  - cardbrowser.cljs: card list scrolling
  - chat.cljs: message panel scrolling
  - deckbuilder.cljs: deck collection scrolling
  - gameboard/log.cljs: game log scrolling
  - lobby_chat.cljs: lobby chat scrolling
  - stats.cljs: game log and history scrolling (2 components)
- Added null safety checks in utility functions
- Maintained all existing functionality while modernizing code patterns

All tests pass and builds complete successfully with no deprecation warnings.