### PR TITLE
Proprionegation functions correctly

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1895,7 +1895,7 @@
                 ;; note that redirection cannot occur during forced encounters, or when not in a run
                 ;; ie: ganked, konjin, etc. This is a good enough stopgap for that for now
                 :change-in-game-state {:req (req (and (->> @state :run :phase (not= :success))
-                                                      (= (count (:encounters @state)) 1)))}
+                                                      (<= (count (:encounters @state)) 1)))}
                 :cost [(->c :agenda 1)]
                 :label "Redirect runner to archives"
                 :msg "make the Runner continue the run on Archives"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1892,10 +1892,7 @@
               :async true
               :effect (effect (add-counter eid card :agenda 1))}
    :abilities [{:req (req (:run @state))
-                ;; note that redirection cannot occur during forced encounters, or when not in a run
-                ;; ie: ganked, konjin, etc. This is a good enough stopgap for that for now
-                :change-in-game-state {:req (req (and (->> @state :run :phase (not= :success))
-                                                      (<= (count (:encounters @state)) 1)))}
+                :change-in-game-state {:req (req (not (:forced-encounter state)))}
                 :cost [(->c :agenda 1)]
                 :label "Redirect runner to archives"
                 :msg "make the Runner continue the run on Archives"

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -459,6 +459,7 @@
    :decklists
    :encounters
    :end-turn
+   :forced-encounter
    :gameid
    :last-revealed
    :log

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -395,7 +395,12 @@
    (let [old-state (get-in @state [:run :phase])]
      (when new-state
        (set-phase state new-state))
+     (swap! state update :forced-encounter (fnil inc 0))
      (wait-for (encounter-ice state side (make-eid state eid) ice)
+               (swap! state (fn [{:keys [forced-encounter] :as s}]
+                              (if (and forced-encounter (> forced-encounter 1))
+                                (update s :forced-encounter dec)
+                                (dissoc s :forced-encounter))))
                ;; reset the state if needed
                (clear-run-prompts state)
                (if (and (not (:run @state))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1718,6 +1718,7 @@
         #(send-command "continue")])
 
      (when (and @run
+                (not (:forced-encounter @game-state))
                 (not= "success" phase))
        [cond-button
         (tr [:game_jack-out "Jack Out"])

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -7517,7 +7517,6 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Transfer of Wealth")
     (card-ability state :corp (get-scored state :corp 0) 0)
-    (run-continue state)
     (is (changed? [(:credit (get-corp)) 0
                    (:credit (get-runner)) 0
                    (count-tags state) 0


### PR DESCRIPTION
Proprionegation will function correctly during forced encounters, will correctly end encounters on redirect, and should work nicely during every relevant phase.

Closes #8210

Because it was very adjacent, I also made it so you can't jack out during forced encounters.

Closes #8221