### PR TITLE
fixes nrdb import to prune out deck title strings, attempt to downloa…

### DIFF
--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -3,20 +3,28 @@
             [monger.collection :as mc]
             [monger.operators :refer :all]
             [org.httpkit.client :as http]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [taoensso.timbre :as timbre]))
 
-(def nrdb-decklist-url "https://netrunnerdb.com/api/2.0/public/decklist/")
-(def nrdb-readable-url "https://netrunnerdb.com/en/decklist/")
+(def nrdb-decklist-url "https://netrunnerdb.com/api/2.0/public/")
+(def nrdb-readable-url "https://netrunnerdb.com/en/")
+
+(def private-endpoint "deck/")
+(def public-endpoint "decklist/")
 
 (defn- parse-input
-  "Want to handle an NRDB URL or just a deck id number"
+  "Want to handle an NRDB URL or just a deck/decklist id number
+   returns: [:public/:private/:unknown, id]"
   [input]
-  (let [input (str/replace input "www.netrunnerdb.com" "netrunnerdb.com")
-        input (if (str/starts-with? input nrdb-readable-url)
-                (subs input (count nrdb-readable-url))
-                input)
-        [id] (str/split input #"/")]
-      id))
+  (let [id (if (str/includes? input "/")
+             (let [frame (second (str/split input #"decklist/|deck/"))]
+               (first (str/split frame #"/")))
+             input)
+        endpoint (cond
+                   (str/includes? input "/decklist/") :public
+                   (str/includes? input "/deck/") :private
+                   :else :unknown)]
+    [endpoint id]))
 
 (defn- lookup-card [db id]
   (or (mc/find-one-as-map db "cards" {:code id})
@@ -41,21 +49,37 @@
           :notes (str "imported from " nrdb-readable-url (:id deck))}
          (parse-cards db (:cards deck))))
 
-(defn- parse-response [db body]
+(defn- parse-response [endpoint db body]
   (let [parsed (json/parse-string body true)]
     (cond
-      (not (:success parsed)) (throw (Exception. "Query failed."))
-      (not= 1 (:total parsed)) (throw (Exception. "Query did not return one element."))
+      (not (:success parsed)) (timbre/info (Exception. "NRDB Query did not return success using endpoint: " endpoint))
+      (not= 1 (:total parsed)) (timbre/info (Exception. "NRDB Query did not return one element"))
       (contains? parsed :data) (parse-nrdb-deck db (first (:data parsed)))
-      :else (throw (Exception. "Query does not have a data field")))))
+      :else (timbre/info (Exception. "NRDB Query does not have a data field")))))
+
+(defn try-download-public-decklist
+  "Try to download a public decklist given a specific endpoint. If the endpoint is unknown, try public first, then private"
+  [db deck-id endpoint]
+  (let [chosen-endpoint (case endpoint
+                          :public public-endpoint
+                          :private private-endpoint
+                          :unknown public-endpoint)
+        url (str nrdb-decklist-url chosen-endpoint deck-id)
+        data (http/get url)
+        {:keys [status body error]} @data]
+    (cond
+      error (timbre/info (Exception. (str "Failed to download deck " deck-id ": " error)))
+      (= 200 status)
+      (let [maybe-parsed (parse-response endpoint db body)]
+        (cond
+          maybe-parsed maybe-parsed
+          (= endpoint :unknown) (try-download-public-decklist db deck-id :private)
+          :else nil))
+      :else (do (timbre/info (Exception. (str "Failed to download deck " deck-id " using endpoint " endpoint ", status: " error)))
+                (when (= endpoint :unknown)
+                  (try-download-public-decklist db deck-id :private))))))
 
 (defn download-public-decklist
   [db input]
-  (when-let [deck-id (parse-input input)]
-    (let [url (str nrdb-decklist-url deck-id)
-          data (http/get url)
-          {:keys [status body error]} @data]
-      (cond
-        error (throw (Exception. (str "Failed to download deck " error)))
-        (= 200 status) (parse-response db body)
-        :else (throw (Exception. (str "Failed to download deck, status " status)))))))
+  (let [[endpoint deck-id] (parse-input input)]
+    (when deck-id (try-download-public-decklist db deck-id endpoint))))

--- a/test/clj/game/core/access_test.clj
+++ b/test/clj/game/core/access_test.clj
@@ -357,7 +357,7 @@
                         :discard ["Hostile Takeover" "15 Minutes"]}})
       (take-credits state :corp)
       (run-empty-server state "Archives")
-      (is (= ["Hostile Takeover" "15 Minutes"] (prompt-buttons :runner)))
+      (is (= (sort ["Hostile Takeover" "15 Minutes"]) (sort (prompt-buttons :runner))))
       (click-prompt state :runner "Hostile Takeover")
       (click-prompt state :runner "Steal")
       (is (accessing state "15 Minutes"))


### PR DESCRIPTION
…d private lists, and work on private lists in general

I assume this simply never worked on private lists in the first place, and pasting the whole url broke whenever nrdb decided to start poluting the url with the deck title.

I also made the exceptions in the nrdb fetching area log via timbre/info, and the same for those in deck import route (Closes #8350)