### PR TITLE
Make giving tags use an ability

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -17,7 +17,7 @@
    [game.core.cost-fns :refer [rez-cost install-cost]]
    [game.core.choose-one :refer [choose-one-helper]]
    [game.core.damage :refer [damage]]
-   [game.core.def-helpers :refer [corp-recur defcard do-net-damage gain-credits-ability
+   [game.core.def-helpers :refer [corp-recur defcard do-net-damage gain-credits-ability give-tags
                                   offer-jack-out reorder-choice take-credits get-x-fn]]
    [game.core.drawing :refer [draw draw-up-to]]
    [game.core.effects :refer [register-lingering-effect]]
@@ -497,10 +497,7 @@
                        :value (req (- (get-counters card :agenda)))}]})
 
 (defcard "Breaking News"
-  {:on-score {:async true
-              :silent (req true)
-              :msg "give the Runner 2 tags"
-              :effect (effect (gain-tags :corp eid 2))}
+  {:on-score (give-tags 2)
    :events (let [event {:unregister-once-resolved true
                         :req (effect (first-event? :agenda-scored #(same-card? card (:card (first %)))))
                         :msg "make the Runner lose 2 tags"
@@ -967,9 +964,7 @@
                                    card nil))))}]})
 
 (defcard "Fly on the Wall"
-  {:on-score {:msg "give the runner 1 tag"
-              :async true
-              :effect (req (gain-tags state :runner eid 1))}})
+  {:on-score (give-tags 1)})
 
 (defcard "Freedom of Information"
   {:advancement-requirement (req (- (count-tags state)))})
@@ -1602,9 +1597,7 @@
   {:advancement-requirement (req (- (or (get-in @state [:runner :brain-damage]) 0)))})
 
 (defcard "Oracle Thinktank"
-  {:stolen {:msg "give the Runner 1 tag"
-            :async true
-            :effect (effect (gain-tags eid 1))}
+  {:stolen (give-tags 1)
    :abilities [{:action true
                 :cost [(->c :click 1) (->c :tag 1)]
                 :req (req (is-scored? state :runner card))
@@ -2060,9 +2053,7 @@
                 :label "give runner 1 tag"
                 :keep-menu-open :while-clicks-left
                 :trace {:base 2
-                        :successful {:msg "give the Runner 1 tag"
-                                     :async true
-                                     :effect (effect (gain-tags eid 1))}}}]})
+                        :successful (give-tags 1)}}]})
 
 (defcard "Salvo Testing"
   {:events [{:event :agenda-scored
@@ -2372,9 +2363,7 @@
 
 (defcard "TGTBT"
   {:flags {:rd-reveal (req true)}
-   :on-access {:msg "give the Runner 1 tag"
-               :async true
-               :effect (effect (gain-tags eid 1))}})
+   :on-access (give-tags 1)})
 
 (defcard "The Cleaners"
   {:prevention [{:prevents :pre-damage
@@ -2446,13 +2435,8 @@
                             card nil))}]})
 
 (defcard "Tomorrow's Headline"
-  (let [ability
-        {:interactive (req true)
-         :msg "give the Runner 1 tag"
-         :async true
-         :effect (req (gain-tags state :corp eid 1))}]
-    {:on-score ability
-     :stolen ability}))
+  {:on-score (give-tags 1)
+   :stolen (give-tags 1)})
 
 (defcard "Transport Monopoly"
   {:on-score (agenda-counters 2)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -20,7 +20,7 @@
    [game.core.choose-one :refer [choose-one-helper]]
    [game.core.cost-fns :refer [play-cost]]
    [game.core.damage :refer [damage]]
-   [game.core.def-helpers :refer [corp-install-up-to-n-cards corp-recur corp-rez-toast defcard gain-credits-ability
+   [game.core.def-helpers :refer [corp-install-up-to-n-cards corp-recur corp-rez-toast defcard gain-credits-ability give-tags
                                   reorder-choice spend-credits take-credits trash-on-empty get-x-fn with-revealed-hand]]
    [game.core.drawing :refer [draw first-time-draw-bonus max-draw
                               remaining-draws]]
@@ -405,10 +405,7 @@
                 :waiting-prompt true
                 :prompt (msg "Pay 4 [Credits] to use " (:title card) " ability?")
                 :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}
-                :yes-ability {:async true
-                              :cost [(->c :credit 4)]
-                              :msg "give the runner 2 tags"
-                              :effect (req (gain-tags state :corp eid 2))}}}})
+                :yes-ability (assoc (give-tags 2) :cost [(->c :credit 4)])}}})
 
 (defcard "Bio-Ethics Association"
   (let [ability {:req (req unprotected)
@@ -2530,11 +2527,7 @@
 
 (defcard "Public Access Plaza"
   (assoc (creds-on-round-start 1)
-         :on-trash {:async true
-                    :req (req (and (= :runner side)
-                                   (threat-level 2 state)))
-                    :msg "give the Runner 1 tag"
-                    :effect (req (gain-tags state side eid 1))}))
+         :on-trash (assoc (give-tags 1) :req (req (and (= :runner side) (threat-level 2 state))))))
 
 (defcard "Public Health Portal"
   (let [ability {:once :per-turn
@@ -2964,9 +2957,7 @@
                 :effect (effect (continue-ability
                                   {:trace {:base 3
                                            :label "Trace 3 - Give the Runner 1 tag"
-                                           :successful {:msg "give the Runner 1 tag"
-                                                        :async true
-                                                        :effect (effect (gain-tags :runner eid 1))}}}
+                                           :successful (give-tags 1)}}
                                   card nil))}]})
 
 (defcard "Snare!"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3556,10 +3556,7 @@
              :effect (effect (gain-tags eid 1))}]})
 
 (defcard "Ping"
-  {:on-rez {:req (req (and run this-server))
-            :msg "give the Runner 1 tag"
-            :async true
-            :effect (effect (gain-tags :corp eid 1))}
+  {:on-rez (assoc (give-tags 1) :req (req (and run this-server)))
    :subroutines [end-the-run]})
 
 (defcard "Piranhas"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -17,7 +17,7 @@
    [game.core.costs :refer [total-available-credits]]
    [game.core.damage :refer [damage]]
    [game.core.def-helpers :refer [combine-abilities corp-recur defcard
-                                  do-brain-damage do-net-damage offer-jack-out
+                                  do-brain-damage do-net-damage give-tags offer-jack-out
                                   reorder-choice get-x-fn with-revealed-hand]]
    [game.core.drawing :refer [draw maybe-draw draw-up-to]]
    [game.core.effects :refer [any-effects get-effects is-disabled? is-disabled-reg? register-lingering-effect unregister-effects-for-card unregister-effect-by-uuid unregister-static-abilities update-disabled-cards]]
@@ -195,14 +195,6 @@
                                   (str "uses " (:title card) " to end the run"))
                       (end-run state :corp eid card))
                   (continue-ability state side ability card nil)))})
