### PR TITLE
Synapse vs hannah

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -155,6 +155,7 @@
              :optional {:prompt "Remove 1 power counter to draw 2 cards?"
                         :waiting-prompt true
                         :req (req (and (= :runner (:side context))
+                                       (pos? (:amount context))
                                        (pos? (get-counters card :power))))
                         :yes-ability {:cost [(->c :power 1)]
                                       :msg "draw 2 cards"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -2482,7 +2482,9 @@
 
 (defcard "Synapse Global: Faster than Thought"
   {:events [{:event :runner-lose-tag
-             :req (req (first-event? state side :runner-lose-tag))
+             :req (req (letfn [(valid-ctx? [[ctx]] (pos? (:amount ctx)))]
+                         (and (valid-ctx? targets)
+                              (first-event? state side :runner-lose-tag valid-ctx?))))
              :prompt "Reveal and install a card from HQ?"
              :change-in-game-state {:req (req (seq (:hand corp))) :silent true}
              :choices {:req (req (and (corp? target)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -4013,8 +4013,8 @@
                                                                                                 " to " (decapitalize target))))
                                :else (effect-completed state side eid)))}
    :events [{:event :runner-lose-tag
-             :req (req
-                    (= :runner (:side context)))
+             :req (req (and (= :runner (:side context))
+                            (pos? (:amount context))))
              :msg "gain 1 [Credits]"
              :async true
              :interactive (req true)

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -73,11 +73,12 @@
   ([state side eid n {:keys [suppress-checkpoint] :as args}]
    (if (= n :all)
      (lose-tags state side eid (get-in @state [:runner :tag :base]))
-     (do (swap! state update-in [:stats :runner :lose :tag] (fnil + 0) n)
-         (deduct state :runner [:tag {:base n}])
-         (update-tag-status state)
-         (queue-event state :runner-lose-tag {:amount n
-                                              :side side})
-         (if suppress-checkpoint
-           (effect-completed state nil eid)
-           (checkpoint state eid))))))
+     (do (let [n (min n (get-in @state [:runner :tag :base]))]
+           (swap! state update-in [:stats :runner :lose :tag] (fnil + 0) n)
+           (deduct state :runner [:tag {:base n}])
+           (update-tag-status state)
+           (queue-event state :runner-lose-tag {:amount n
+                                                :side side})
+           (if suppress-checkpoint
+             (effect-completed state nil eid)
+             (checkpoint state eid)))))))

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -73,12 +73,12 @@
   ([state side eid n {:keys [suppress-checkpoint] :as args}]
    (if (= n :all)
      (lose-tags state side eid (get-in @state [:runner :tag :base]))
-     (do (let [n (min n (get-in @state [:runner :tag :base]))]
-           (swap! state update-in [:stats :runner :lose :tag] (fnil + 0) n)
-           (deduct state :runner [:tag {:base n}])
-           (update-tag-status state)
-           (queue-event state :runner-lose-tag {:amount n
-                                                :side side})
-           (if suppress-checkpoint
-             (effect-completed state nil eid)
-             (checkpoint state eid)))))))
+     (let [n (min n (get-in @state [:runner :tag :base]))]
+       (swap! state update-in [:stats :runner :lose :tag] (fnil + 0) n)
+       (deduct state :runner [:tag {:base n}])
+       (update-tag-status state)
+       (queue-event state :runner-lose-tag {:amount n
+                                            :side side})
+       (if suppress-checkpoint
+         (effect-completed state nil eid)
+         (checkpoint state eid))))))

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -5258,6 +5258,16 @@
     (click-prompt state :runner "No")
     (is (no-prompt? state :runner) "Panopticon got cancelled, no prompt")))
 
+(deftest synapse-vs-remove-no-tags
+  (do-game
+    (new-game {:corp {:id "Synapse Global: Faster than Thought"
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Hannah \"Wheels\" Pilintra"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Hannah \"Wheels\" Pilintra")
+    (card-ability state :runner (get-resource state 0) 1)
+    (is (no-prompt? state :corp) "No install prompt, because 0 tags were removed")))
+
 (deftest sync-everything-everywhere
   ;; SYNC: Everything, Everywhere
   (do-game


### PR DESCRIPTION
Adjusts our tag loss event to constrain the tags lost to the number of tags there are to lose.

Additionally, adjusts amanuensis, valentina, and synapse to check that there is actually a positive number of tags removed.

Closes #8245