### PR TITLE
Track source card for rfg

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -532,8 +532,7 @@
       {:paid/msg (str "removes " (:title card) " from the game")
        :paid/type :remove-from-game
        :paid/value 1
-       :paid/product c
-       :paid/targets [card]})))
+       :paid/targets [c]})))
 
 ;; RfgProgram
 (defmethod value :rfg-program [cost] (:cost/amount cost))

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -357,7 +357,6 @@
                      cost-obj {:paid/type (:paid/type cur)
                                :paid/value (+ (:paid/value existing 0) (:paid/value cur 0))
                                :paid/x-value (+ (:paid/x-value existing 0) (:paid/x-value cur 0))
-                               :paid/product (:paid/product cur)
                                :paid/targets (seq (concat (:paid/targets existing) (:paid/targets cur)))}]
                  (assoc acc (:paid/type cur) cost-obj)))
              {}

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -135,10 +135,6 @@
   [eid cost-type]
   (get-in eid [:cost-paid cost-type :paid/value]))
 
-(defn cost-product
-  [eid cost-type]
-  (get-in eid [:cost-paid cost-type :paid/product]))
-
 (defn x-cost-value
   [eid]
   (get-in eid [:cost-paid :x-credits :paid/x-value] 0))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -53,8 +53,8 @@
       runner-currently-drawing (seq (peek (get-in @state [:runner :register :currently-drawing])))
       ;; intended to pick out cards that have moved as part of paying a cost
       source-card (or (game.core.card/get-card state card)
-                      (game.core.card/get-card state (game.core.payment/cost-product eid :remove-from-game)))
-      ]
+                      (game.core.card/get-card state
+                                               (first (game.core.payment/cost-targets eid :remove-from-game))))]
     (partition 2)
     (map (juxt first identity))
     (into {})))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -5392,6 +5392,7 @@
         (card-ability state :corp spin 0)
         (click-card state :corp "Ice Wall")
         (click-card state :corp "Enigma")
+        (is (last-log-contains? state "uses Spin Doctor") "tracks source card properly")
         (is (find-card "Spin Doctor" (:rfg (get-corp))) "Spin Doctor is rfg'd")
         (is (find-card "Ice Wall" (:deck (get-corp))) "Ice Wall is shuffled back into the deck")
         (is (find-card "Enigma" (:deck (get-corp))) "Enigma is shuffled back into the deck"))))


### PR DESCRIPTION
I added this under macros so I can expand it later (ie, with `trash-can`).

Since continue-ability (and resolve-ability in general) seem to refresh the reference to the card, abstracting some of these is awkward, so I added a macro to make it a bit easier.

Makes it so spin and moon pool log correctly - get-card doesn't work because the card is no longer there (it was rfg'd), so we can track the source via the eid and costs paid.