-
-(defn give-tags
-  "Basic give runner n tags subroutine."
-  [n]
-  {:label (str "Give the Runner " (quantify n "tag"))
-   :msg (str "give the Runner " (quantify n "tag"))
-   :async true
-   :effect (effect (gain-tags :corp eid n))})
 
 (def gain-power-counter
   "Places 1 power counter on a card."

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -17,7 +17,7 @@
    [game.core.cost-fns :refer [play-cost trash-cost]]
    [game.core.costs :refer [total-available-credits]]
    [game.core.damage :refer [damage]]
-   [game.core.def-helpers :refer [corp-install-up-to-n-cards corp-recur defcard do-meat-damage draw-abi drain-credits gain-credits-ability do-brain-damage reorder-choice something-can-be-advanced? get-x-fn with-revealed-hand tutor-abi]]
+   [game.core.def-helpers :refer [corp-install-up-to-n-cards corp-recur defcard do-meat-damage draw-abi drain-credits gain-credits-ability give-tags do-brain-damage reorder-choice something-can-be-advanced? get-x-fn with-revealed-hand tutor-abi]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid make-result]]
@@ -394,11 +394,7 @@
                            (effect-completed state side eid))))))}}))
 
 (defcard "Big Brother"
-  {:on-play
-   {:req (req tagged)
-    :msg "give the Runner 2 tags"
-    :async true
-    :effect (effect (gain-tags :corp eid 2))}})
+  {:on-play (assoc (give-tags 2) :req (req tagged))})
 
 (defcard "Big Deal"
   {:on-play
@@ -426,9 +422,7 @@
   {:on-play (choose-one-helper
               {:req (req tagged)}
               [{:option "Give the runner 1 tag"
-                :ability {:msg "give the Runner 1 tag"
-                          :effect (req (gain-tags state side eid 1))
-                          :async true}}
+                :ability (give-tags 1)}
                {:option "Remove any number of tags"
                 :ability {:req (req tagged)
                           :prompt "Remove how many tags?"
@@ -831,11 +825,7 @@
                              (continue-ability state side trash-from-hq card nil)))}}))
 
 (defcard "Distributed Tracing"
-  {:on-play
-   {:req (req (last-turn? state :runner :stole-agenda))
-    :msg "give the runner a tag"
-    :async true
-    :effect (req (gain-tags state :corp eid 1))}})
+  {:on-play (assoc (give-tags 1) :req (req (last-turn? state :runner :stole-agenda)))})
 
 (defcard "Diversified Portfolio"
   (letfn [(number-of-non-empty-remotes [state]
@@ -892,9 +882,7 @@
              :condition :hosted
              :trace {:base 3
                      :req (req (same-card? current-ice (:host card)))
-                     :successful {:msg "give the Runner 1 tag"
-                                  :async true
-                                  :effect (effect (gain-tags :runner eid 1))}}}]})
+                     :successful (give-tags 1)}}]})
 
 (defcard "Economic Warfare"
   {:on-play
@@ -1313,10 +1301,7 @@
    {:trace {:base 4
             :req (req (last-turn? state :runner :made-run))
             :label "Give the Runner 4 tags"
-            :successful
-            {:async true
-             :msg "give the Runner 4 tags"
-             :effect (effect (gain-tags eid 4))}}}})
+            :successful (give-tags 4)}}})
 
 (defcard "Hasty Relocation"
   (letfn [(hr-final [chosen original]
@@ -1704,9 +1689,7 @@
              :interactive (req true)
              :trace {:req (req (first-event? state side :successful-run))
                      :base 2
-                     :successful {:msg "give the Runner 1 tag"
-                                  :async true
-                                  :effect (effect (gain-tags eid 1))}}}]})
+                     :successful (give-tags 1)}}]})
 
 (defcard "Market Forces"
   {:on-play (assoc (drain-credits :corp :runner (req (* 3 (count-tags state))))
@@ -2712,10 +2695,7 @@
     {:base 3
      :req (req (last-turn? state :runner :successful-run))
      :label "Trace 3 - Give the Runner 1 tag"
-     :successful
-     {:msg "give the Runner 1 tag"
-      :async true
-      :effect (effect (gain-tags :corp eid 1))}}}})
+     :successful (give-tags 1)}}})
 
 (defcard "Seamless Launch"
   {:on-play

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -15,7 +15,7 @@
    [game.core.cost-fns :refer [install-cost rez-cost]]
    [game.core.costs :refer [total-available-credits]]
    [game.core.damage :refer [damage]]
-   [game.core.def-helpers :refer [corp-rez-toast defcard offer-jack-out
+   [game.core.def-helpers :refer [corp-rez-toast defcard give-tags offer-jack-out
                                   reorder-choice take-credits get-x-fn]]
    [game.core.drawing :refer [draw]]
    [game.core.effects :refer [register-lingering-effect]]
@@ -286,9 +286,7 @@
              :interactive (req true)
              :trace {:base 5
                      :req (req this-server)
-                     :successful {:msg "give the Runner 1 tag"
-                                  :async true
-                                  :effect (effect (gain-tags :corp eid 1))}
+                     :successful (give-tags 1)
                      :unsuccessful
                      {:async true
                       :msg "trash itself"
@@ -718,9 +716,7 @@
    :on-access {:interactive (req true)
                :trace {:req (req (not (in-discard? card)))
                        :base 3
-                       :successful {:msg "give the Runner 2 tags"
-                                    :async true
-                                    :effect (effect (gain-tags :corp eid 2))}}}})
+                       :successful (give-tags 2)}}})
 
 (defcard "Fractal Threat Matrix"
   {:events [{:event :subroutines-broken
@@ -1546,10 +1542,7 @@
                  (effect
                    (continue-ability
                      (let [n target]
-                       {:async true
-                        :cost [(->c :credit n)]
-                        :msg (str "give the Runner " (quantify n "tag"))
-                        :effect (effect (gain-tags :corp eid n))})
+                       (assoc (give-tags n) :cost [(->c :credit n)]))
                      card nil))}]
     {:on-trash {:silent (req true)
                 :req (req (= :runner side))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -187,7 +187,7 @@
    (resolve-ability state side eid (draw-abi n args) card nil)))
 
 (defn give-tags
-  "Basic give runner n tags subroutine."
+  "Basic give runner n tags ability."
   [n]
   {:label (str "Give the Runner " (quantify n "tag"))
    :msg (str "give the Runner " (quantify n "tag"))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -186,6 +186,15 @@
   ([state side eid card n args]
    (resolve-ability state side eid (draw-abi n args) card nil)))
 
+(defn give-tags
+  "Basic give runner n tags subroutine."
+  [n]
+  {:label (str "Give the Runner " (quantify n "tag"))
+   :msg (str "give the Runner " (quantify n "tag"))
+   :interactive (req true)
+   :async true
+   :effect (effect (gain-tags :corp eid n))})
+
 (defn run-server-ability
   "Runs a target server, if possible"
   [server]


### PR DESCRIPTION
I moved the `give-tags` ability from `ice.clj` into `def_helpers.clj`, and made all the non-ice card files use it.

This change should be invisible I think, I just got sick of writing the same code like 50 different times.