### PR TITLE
fix spectate by side

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -250,9 +250,9 @@
         runner-specs (get-in @app-state [:current-game :runner-spectators])
         me (:user @app-state)]
     (cond
-      (some #(= (:uid %) (:uid me)) corp-specs)
+      (some #(= (-> % :user :username) (:username me)) corp-specs)
       :corp
-      (some #(= (:uid %) (:uid me)) runner-specs)
+      (some #(= (-> % :user :username) (:username me)) runner-specs)
       :runner
       :else
       nil)))


### PR DESCRIPTION
Turns out uid is stipped, so this was only checking if at least one user chose to spectate by side, then applying that to everyone. Whoopps!

Closes #7914