### PR TITLE
false lead can be queued to prompt after the runner turn begins trigg…

### DIFF
--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -50,8 +50,9 @@
                              (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))
                (effect-completed state nil eid))
              (swap! state dissoc (if (= side :corp) :corp-phase-12 :runner-phase-12))
-             (when (= side :corp)
-               (update-all-advancement-requirements state)))))
+             (wait-for (trigger-event-simult state side (if (= side :corp) :post-corp-turn-begins :post-runner-turn-begins) nil nil)
+                       (when (= side :corp)
+                         (update-all-advancement-requirements state))))))
 
 (defn start-turn
   "Start turn."

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -1476,6 +1476,46 @@
     (card-ability state :corp (get-scored state :corp 0) 0)
     (is (= 2 (:click (get-runner))) "Runner should lose 2 clicks from False Lead")))
 
+(deftest false-lead-no-prompt
+  ;; False Lead
+  (do-game
+    (new-game {:corp {:score-area ["False Lead"]}})
+    (take-credits state :corp)
+    (is (no-prompt? state :corp) "No prompt")))
+
+(deftest false-lead-yes-prompt
+  ;; False Lead
+  (do-game
+    (new-game {:corp {:score-area ["False Lead"]}})
+    (card-ability state :corp (get-scored state :corp 0) 1)
+    (click-prompt state :corp "Always")
+    (take-credits state :corp)
+    (is (changed? [(:click (get-runner)) -2]
+          (click-prompt state :corp "Yes"))
+        "Fired false lead")))
+
+(deftest false-lead-when-tagged-prompt-fires
+  ;; False Lead
+  (do-game
+    (new-game {:corp {:score-area ["False Lead"]}
+               :runner {:tags 4}})
+    (card-ability state :corp (get-scored state :corp 0) 1)
+    (click-prompt state :corp "When tagged")
+    (take-credits state :corp)
+    (is (changed? [(:click (get-runner)) -2]
+          (click-prompt state :corp "Yes"))
+        "Fired false lead")))
+
+(deftest false-lead-when-tagged-prompt-fizzles
+  ;; False Lead
+  (do-game
+    (new-game {:corp {:score-area ["False Lead"]}
+               :runner {:tags 0}})
+    (card-ability state :corp (get-scored state :corp 0) 1)
+    (click-prompt state :corp "When tagged")
+    (take-credits state :corp)
+    (is (no-prompt? state :corp))))
+
 (deftest fetal-ai
   ;; Fetal AI
   (do-game


### PR DESCRIPTION
…ers have fired

Just some QOL to reduce the friction when using false lead.

Closes #8338