### PR TITLE
fix afterimage validation

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -416,17 +416,14 @@
                :interactive (req true)
                :optional
                {:req (req (and (has-subtype? (:ice context) "Sentry")
-                               (can-pay? state :runner eid card nil [(->c :credit 2)])
-                               (some #(has-subtype? % "Stealth")
-                                     (all-active state :runner))))
+                               (can-pay? state side (assoc eid :source-type :ability) card nil [(->c :credit 2 {:stealth :all-stealth})])))
                 :once :per-turn
                 :prompt (msg "Pay 2 [Credits] to bypass " (:title (:ice context)) "?")
-                :yes-ability
-                {:cost [(->c :credit 2 {:stealth :all-stealth})]
-                 :msg (msg "bypass " (:title (:ice context)))
-                 :effect (req (bypass-ice state))}}}]
+                :yes-ability {:cost [(->c :credit 2 {:stealth :all-stealth})]
+                              :msg (msg "bypass " (:title (:ice context)))
+                              :effect (req (bypass-ice state))}}}]
      :abilities [(break-sub 1 2 "Sentry")
-                 (strength-pump (->c :credit 1 {:stealth 1}) 2 :end-of-encounter)]}))
+                 (strength-pump (->c :credit 1 {:stealth :all-stealth}) 2 :end-of-encounter)]}))
 
 (defcard "Aghora"
   (swap-with-in-hand "Aghora"

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -392,7 +392,7 @@
       (core/gain state :runner :click 1)
       (run-on state "HQ")
       (rez state :corp (get-ice state :hq 0))
-      (run-continue state)
+      (run-continue state :encounter-ice)
       (click-prompt state :runner "Yes")
       (click-card state :runner (get-program state 1))
       (click-card state :runner (get-program state 2))


### PR DESCRIPTION
Turns out we were:
1) checking you could arbitarily pay 2c (not as an ability)
2) checking that a stealth card existed
so this fixes two annoying scenarios:
* Getting asked when you have <2 stealth creds available
* Not getting asked when you have 2 stealth creds available, but zero real creds

Closes #8305