### PR TITLE
reset icebreaker strength between turns

### DIFF
--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1142,6 +1142,13 @@
               (unregister-floating-events state nil duration))
             (effect-completed state nil eid)))
 
+(defn resolve-durations
+  "unregisters all floating and lingering effects for the given durations"
+  [state side & durations]
+  (doseq [duration durations]
+    (unregister-lingering-effects state side duration)
+    (unregister-floating-events state side duration)))
+
 (defn get-old-uniques
   [state side]
   (some->> (all-active-installed state side)

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -881,6 +881,19 @@
     (is (= 2 (count (:discard (get-corp)))) "Vanilla Campaign trashed")
     (is (= 0 (get-counters (get-program state 0) :virus)) "No virus counter because not accessed")))
 
+(deftest audrey-v2-strength-resets
+  (do-game
+    (new-game {:corp {:hand ["Rashida Jaheem" "Vanilla"]}
+               :runner {:hand ["Knifed" "Audrey v2" "Sure Gamble"]}})
+    (play-from-hand state :corp "Vanilla" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Audrey v2")
+    (card-ability state :runner (get-program state 0) 1)
+    (click-card state :runner "Knifed")
+    (is (= 3 (get-strength (get-program state 0))))
+    (take-credits state :runner)
+    (is (= 0 (get-strength (get-program state 0))) "Strength resets end of turn")))
+
 (deftest aumakua-automated-test
   (basic-program-test {:name "Aumakua"
                        :counters-modify-strength {:type :virus}


### PR DESCRIPTION
This is a stopgap just for audrey (and twinning mantle enjoyers) until I figure out a better solution. It also cleans up `turns` a little bit.