### PR TITLE
zato works better

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -2016,7 +2016,6 @@
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
    :static-abilities [{:type :gain-encounter-ability
                        :req (req (and (protecting-same-server? card target)
-                                      (some #(:printed %) (:subroutines target))
                                       (not (:disabled target))))
                        :value (req {:async true
                                     :ability-name "ZATO City Grid"
@@ -2024,17 +2023,19 @@
                                     :optional
                                     {:waiting-prompt true
                                      :prompt "Trash ice to fire a (printed) subroutine?"
-                                     :yes-ability {:msg (msg "trash " (card-str state (:ice context)))
-                                                   :async true
+                                     :yes-ability {:async true
                                                    :effect (req (let [target-ice (:ice context)]
-                                                                  (wait-for (trash state side target-ice {:cause-card target-ice})
-                                                                            (continue-ability
-                                                                              state side
-                                                                              {:prompt "Choose a subroutine to resolve"
-                                                                               :choices (req (unbroken-subroutines-choice target-ice))
-                                                                               :msg (msg "resolves the subroutine (\"[Subroutine] "
-                                                                                         target "\") from " (:title target-ice))
-                                                                               :async true
-                                                                               :effect (req (let [sub (first (filter #(= target (make-label (:sub-effect %))) (:subroutines target-ice)))]
-                                                                                              (resolve-subroutine! state side eid target-ice (assoc sub :external-trigger true))))}
-                                                                              card nil))))}}})}]})
+                                                                  (continue-ability
+                                                                    state side
+                                                                    (if (seq (filter :printed (:subroutines target-ice)))
+                                                                      {:prompt "Choose a subroutine to resolve"
+                                                                       :choices (req (unbroken-subroutines-choice target-ice))
+                                                                       :cost [(->c :trash-can)]
+                                                                       :msg (msg "resolve (\"[Subroutine] "
+                                                                                 target "\")")
+                                                                       :async true
+                                                                       :effect (req (let [sub (first (filter #(= target (make-label (:sub-effect %))) (:subroutines target-ice)))]
+                                                                                      (resolve-subroutine! state side eid target-ice (assoc sub :external-trigger true))))}
+                                                                      {:cost [(->c :trash-can)]
+                                                                       :change-in-game-state {:req (req false)}})
+                                                                    card nil)))}}})}]})

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -228,8 +228,9 @@
                    (trigger-event-simult state side :subroutine-fired nil {:sub sub :ice ice})
                    (when (:run @state)
                      (swap! state update-in [:run :subroutines-fired] (fnil inc 0)))
+                   ;; note that the only way a sub should fire without the ice existing is through zato city grid (or maybe nanisivik?)
                    (wait-for
-                     (resolve-ability state side (make-eid state eid) (:sub-effect sub) (get-card state ice) nil)
+                     (resolve-ability state side (make-eid state eid) (:sub-effect sub) (or (get-card state ice) ice) nil)
                      (checkpoint state nil eid {:duration :subroutine-currently-resolving}))))))))
 
 (defn- resolve-next-unbroken-sub


### PR DESCRIPTION
ZATO is now formatted a bit nicer.

As per the ncigs change, you can trash a 0-sub ice to do nothing.

The `resolve-subroutine!` fn will use the old ice in the case that the ice no longer exists. This means that border control and similar ice will (ideally) use their historical position when firing zato, rather than the count of ice in archives, etc.

Also the name wont get lost.

Closes #8275