### PR TITLE
Installs during access are not candidates

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -2089,6 +2089,7 @@
                :async true
                :prompt "Install a non-agenda from HQ?"
                :change-in-game-state {:silent true :req (req (seq (:hand corp)))}
+               :waiting-prompt true
                :choices {:card (every-pred corp? in-hand? (complement agenda?) (complement operation?))}
                :effect (req (corp-install state side eid target nil {:msg-keys {:install-source card}}))}
               score-ev]}))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -232,6 +232,8 @@
             (queue-event state :corp-install {:card (get-card state moved-card)
                                               :install-state install-state})
             (update-disabled-cards state)
+            (when (:breach @state)
+              (swap! state update-in [:breach :installed] (fnil conj #{}) (:cid moved-card)))
             (case install-state
               ;; Ignore all costs
               :rezzed-no-cost

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -4703,6 +4703,23 @@
     (click-prompts state :corp "PAD Campaign" "New remote")
     (is (= "PAD Campaign" (:title (get-content state :remote1 0))) "installed other in new remote")))
 
+(deftest poetri-luxury-brands-steal-no-forced-trap
+  (doseq [access-snare? ["Yes" "No"]]
+    (do-game
+      (new-game {:corp {:id "Poétrï Luxury Brands: All the Rage"
+                        :hand ["Tucana" "Hostile Takeover" "Snare!"]}})
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (play-from-hand state :corp "Tucana" "Server 1")
+      (take-credits state :corp)
+      (run-empty-server state :remote1)
+      (click-prompts state :runner "Tucana" "No action" "Steal")
+      (click-prompts state :corp "Snare!" "Server 1")
+      (click-prompt state :runner access-snare?)
+      (case access-snare?
+        "Yes" (click-prompt state :corp "No")
+        "No" (do (is (no-prompt? state :corp))
+                 (is (no-prompt? state :runner)))))))
+
 (deftest pravdivost-consulting-fake-prompt
   ;; Pravdivost Consulting: Political Solutions
   (do-game

--- a/test/clj/game/core/access_test.clj
+++ b/test/clj/game/core/access_test.clj
@@ -132,7 +132,8 @@
           (card-subroutine state :corp (refresh ansel) 1)
           (click-card state :corp "Ganked!")
           (click-prompt state :corp "R&D")
-          (encounter-continue state))
+          (encounter-continue state)
+          (click-prompt state :runner "Yes"))
         (click-prompt state :corp "No")
         (click-prompt state :runner "No action")))))
 
@@ -273,7 +274,8 @@
          (card-subroutine state :corp (refresh ansel) 1)
          (click-card state :corp "Ganked!")
          (click-prompt state :corp "HQ")
-         (encounter-continue state))
+         (encounter-continue state)
+         (click-prompt state :runner "Yes"))
        (click-prompt state :corp "No")
        (click-prompt state :runner "No action")))))
 
@@ -544,7 +546,8 @@
           (card-subroutine state :corp (refresh ansel) 1)
           (click-card state :corp "Ganked!")
           (click-prompt state :corp "Archives")
-          (encounter-continue state))
+          (encounter-continue state)
+          (click-prompt state :runner "Yes"))
         (click-prompt state :corp "No")
         (click-prompt state :runner "No action")))))
 
@@ -580,7 +583,8 @@
           (card-subroutine state :corp (refresh ansel) 1)
           (click-card state :corp "Ganked!")
           (click-prompt state :corp "Server 1")
-          (encounter-continue state))
+          (encounter-continue state)
+          (click-prompt state :runner "Yes"))
         (click-prompt state :corp "No")
         (click-prompt state :runner "No action")))))
 


### PR DESCRIPTION
Closes #8181

I split `access-card` into `access-card` and `access-card-continue`, and added logic for if the card was installed during the active breach (ie for loki ansel, or poetri nonsense).

Then I made it so that if you access a card that was installed during the current breach, the game will ask you for consent.