### PR TITLE
Removed Misspelled Keys

### DIFF
--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -114,12 +114,10 @@
   (let [email (str username "@example.com")
         players {:runner {:player {:username "<nobody>" :emailhash (md5 "nobody@example.com")}
                           :deck-name "Firestorm (Worlds 110th)"
-                          :identity "Ele \"Smoke\" Scovak: Cynosure of the Net"
-                          :agenda-points 0}
+                          :identity "Ele \"Smoke\" Scovak: Cynosure of the Net"}
                  :corp {:player {:username "<nobody>" :emailhash (md5 "nobody@example.com")}
                         :deck-name "That One SYNC Deck -- 35th at Worlds"
-                        :identity "SYNC: Everything, Everywhere"
-                        :agenda-points 0}}
+                        :identity "SYNC: Everything, Everywhere"}}
         side (rand-nth (keys players))
         players (update players side
                         #(assoc % :player {:username username :emailhash (md5 email)}))


### PR DESCRIPTION
I found two uses of keys `:agenda-points` a mix of the `:agenda-point` and `:agendapoints` keys. These are not used anywhere so I got rid of them.

I consider adding the correct keys in, which would probably be `:agenda-point`, but they aren't there no so they don't seem to be needed. I went with the smaller logical change and just removed the extra key.