### PR TITLE
Timbre stratify logs

### DIFF
--- a/dev/src/clj/web/dev.clj
+++ b/dev/src/clj/web/dev.clj
@@ -4,9 +4,11 @@
    [potemkin :refer [import-vars]]
    [web.core]
    [web.system :as system]
+   [web.logs :refer [timbre-init!]]
    [tasks.nrdb :as nrdb]))
 
 (ig-repl/set-prep! (fn [] (system/server-config)))
+(timbre-init!)
 
 (import-vars
   [integrant.repl

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -22,13 +22,14 @@
     [game.core.prompts :refer [resolve-select first-prompt-by-eid first-selection-by-eid]]
     [game.core.props :refer [add-counter add-prop set-prop]]
     [game.core.runs :refer [continue get-runnable-zones]]
-    [game.core.say :refer [play-sfx system-msg implementation-msg]]
+    [game.core.say :refer [play-sfx system-msg implementation-msg n-last-logs]]
     [game.core.servers :refer [name-zone zones->sorted-names]]
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards to-keyword]]))
+    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards to-keyword]]
+    [taoensso.timbre :as timbre]))
 
 (defn- update-click-state
   "Update :click-states to hold latest 4 moments before performing actions."
@@ -206,9 +207,9 @@
 
 (defn- prompt-error
   [context prompt prompt-args]
-  (.println *err* (with-out-str (print-stack-trace (Exception. (str "Error " context)))))
-  (.println *err* (str "Prompt: " prompt))
-  (.println *err* (str "Prompt args: " prompt-args)))
+  (timbre/error (str (with-out-str (print-stack-trace (Exception. (str "Error " context))))
+                     "\nPrompt: " prompt
+                     "\nPrompt args: " prompt-args)))
 
 (defn- maybe-pay
   [state side eid card choices choice]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -207,9 +207,9 @@
 
 (defn- prompt-error
   [context prompt prompt-args]
-  (timbre/error (str (with-out-str (print-stack-trace (Exception. (str "Error " context))))
-                     "\nPrompt: " prompt
-                     "\nPrompt args: " prompt-args)))
+  (timbre/error (Exception. (str "Error " context
+                                 "\nPrompt: " prompt
+                                 "\nPrompt args: " prompt-args))))
 
 (defn- maybe-pay
   [state side eid card choices choice]

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -7,11 +7,12 @@
     [game.core.prevention :refer [resolve-damage-prevention]]
     [game.core.prompt-state :refer [add-to-prompt-queue remove-from-prompt-queue]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
-    [game.core.say :refer [system-msg]]
+    [game.core.say :refer [system-msg n-last-logs]]
     [game.core.winning :refer [flatline]]
     [game.macros :refer [wait-for]]
     [game.utils :refer [dissoc-in enumerate-str side-str]]
-    [jinteki.utils :refer [str->int]]))
+    [jinteki.utils :refer [str->int]]
+    [taoensso.timbre :as timbre]))
 
 (defn damage-name [damage-type]
   (case damage-type
@@ -64,7 +65,7 @@
   (wait-for (trigger-event-simult state side :pre-resolve-damage nil dmg-type side n)
             (if (not (pos? n))
               (do ;; shouldn't be possible, should be handled before getting here
-                (println "attempted to resolve 0 damage")
+                (timbre/error (str "attempted to resolve 0 damage: \n" (n-last-logs state 5) "\n"))
                 (effect-completed state side eid))
               (let [hand (get-in @state [:runner :hand])
                     chosen-cards (seq (get-chosen-damage state))

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -14,14 +14,15 @@
     [game.core.payment :refer [build-spend-msg can-pay? handler]]
     [game.core.prompt-state :refer [add-to-prompt-queue]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-select show-wait-prompt]]
-    [game.core.say :refer [system-msg system-say]]
+    [game.core.say :refer [system-msg system-say n-last-logs]]
     [game.core.update :refer [update!]]
     [game.core.winning :refer [check-win-by-agenda]]
     [game.macros :refer [continue-ability req wait-for]]
     [game.utils :refer [dissoc-in distinct-by enumerate-str in-coll? remove-once same-card? server-cards side-str to-keyword]]
     [jinteki.utils :refer [other-side]]
     [game.core.memory :refer [update-mu]]
-    [game.core.to-string :refer [card-str]]))
+    [game.core.to-string :refer [card-str]]
+    [taoensso.timbre :as timbre]))
 
 ;; resolve-ability docs
 
@@ -283,10 +284,12 @@
         :else (check-ability state side ability card targets)))
     ;; Something has gone terribly wrong, error out
     :else
