### PR TITLE
Poetri gives appropriate info

### DIFF
--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -463,6 +463,7 @@
       (when (:breach @state)
         (let [zone (or (#{:discard :deck :hand} (first (get-zone card)))
                        (second (get-zone card)))]
+          (swap! state update-in [:breach :known-cids zone] conj (:cid card))
           (swap! state update-in [:breach :cards-accessed zone] (fnil inc 0))))
       (when (:run @state)
         (let [zone (or (#{:discard :deck :hand} (first (get-zone card)))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -209,6 +209,10 @@
         dest-zone (get-in @state (cons :corp slot))
         install-state (or (:install-state cdef) install-state)
         no-msg (not (if (nil? display-message) true display-message))
+        ;; if cards are no longer candidates, but get installed during a breach, it is known
+        from-zone (or (#{:discard :deck :hand} (first (get-zone card)))
+                      (second (get-zone card)))
+        args (update-in args [:msg-keys :known] #(or % (contains? (set (get-in @state [:breach :known-cids from-zone] [])) (:cid card))))
         c (-> card
               (assoc :advanceable (:advanceable cdef) :new true)
               (dissoc :seen :disabled))]


### PR DESCRIPTION
Cards that have been seen during a breach are known (unless the zone gets shuffled).

This means poetri installs can be more informative for the runner.

This also means that discards during a breach may be more informative for the runner too.

Closes #8339