### PR TITLE
improve error logging

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -9,6 +9,7 @@
    [game.core.diffs :as diffs]
    [game.core.say :refer [make-system-message]]
    [game.core.set-up :refer [init-game]]
+   [game.core.finding :refer [find-latest]]
    [game.main :as main]
    [jinteki.preconstructed :as preconstructed]
    [jinteki.utils :refer [side-from-str]]
@@ -294,11 +295,13 @@
                                  (map :text)
                                  (take-last 5)
                                  (str/join "\n\t"))
-                            "unable to fetch log from state")]
+                            "unable to fetch log from state")
+                card? (when (:card args) (:printed-title (find-latest state (:card args))))]
             (println (str "Caught exception"
                           "\nException Data: " (or (ex-data e) (.getMessage e))
                           "\nStacktrace: " (with-out-str (stacktrace/print-stack-trace e 100))
                           "\nCommand: " command " - " args
+                          (when card? (str "\nRelevant Card: " card?))
                           "\nLast messages: " last-logs))))))))
 
 (defmethod ws/-msg-handler :game/resync


### PR DESCRIPTION
This makes it so that when an error occurs, our log file will list:
* the last 5 messages not typed by a user, if possible
* The action being attempted, and any args to that action

as an example:
![improve-logging](https://github.com/user-attachments/assets/818d4f65-e713-48cf-9877-8f743e2decdb)

This should make it way easier to look at an error in the log and try and track down what caused it, in cases where the stacktrace is not helpful

~~maybe I should be checking if the args have a cid and trying to track down that card too~~
See below

![relevant-card](https://github.com/user-attachments/assets/44328f13-5abf-442b-a132-817e52303c60)
