### PR TITLE
bigger picture does not double-print it's outcome anymore

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -421,7 +421,6 @@
                                  :no-ability {:effect (effect (system-msg (str "declines to use " (:title card) " to score " (card-str state card-to-score))))}}}
                                card nil))))}})
 
-;; TODO - write a helper for "drain X credits to gain Y credits"
 (defcard "Bigger Picture"
   {:on-play (choose-one-helper
               {:req (req tagged)}
@@ -433,10 +432,6 @@
                 :ability {:req (req tagged)
                           :prompt "Remove how many tags?"
                           :choices {:number (req (count-tags state))}
-                          :msg (msg
-                                 (let [drained (min (:credit runner) (* 5 target))]
-                                   (str "remove " (quantify target "tag") " to force the runner to lose " drained
-                                        " [Credits]")))
                           :async true
                           :effect (req (continue-ability
                                          state side


### PR DESCRIPTION
Fixes the double-printing here:
![bigger-picture_001](https://github.com/user-attachments/assets/516c85d7-f8b3-4afc-a226-d5f9a8d7b6d4)