-    (.println *err* (with-out-str
-                      (print-stack-trace
-                        (Exception. (str "Ability is nil????" ability card targets))
-                        2500)))))
+    (timbre/error (str (with-out-str
+                         (print-stack-trace
+                           (Exception. (str "Ability is nil????" ability card targets))
+                           2500))
+                       "\n"
+                       (n-last-logs state 5)))))
 
 ;;; Checking functions for resolve-ability
 (defn- check-choices

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -284,12 +284,8 @@
         :else (check-ability state side ability card targets)))
     ;; Something has gone terribly wrong, error out
     :else
-    (timbre/error (str (with-out-str
-                         (print-stack-trace
-                           (Exception. (str "Ability is nil????" ability card targets))
-                           2500))
-                       "\n"
-                       (n-last-logs state 5)))))
+    (timbre/error (Exception. (str "Ability is nil????" ability card targets))
+                  (n-last-logs state 5))))
 
 ;;; Checking functions for resolve-ability
 (defn- check-choices

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -347,7 +347,6 @@
      (effect-completed state side eid)
      (wait-for (resolve-trash-prevention state side cards args)
                (let [trashlist (:remaining async-result)
-                     ;;_ (println "async result: " trashlist)
                      _ (update-current-ice-to-trash state (map :card trashlist))]
                  (wait-for
                    (trigger-event-sync state side :pre-trash-interrupt (map :card trashlist))

--- a/src/clj/game/core/props.clj
+++ b/src/clj/game/core/props.clj
@@ -31,7 +31,6 @@
   "Adds n counters of the specified type to a card"
   ([state side eid card prop-type n] (add-counter state side eid card prop-type n nil))
   ([state side eid card prop-type n {:keys [placed suppress-checkpoint] :as args}]
-   ;;(println "N: " n ", card: " (:title card), ", side: " side ", prop-type: " prop-type ", args: " args)
    (if-let [card (get-card state card)]
      (if (= prop-type :advancement)
        ;; if advancement counter use existing system

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -527,21 +527,14 @@
 (defmethod start-next-phase :default
   [state _ _]
   (when-not (= :success (:phase (:run @state)))
-    (timbre/error (str "start-next-phase :default: \n"
-                       (with-out-str
-                         (print-stack-trace
-                           (Exception. "no phase found and not accessing cards")
-                           2500))
-                       "\n" (n-last-logs state 5) "\n"))))
+    (timbre/error (Exception. "no phase found and not accessing cards")
+                  (str "start-next-phase :default:\n" (n-last-logs state 5) "\n"))))
 
 (defmethod continue :default
   [state _ _]
-  (timbre/error (str "continue :default: \n"
-                     (with-out-str (print-stack-trace
-                                     (Exception.
-                                       (str "Continue clicked at the wrong time, run phase: " (:phase (:run @state))))
-                                     2500))
-                     "\n" (n-last-logs state 5) "\n")))
+  (timbre/error (Exception.
+                  (str "Continue clicked at the wrong time, run phase: " (:phase (:run @state))))
+                (str "continue :default:\n" (n-last-logs state 5) "\n")))
 
 (defn redirect-run
   ([state side server] (redirect-run state side server nil))

--- a/src/clj/game/core/say.clj
+++ b/src/clj/game/core/say.clj
@@ -107,3 +107,16 @@
                        (update :sfx #(take 3 %))
                        (update :sfx-current-id inc))
                    state))))
+
+(defn n-last-logs
+  "Gets the n last log messages not sent by a user (ie game logs only)"
+  [state n]
+  (if @state
+    ;; this should filter out user-typed messages, so we don't accidentally
+    ;; spy on private conversations
+    (->> @state :log
+         (filter #(= (:user %) "__system__"))
+         (map :text)
+         (take-last n)
+         (str/join "\n\t"))
+    "unable to fetch log from state"))

--- a/src/clj/game/core/turmoil.clj
+++ b/src/clj/game/core/turmoil.clj
@@ -10,7 +10,8 @@
    [game.core.say :refer [system-msg]]
    [game.core.set-up :refer [build-card]]
    [game.utils :refer [same-card? server-cards server-card]]
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   [taoensso.timbre :as timbre]))
 
 ;; store all this in memory once so we don't need to recalculate it a trillion times
 ;; everything should be a vec, so rand-nth will be O[1] instead of O[n/2]
