### PR TITLE
Allow /save-replay during prompts

### DIFF
--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -43,7 +43,7 @@
   [state side command]
   (let [prompt-type (get-in @state [side :prompt-state :prompt-type])]
     ;; we can process these commands whenever, they are for fixing stuff
-    (or (contains? #{"/close-prompt" "/undo-click" "/undo-turn" "/swap-sides"} (str/trim command))
+    (or (contains? #{"/close-prompt" "/undo-click" "/undo-turn" "/swap-sides" "/save-replay"} (str/trim command))
         ;; but otherwise, we should not process commands unless there is no prompt,
         ;; or just a run prompt
         (not prompt-type)


### PR DESCRIPTION
`/save-replay` should be allowed at all times, cuz it's not related to the game itself.