### PR TITLE
Fix get-image-path to always return an array

### DIFF
--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -381,23 +381,28 @@
       (reset! scroll-top-atom h))))
 
 (defn get-image-path
-  "Image search priority: Resolution > Language > Art"
+  "Image search priority: Resolution > Language > Art. Always returns an array."
   ([images lang res art] (get-image-path images lang res art 0))
   ([images lang res art depth]
    (when (< depth 4)
-     (or (get-in images [lang res art])
-         ;; try to downgrade the res first
-         (and (not= res :default)
-              (get-image-path images lang :default art (inc depth)))
-         ;; try to downgrade the language second
-         (and (not= lang :en)
-              (get-image-path images :en res art (inc depth)))
-         ;; try to downgrade the art last
-         (and (not= art :stock)
-              (get-image-path images lang res :stock (inc depth)))
-         ;; fallback if on 0 depth only
-         (and (zero? depth)
-              "img/missing.png")))))
+     (let [result (or (get-in images [lang res art])
+                      ;; try to downgrade the res first
+                      (and (not= res :default)
+                           (get-image-path images lang :default art (inc depth)))
+                      ;; try to downgrade the language second
+                      (and (not= lang :en)
+                           (get-image-path images :en res art (inc depth)))
+                      ;; try to downgrade the art last
+                      (and (not= art :stock)
+                           (get-image-path images lang res :stock (inc depth)))
+                      ;; fallback if on 0 depth only
+                      (and (zero? depth)
+                           "img/missing.png"))]
+       (if (sequential? result)
+         result
+         (if result
+           [result]
+           nil))))))
 
 (defn image-or-face [card]
   (cond


### PR DESCRIPTION
Function previously returned either a string or array based on the images field value. This inconsistency caused issues in calling code that expected a uniform return type.

This should fix flip identity images in historical replays saved when images were strings, not an arrays.

The changes that made code expect an array and the database store an array were done in 29f91b0bb and befb48262, respectively.