@@ -33,7 +34,7 @@
 
 (defn- set-cards! []
   (when-not @has-been-set?
-    (println "assigning server cards for turmoil")
+    (timbre/info "assigning server cards for turmoil")
     (reset! agenda-by-points
             (->> (server-cards)
                  (filterv agenda?)

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -9,7 +9,8 @@
    [web.mongodb :refer [->object-id]]
    [web.user :refer [active-user? visible-to-user]]
    [web.utils :refer [response mongo-time-to-utc-string]]
-   [web.ws :as ws]))
+   [web.ws :as ws]
+   [taoensso.timbre :as timbre]))
 
 (def msg-collection "messages")
 (def log-collection "moderator_actions")
@@ -103,7 +104,7 @@
     timestamp :timestamp}]
   (when-let [id (:_id msg)]
     (when (or isadmin ismoderator)
-      (println username "deleted message" msg "\n")
+      (timbre/info {:type :mod-action} (str username "deleted message" msg "\n"))
       (mc/remove-by-id db msg-collection (->object-id id))
       (mc/insert db log-collection
                  {:moderator username
@@ -123,7 +124,7 @@
     timestamp :timestamp}]
   (when (and sender
              (or isadmin ismoderator))
-    (println username "deleted all messages from user" sender "\n")
+    (timbre/info {:type :mod-action} (str username "deleted all messages from user" sender "\n"))
     (mc/remove db msg-collection {:username sender})
     (mc/insert db log-collection
                {:moderator username

--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -1,7 +1,9 @@
 (ns web.core
   (:require
    [monger.collection :as mc]
-   [web.system :refer [start stop]])
+   [web.system :refer [start stop]]
+   [taoensso.timbre :as timbre]
+   [web.logs :refer [timbre-init!]])
   (:gen-class :main true))
 
 (defn -main [& _args]
@@ -11,7 +13,8 @@
         db (-> system :mongodb/connection :db)
         config (mc/find-one-as-map db "config" nil)
         frontend-version (:version config)]
-    (println "Jinteki server running in" server-mode "mode on port" port)
-    (println "Frontend version" frontend-version)
+    (timbre-init!)
+    (timbre/info (str "Jinteki server running in" server-mode "mode on port" port))
+    (timbre/info (str "Frontend version" frontend-version))
 
     (.addShutdownHook (Runtime/getRuntime) (Thread. #(stop system)))))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -317,12 +317,12 @@
       (when (and lobby (lobby/in-lobby? uid lobby))
         (if-let [state (:state lobby)]
           (send-state-to-uid! uid :game/resync lobby (diffs/public-states state))
-          (println (str "resync request unknown state"
-                        "\nGameID:" gameid
-                        "\nGameID by ClientID:" gameid
-                        "\nClientID:" uid
-                        "\nPlayers:" (map #(select-keys % [:uid :side]) (:players lobby))
-                        "\nSpectators" (map #(select-keys % [:uid]) (:spectators lobby))))))
+          (timbre/error (str "resync request unknown state"
+                             "\nGameID:" gameid
+                             "\nGameID by ClientID:" gameid
+                             "\nClientID:" uid
+                             "\nPlayers:" (map #(select-keys % [:uid :side]) (:players lobby))
+                             "\nSpectators" (map #(select-keys % [:uid]) (:spectators lobby))))))
       (lobby/log-delay! timestamp id))))
 
 (defmethod ws/-msg-handler :game/watch

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -17,7 +17,8 @@
    [web.app-state :as app-state]
    [web.lobby :as lobby]
    [web.stats :as stats]
-   [web.ws :as ws]))
+   [web.ws :as ws]
+   [taoensso.timbre :as timbre]))
 
 (defn game-diff-json
   "Converts the appropriate diff to json"
@@ -297,12 +298,12 @@
                                  (str/join "\n\t"))
                             "unable to fetch log from state")
                 card? (when (:card args) (:printed-title (find-latest state (:card args))))]
-            (println (str "Caught exception"
-                          "\nException Data: " (or (ex-data e) (.getMessage e))
-                          "\nStacktrace: " (with-out-str (stacktrace/print-stack-trace e 100))
-                          "\nCommand: " command " - " args
-                          (when card? (str "\nRelevant Card: " card?))
-                          "\nLast messages: " last-logs))))))))
+            (timbre/error (str "Caught exception"
+                               "\nException Data: " (or (ex-data e) (.getMessage e))
+                               "\nStacktrace: " (with-out-str (stacktrace/print-stack-trace e 100))
+                               "\nCommand: " command " - " args
+                               (when card? (str "\nRelevant Card: " card?))
+                               "\nLast messages: " last-logs))))))))
 
 (defmethod ws/-msg-handler :game/resync
   game--resync

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -298,12 +298,10 @@
                                  (str/join "\n\t"))
                             "unable to fetch log from state")
                 card? (when (:card args) (:printed-title (find-latest state (:card args))))]
