### PR TITLE
Small gitignore Fix for data/ Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ pom.xml
 .cache
 *.archive
 
-data/
+data/**
 !data/promos.edn
 !data/quotes-corp.edn
 !data/quotes-runner.edn


### PR DESCRIPTION
When I was doing the quote updates I got some warnings from git about trying to include `data/` even though it is ignored. I did a test and by changing the one line to ignore everything in the directory instead and that seems to work.