### PR TITLE
Choose access command

### DIFF
--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -843,35 +843,44 @@
         (req (if (any-effects state side :corp-choose-hq-access)
                ;; corp chooses access
                (continue-ability
-                state :corp
-                {:async true
-                 :prompt (str "Choose a card in HQ for the Runner to access")
-                 :waiting-prompt true
-                 :choices {:all true
-                           :card #(and (in-hand? %)
-                                       (corp? %)
-                                       (not (already-accessed-fn %)))}
-                 :effect (req (wait-for (access-card state :runner target (:title target))
-                                        (continue-ability
-                                         state :runner
-                                         (access-helper-hq
-                                          state {:random-access-limit (dec random-access-limit)
-                                                 :total-mod (access-bonus-count state side :total)
-                                                 :chosen (inc chosen)}
-                                          (conj already-accessed (:cid target)) args)
-                                         card nil)))}
-                card nil)
+                 state :corp
+                 {:async true
+                  :prompt (str "Choose a card in HQ for the Runner to access (clicking done will randomly choose a candidate)")
+                  :waiting-prompt true
+                  :choices {:card #(and (in-hand? %)
+                                        (corp? %)
+                                        (not (already-accessed-fn %)))}
+                  :effect (req (wait-for (access-card state :runner target (:title target))
+                                         (continue-ability
+                                           state :runner
+                                           (access-helper-hq
+                                             state {:random-access-limit (dec random-access-limit)
+                                                    :total-mod (access-bonus-count state side :total)
+                                                    :chosen (inc chosen)}
+                                             (conj already-accessed (:cid target)) args)
+                                           card nil)))
+                  :cancel-effect (req (let [accessed (first (drop-while already-accessed-fn (access-cards-from-hq state)))]
+                                        (wait-for (access-card state side accessed (:title accessed))
+                                                  (continue-ability
+                                                    state side
+                                                    (access-helper-hq
+                                                      state {:random-access-limit (dec random-access-limit)
+                                                             :total-mod (access-bonus-count state side :total)
+                                                             :chosen (inc chosen)}
+                                                      (conj already-accessed (:cid accessed)) args)
+                                                    card nil))))}
+                 card nil)
                ;; normal access
                (let [accessed (first (drop-while already-accessed-fn (access-cards-from-hq state)))]
                  (wait-for (access-card state side accessed (:title accessed))
                            (continue-ability
-                            state side
-                            (access-helper-hq
-                             state {:random-access-limit (dec random-access-limit)
-                                    :total-mod (access-bonus-count state side :total)
-                                    :chosen (inc chosen)}
-                             (conj already-accessed (:cid accessed)) args)
-                            card nil)))))
+                             state side
+                             (access-helper-hq
+                               state {:random-access-limit (dec random-access-limit)
+                                      :total-mod (access-bonus-count state side :total)
+                                      :chosen (inc chosen)}
+                               (conj already-accessed (:cid accessed)) args)
+                             card nil)))))
 
         unrezzed-cards-fn
         (req

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -860,6 +860,7 @@
                                              (conj already-accessed (:cid target)) args)
                                            card nil)))
                   :cancel-effect (req (let [accessed (first (drop-while already-accessed-fn (access-cards-from-hq state)))]
+                                        (system-msg state side (str "randomly chooses " (:title accessed) " to be accessed"))
                                         (wait-for (access-card state side accessed (:title accessed))
                                                   (continue-ability
                                                     state side

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -10,6 +10,7 @@
    [game.core.charge :refer [charge-card]]
    [game.core.damage :refer [damage]]
    [game.core.drawing :refer [draw]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [resolve-ability trigger-event]]
    [game.core.flags :refer [is-scored?]]
@@ -447,6 +448,16 @@
                                           :gameid (:gameid @state)}))))}
       nil nil)))
 
+(defn command-choose-hq-accesses
+  [state side]
+  (when (:run @state)
+    (system-msg state :corp "will be choosing the cards accessed from HQ this run")
+    (register-lingering-effect
+      state side (make-card {:title "/choose-hq-access command"})
+      {:type :corp-choose-hq-access
+       :duration :end-of-run
+       :value true})))
+
 (defn parse-command
   [state text]
   (let [[command & args] (safe-split text #" ")
@@ -475,6 +486,7 @@
                                              :effect (req (charge-card %1 %2 eid target))
                                              :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                             (make-card {:title "/charge command"}) nil)
+            "/choose-hq-access" #(command-choose-hq-accesses %1 %2)
             "/clear-win"  clear-win
             "/click"      #(swap! %1 assoc-in [%2 :click] (constrain-value value 0 1000))
             "/close-prompt" command-close-prompt

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -134,6 +134,9 @@
    {:name "/charge"
     :usage "/charge"
     :help "Charge an installed card"}
+   {:name "/choose-hq-access"
+    :usage "/choose-hq-access"
+    :help "allows the corp player to choose the cards accessed from HQ during this run. Use this for manual fixes that require a re-run"}
    {:name "/clear-win"
     :usage "/clear-win"
     :help "requests game to clear the current win state.  Requires both players to request it"}

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -69,16 +69,27 @@
           (is (no-prompt? state :runner) "Prompt is cleared")
           (is (= 4 (get-counters (refresh hotel) :power)) "Charged Earthrise Hotel")))))
 
-  (testing "/click"
+  (testing "/choose-hq-access"
     (let [user {:username "Corp"}]
       (do-game
-        (new-game)
-        (core/command-parser state :corp {:user user :text "/click 3"})
-        (is (= 3 (:click (get-corp))) "Corp has 3 clicks")
-        (core/command-parser state :corp {:user user :text "/click -5"})
-        (is (= 0 (:click (get-corp))) "Corp has 0 clicks")
-        (core/command-parser state :corp {:user user :text "/click 99999999999999999999999999999999999999999999"})
-        (is (= 1000 (:click (get-corp))) "Corp has 1000 clicks"))))
+        (new-game {:corp {:hand ["IPO" "Hedge Fund" "Beanstalk Royalties"]}
+                   :runner {:hand ["Legwork"]}})
+        (take-credits state :corp)
+        (play-from-hand state :runner "Legwork")
+        (core/command-parser state :corp {:user user :text "/choose-hq-access"})
+        (run-continue-until state :success)
+        (click-card state :corp "IPO")
+        (accessing state "IPO")
+        (click-prompt state :runner "No action")
+        (click-card state :corp "Hedge Fund")
+        (accessing state "Hedge Fund")
+        (click-prompt state :runner "No action")
+        (click-card state :corp "Beanstalk Royalties")
+        (accessing state "Beanstalk Royalties")
+        (click-prompt state :runner "No action")
+        (run-empty-server state :hq)
+        (click-prompt state :runner "No action")
+        (is (no-prompt? state :corp) "Did not persist across runs"))))
 
   (testing "/counter"
     (let [user {:username "Corp"}]


### PR DESCRIPTION
I added a command that lets you choose accesses from HQ. This is intended for fixing the game state in cases where a run-back is required.

I also made it so when choosing hq accesses, you can (true to table play) just randomly pick anyway if you like.