-            (timbre/error (str "Caught exception"
-                               "\nException Data: " (or (ex-data e) (.getMessage e))
-                               "\nStacktrace: " (with-out-str (stacktrace/print-stack-trace e 100))
-                               "\nCommand: " command " - " args
-                               (when card? (str "\nRelevant Card: " card?))
-                               "\nLast messages: " last-logs))))))))
+            (timbre/error e (str "Caught exception"
+                                 "\nCommand: " command " - " args
+                                 (when card? (str "\nRelevant Card: " card?))
+                                 "\nLast messages: " last-logs))))))))
 
 (defmethod ws/-msg-handler :game/resync
   game--resync

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -20,7 +20,8 @@
    [web.mongodb :as mongodb]
    [web.stats :as stats]
    [web.ws :as ws]
-   [taoensso.encore :as enc]))
+   [taoensso.encore :as enc]
+   [taoensso.timbre :as timbre]))
 
 (read-write/print-time-literals-clj!)
 
@@ -79,8 +80,8 @@
                 (swap! cleaned! + (count stale))
                 (swap! (:occupants pool) set/difference stale))))
           (if (pos? @cleaned!)
-            (println "cleaned up" @cleaned! "stale pool occupants!")
-            (println "all pools are tidy!"))))))
+            (timbre/info (str "cleaned up" @cleaned! "stale pool occupants!"))
+            (timbre/info "all pools are tidy!"))))))
 
 (defonce lobby-pool (cp/threadpool 1 {:name "lobbies-thread"}))
 (defmacro lobby-thread [& expr] `(cp/future lobby-pool ~@expr))

--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -3,19 +3,32 @@
    [taoensso.timbre :as timbre]
    [clojure.java.io :as io]))
 
-(defn appender
-  [file min-level print?]
+(def default-appender
   {:enabled? true
    :async? true
-   :min-level min-level
+   :min-level :info
+   :output-fn timbre/default-output-fn
+   :fn (fn [{:keys [level output_ context]}]
+         (when-not (or (= level :error) (= level :fatal) (= (:type context) :moderator))
+           (spit "logs/clojure.log" (str @output_ "\n") :append true)))})
+
+(def exceptions-appender
+  {:enabled? true
+   :async? true
+   :min-level :error
    :output-fn timbre/default-output-fn
    :fn (fn [{:keys [output_]}]
-         (when print? (println @output_))
-         (spit file (str @output_ "\n") :append true))})
+         (println @output_)
+         (spit "logs/exceptions.log" (str @output_ "\n") :append true))})
 
-(def log-appender (appender "logs/clojure.log" :info nil))
-(def exceptions-appender (appender "logs/exceptions.log" :error true))
-(def mod-action-appender (appender "logs/mod-actions.log" :info nil))
+(def mod-action-appender
+  {:enabled? true
+   :async? true
+   :min-level :info
+   :output-fn timbre/default-output-fn
+   :fn (fn [{:keys [output_ context]}]
+         (when (= (:type context) :moderator))
+         (spit "logs/clojure.log" (str @output_ "\n") :append true))})
 
 (defn timbre-init!
   []
@@ -25,6 +38,6 @@
   ;; maybe we can actually just have an indexed html that points to different log files?
   ;; that would actually be sick as hell
   (timbre/merge-config!
-    {:appenders {:default log-appender
-                 :exceptions exceptions-appender
+    {:appenders {:default default-appender
+                 :error exceptions-appender
                  :mod-action mod-action-appender}}))

--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -1,0 +1,30 @@
+(ns web.logs
+  (:require
+   [taoensso.timbre :as timbre]
+   [clojure.java.io :as io]))
+
+(defn appender
+  [file min-level print?]
+  {:enabled? true
+   :async? true
+   :min-level min-level
+   :output-fn timbre/default-output-fn
+   :fn (fn [{:keys [output_]}]
+         (when print? (println @output_))
+         (spit file (str @output_ "\n") :append true))})
+
+(def log-appender (appender "logs/clojure.log" :info nil))
+(def exceptions-appender (appender "logs/exceptions.log" :error true))
+(def mod-action-appender (appender "logs/mod-actions.log" :info nil))
+
+(defn timbre-init!
+  []
+  (io/make-parents "logs/clojure.log")
+  (println "initialized timbre")
+  ;; todo - back up the logs files or something like that
+  ;; maybe we can actually just have an indexed html that points to different log files?
+  ;; that would actually be sick as hell
+  (timbre/merge-config!
+    {:appenders {:default log-appender
+                 :exceptions exceptions-appender
+                 :mod-action mod-action-appender}}))

--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -28,7 +28,7 @@
    :output-fn timbre/default-output-fn
    :fn (fn [{:keys [output_ context]}]
          (when (= (:type context) :moderator))
-         (spit "logs/clojure.log" (str @output_ "\n") :append true))})
+         (spit "logs/mod-actions.log" (str @output_ "\n") :append true))})
 
 (defn timbre-init!
   []

--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -33,11 +33,11 @@
 (defn timbre-init!
   []
   (io/make-parents "logs/clojure.log")
-  (println "initialized timbre")
   ;; todo - back up the logs files or something like that
   ;; maybe we can actually just have an indexed html that points to different log files?
   ;; that would actually be sick as hell
   (timbre/merge-config!
     {:appenders {:default default-appender
+                 :println {:enabled? false}
                  :error exceptions-appender
                  :mod-action mod-action-appender}}))

--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -33,6 +33,9 @@
 (defn timbre-init!
   []
   (io/make-parents "logs/clojure.log")
+  ;; clojure.log and exceptions.log can be cleaned up between each run
+  (when-let [f (io/file "logs/clojure.log")] (when (.exists f) (.delete f)))
+  (when-let [f (io/file "logs/exceptions.log")] (when (.exists f) (.delete f)))
   ;; todo - back up the logs files or something like that
   ;; maybe we can actually just have an indexed html that points to different log files?
   ;; that would actually be sick as hell

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -114,11 +114,11 @@
   (doseq [player original-players]
     (if (:side player)
       (inc-game-stats db (get-in player [:user :_id]) (game-record-start player))
-      (timbre/error (str "NULL start player side in stats for gameid" gameid))))
+      (timbre/error (str "NULL start player side in stats for gameid " gameid))))
   (doseq [player ending-players]
     (if (:side player)
       (inc-game-stats db (get-in player [:user :_id]) (game-record-end state player))
-      (timbre/error (str "NULL end player side in stats for gameid" gameid)))))
+      (timbre/error (str "NULL end player side in stats for gameid " gameid)))))
 
 (defn push-stats-update
   "Gather updated deck and user stats and send via web socket to clients"

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -210,8 +210,7 @@
         ;;            (:winner @state))
         ;;   (angel-arena-stats/game-finished db game))
         (catch Exception e
-          (timbre/error (str "Caught exception saving game stats: " (.getMessage e))
-                         "\nStats: " (:stats @state)))))))
+          (timbre/error e (str "Caught exception saving game stats: " (:stats @state))))))))
 
 (defn history
   [{db :system/db
@@ -346,7 +345,7 @@
                  {$set {:replay-shared true}})
       (response 200 {:message "Shared"})
       (catch Exception e
-        (timbre/error (str "Caught exception sharing game: " (.getMessage e)))
+        (timbre/error e "Caught exception sharing game")
         (response 500 {:message "Server error"})))
     (response 401 {:message "Unauthorized"})))
 

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -26,7 +26,7 @@
               ajax-post-fn ajax-get-or-ws-handshake-fn private]} chsk-server
       conns_ (:conns_ private)]
   (defonce handshake-handler (fn [& args] (try (apply ajax-get-or-ws-handshake-fn args)
-                                               (catch Exception _ (println "Caught an error in the handshake handler")))))
+                                               (catch Exception _ (timbre/error "Caught an error in the handshake handler")))))
   (defonce post-handler ajax-post-fn)
   (defonce connected-sockets connected-uids)
   (defonce ch-chsk ch-recv)
@@ -74,7 +74,7 @@
   msg-handler--default
   ;; Handles any hecked messages from the client
   [{:keys [id ?data uid ?reply-fn]}]
-  (println "Unhandled WS msg" id uid (pr-str ?data))
+  (timbre/error (str "Unhandled WS msg" id uid (pr-str ?data)))
   (when ?reply-fn
     (?reply-fn {:msg "Unhandled event"})))
 
@@ -94,5 +94,4 @@
   (try
     (-msg-handler (assoc event :timestamp (inst/now)))
     (catch Exception e
-      (println "Caught an error in the message handler")
-      (println (.printStackTrace e)))))
+      (timbre/error e "Caught an error in the message handler"))))


### PR DESCRIPTION
* All (just about) of our logging now goes through timbre
* The routine stuff goes in clojure.log
* All exceptions go into exceptions.log, and also go to stdout (so you can actually debug stuff)
* All mod actions go to mod-actions.log
* These logs are not erased between restarts
* The run exceptions and other ones that didn't spit out relevant info now do

Additionally
* The exceptions and routine logs get cycled between each restart
* the mod actions one can probably just never get deleted, it's fine

Outside of this repo:
* Update how we run jinteki to accomodate this
* make the exceptions and routine logs available for inspection
* make the mod-actions log explicitly not available for inspection (except maybe with credentials? idk)

Closes #8285