### PR TITLE
Sisyphus uses passed ice

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -2191,6 +2191,7 @@
                :req (req (and (rezzed-gate-or-sentry context)
                               (first-event? state side :pass-ice
                                             #(rezzed-gate-or-sentry (first %)))))
+               :async true
                :effect (req (let [enc-ice (get-card state (:ice context))]
                               (continue-ability
                                 state side


### PR DESCRIPTION
Sisyphus pulls the ice from the ice-passed event rather than scrying the current ice through the run state. This means it will work properly with stuff like inversificator (maybe) as well.

Closes #8303