### PR TITLE
Fix localStorage saving for false boolean settings

### DIFF
--- a/src/cljs/nr/local_storage.cljs
+++ b/src/cljs/nr/local_storage.cljs
@@ -76,8 +76,8 @@
            ;; Remove database-sourced settings from localStorage
            (.removeItem js/localStorage storage-key)
            ;; Save local-only settings to localStorage (if provided)
-           (when-let [value (get settings-map key)]
-             (save! storage-key value)))))
+           (when (contains? settings-map key)
+             (save! storage-key (get settings-map key))))))
      (catch :default e
        (js/console.warn "localStorage not available for settings update:" e)))))
 


### PR DESCRIPTION
Boolean settings with false values were not being saved to localStorage because when-let treats false as falsy. This prevented users from disabling boolean settings that default to true (like sounds-stacked).

Changed to use contains? to check for key existence, allowing both true and false boolean values to be properly saved.