### PR TITLE
To announcement functionality

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -504,6 +504,7 @@ game_gain-credit = Gain Credit
 
 game_game-start = Game start: {$timestamp}
 
+
 game_grip = Grip
 
 game_heap = Heap ({$cnt})
@@ -585,6 +586,10 @@ game_rez-all = Rez All
 game_rfg = Removed from the game
 
 game_rnd = R&D
+
+game_round-end = Round end: {$timestamp}
+
+game_round-extension = (Includes {$minutes}m time extension)
 
 game_run = Run
 

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -9,6 +9,7 @@
 (defonce app-state
   (atom {:lobbies {}
          :lobby-updates {}
+         :tournament nil
          :users {}}))
 
 (defonce lobby-subs-timeout-hours 1)
@@ -48,6 +49,9 @@
 
 (defn get-lobbies []
   (vals (:lobbies @app-state)))
+
+(defn tournament-state []
+  (:tournament @app-state nil))
 
 (defn get-lobby
   ([gameid] (get-lobby gameid (:lobbies @app-state)))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -223,14 +223,20 @@
    ;; for tournament system
    :time-extension
    :excluded?
+   :round-end-time
    ])
+
+(defn maybe-round-end-time
+  [lobby]
+  (when (= (:room lobby) "competitive")
+    (:round-end (app-state/tournament-state) nil)))
 
 (defn lobby-summary
   "Strips private server information from a game map, preparing to send the game to clients."
   ([lobby] (lobby-summary lobby nil))
   ([lobby participating?]
    (-> lobby
-       (assoc :old (> (count (or (:messages lobby) [])) 10)) 
+       (assoc :old (> (count (or (:messages lobby) [])) 10))
        (update :password boolean)
        (update :players #(prepare-players lobby %))
        (update :spectators #(prepare-players lobby %))
@@ -238,6 +244,8 @@
        (update :runner-spectators #(prepare-players lobby %))
        (update :original-players prepare-original-players)
        (update :messages #(when participating? %))
+       ;; if there's a current tournament, insert the end time for the round
+       (assoc :round-end-time (maybe-round-end-time lobby))
        (select-non-nil-keys lobby-keys))))
 
 (defn get-blocked-list [user]

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -89,6 +89,8 @@
   "Note: if the lobby isn't actually real, or has been nulled somehow, executing on the lobby thread is safe"
   `(cp/future (get-in ~lobby [:pool :pool] lobby-pool) ~@expr))
 
+(defmulti assign-tournament-properties identity)
+
 (defn validate-precon
   [format client-precon client-gateway-type]
   (let [target (if (= format "system-gateway") client-gateway-type client-precon)
@@ -217,7 +219,11 @@
    :started
    :timer
    :title
-   :old])
+   :old
+   ;; for tournament system
+   :time-extension
+   :excluded?
+   ])
 
 (defn lobby-summary
   "Strips private server information from a game map, preparing to send the game to clients."
@@ -340,6 +346,7 @@
                                register-lobby lobby uid)
           lobby? (get-in new-app-state [:lobbies (:gameid lobby)])]
       (when lobby?
+        (assign-tournament-properties lobby?)
         (send-lobby-state lobby?)
         (broadcast-lobby-list))
       (log-delay! timestamp id))))

--- a/src/clj/web/tournament.clj
+++ b/src/clj/web/tournament.clj
@@ -3,169 +3,24 @@
    [cheshire.core :as json]
    [clj-uuid :as uuid]
    [cljc.java-time.instant :as inst]
+   [cljc.java-time.duration :as duration]
+   [cljc.java-time.temporal.chrono-unit :as chrono]
    [clojure.string :as str]
+   [clojure.core.async :as async]
+   [game.core :as core]
    [jinteki.utils :refer [str->int]]
    [monger.operators :refer :all]
    [org.httpkit.client :as http]
-   ; [web.lobby :refer [all-games refresh-lobby close-lobby]]
+   ;; [web.lobby :refer [all-games refresh-lobby close-lobby]]
    [web.mongodb :refer [find-maps-case-insensitive]]
    [web.app-state :as app-state]
+   [web.lobby :as lobby]
    [web.stats :refer [fetch-elapsed]]
    [web.utils :refer [response]]
+   [web.game :refer [handle-message-and-send-diffs!]]
    [web.ws :as ws]))
 
-(defn auth [_]
-  (response 200 {:message "ok"}))
-
-(defn parse-response
-  [body]
-  (json/parse-string body true))
-
-(defn download-cobra-data
-  [id]
-  (let [data (http/get (str "http://cobr.ai/tournaments/" id ".json"))
-        {:keys [status body error headers]} @data]
-    (cond
-      error (throw (Exception. (str "Failed to download file " error)))
-      (and
-        (= 200 status)
-        (str/includes? (:content-type headers) "application/json"))
-      (assoc (parse-response body) :cobra-link id)
-      :else (throw (Exception. (str "Failed to download file, status " status))))))
-
-(defn build-players
-  [data]
-  (into {} (for [player (:players data)] [(:id player) player])))
-
-(defn get-player-name
-  [players player]
-  (:name (get players (:id player))))
-
-(defn transform-player
-  [players player]
-  (-> player
-      (assoc :name (get-player-name players player)
-             :score (:combinedScore player))
-      (dissoc :corpScore :runnerScore :combinedScore)))
-
-(defn determine-winner
-  [table]
-  (let [player1-score (get-in table [:player1 :score])
-        player2-score (get-in table [:player2 :score])]
-    (cond
-      (or (nil? player1-score)
-          (nil? player2-score)) :not-finished
-      (> player1-score player2-score) :player1
-      (< player1-score player2-score) :player2
-      :else :tie)))
-
-(defn process-table
-  [table players]
-  (let [player1 (transform-player players (:player1 table))
-        player2 (transform-player players (:player2 table))]
-    (when (and (:name player1) (:name player2))
-      (as-> table table
-        (assoc table :player1 player1 :player2 player2)
-        (assoc table :winner (determine-winner table))
-        (dissoc table :intentionalDraw :eliminationGame)))))
-
-(defn process-round
-  [round players]
-  (keep #(process-table % players) round))
-
-(defn process-all-rounds
-  [data players]
-  (map #(process-round % players) (:rounds data)))
-
-(defn create-tournament-lobby
-  [db {:keys [tournament-name tournament-format selected-round table
-              username1 username2 allow-spectator on-close cobra-link
-              save-replay timer]}]
-  (let [gameid (uuid/v4)
-        title (str tournament-name ", Round " selected-round
-                   ", Table " table ": " username1 " vs " username2)
-        query (into [] (for [username [username1 username2]] {:username username}))
-        players (->> (find-maps-case-insensitive db "users" {$or query})
-                     (map #(select-keys % [:_id :username :emailhash :isadmin :options :stats]))
-                     (map #(update % :_id str))
-                     (map #(hash-map :user %)))
-        players (->> (if (= username1 (get-in (first players) [:user :username]))
-                       [(first players) (second players)]
-                       [(second players) (first players)])
-                     (filter identity)
-                     (into []))
-        now (inst/now)
-        game {:gameid gameid
-              :title title
-              :room "tournament"
-              :format tournament-format
-              :tournament-name tournament-name
-              :cobra-link cobra-link
-              :players players
-              :spectators []
-              :spectator-count 0
-              :messages [{:user "__system__"
-                          :text "The game has been created."}]
-              :allow-spectator allow-spectator
-              :save-replay save-replay
-              :timer timer
-              :spectatorhands false
-              :mute-spectators true
-              :date now
-              :last-update now
-              :on-close on-close}]
-    (when (= 2 (count players))
-      ; (refresh-lobby gameid game)
-      game)))
-
-(defn create-lobbies-for-tournament
-  [db data selected-round {:keys [timer save-replays? single-sided?]}]
-  (let [players (build-players data)
-        rounds (process-all-rounds data players)
-        round (nth rounds selected-round (count rounds))]
-    (keep
-      (fn [table]
-        (let [username1 (get-in table [:player1 :name])
-              username2 (get-in table [:player2 :name])
-              base {:tournament-name (:name data)
-                    :tournament-format "standard"
-                    :cobra-link (:cobra-link data)
-                    :selected-round (inc selected-round)
-                    :table (:table table)
-                    :timer timer
-                    :username1 username1
-                    :username2 username2
-                    :save-replay save-replays?
-                    :allow-spectator true}
-              callback (fn [first-game]
-                         (create-tournament-lobby
-                           db (assoc base
-                                     :username1 username2
-                                     :username2 username1
-                                     :timer (when-let
-                                              [elapsed (fetch-elapsed db (:gameid first-game))]
-                                              (max 0 (- timer elapsed))))))]
-          (create-tournament-lobby
-            db (assoc base :on-close (when-not single-sided? callback)))))
-      round)))
-
-(defn load-tournament
-  [{{db :system/db} :ring-req
-    {:keys [cobra-link]} :?data
-    uid :uid}]
-  (let [data (download-cobra-data cobra-link)
-        player-names (keep :name (:players data))
-        query (into [] (for [username player-names] {:username username}))
-        db-players (find-maps-case-insensitive db "users" {$or query})
-        found-player-names #(seq (filter (fn [e] (= (str/lower-case %) (str/lower-case e))) (map :username db-players)))
-        missing-players (remove found-player-names player-names)
-        players (build-players data)
-        rounds (process-all-rounds data players)]
-    (ws/broadcast-to! [uid] :tournament/loaded {:data {:players players
-                                                       :missing-players missing-players
-                                                       :rounds rounds
-                                                       :cobra-link cobra-link
-                                                       :tournament-name (:name data)}})))
+(defn auth [_] (response 200 {:message "ok"}))
 
 (defn wrap-with-to-handler
   "Wrap a function in a handler which checks that the user is a tournament organizer."
@@ -177,50 +32,6 @@
       (do (handler msg)
           (when reply-fn (reply-fn 200)))
       (when reply-fn (reply-fn 403)))))
-
-(defn create-tables
-  [{{db :system/db} :ring-req
-    {:keys [cobra-link selected-round save-replays? single-sided? timer]} :?data
-    uid :uid}]
-  (let [data (download-cobra-data cobra-link)
-        created-rounds (create-lobbies-for-tournament
-                         db data
-                         (str->int selected-round)
-                         {:timer timer
-                          :save-replays? save-replays?
-                          :single-sided? single-sided?})]
-    (ws/broadcast-to! [uid] :tournament/created {:data {:created-rounds (count created-rounds)}})))
-
-(defmethod ws/-msg-handler :tournament/create
-  tournament--create
-  [event]
-  ((wrap-with-to-handler create-tables) event))
-
-(defn close-tournament-tables
-  [cobra-link]
-  (when cobra-link
-    (let [tables (for [game (vals {})
-                       :when (= cobra-link (:cobra-link game))]
-                   {:started false
-                    :gameid (:gameid game)})]
-      ; (map #(close-lobby % true) tables)
-      )))
-
-(defmethod ws/-msg-handler :tournament/fetch
-  tournament--fetch
-  [event]
-  ((wrap-with-to-handler load-tournament) event))
-
-(defn- delete-tables
-  [{{:keys [cobra-link]} :?data
-    uid :uid}]
-  (let [deleted-rounds (close-tournament-tables cobra-link)]
-    (ws/broadcast-to! [uid] :tournament/deleted {:data {:deleted-rounds (count deleted-rounds)}})))
-
-(defmethod ws/-msg-handler :tournament/delete
-  tournament--delete
-  [event]
-  ((wrap-with-to-handler delete-tables) event))
 
 (defn- view-tables
   [{uid :uid}]
@@ -254,3 +65,153 @@
   tournament--update-tables
   [event]
   ((wrap-with-to-handler update-tables) event))
+
+;; here we need to set up a timer that will always run until a round is deleted
+(defn- same-second? [a b]
+  (= (inst/truncated-to a chrono/seconds)
+     (inst/truncated-to b chrono/seconds)))
+
+(defonce tasks (atom {}))
+
+(defn cancel-task
+  "Cancel scheduled task by key"
+  [keyvec]
+  (when-let [{:keys [stop-chan]} (get-in @tasks keyvec nil)]
+    (async/close! stop-chan)
+    (swap! tasks dissoc key)))
+
+(defn cancel-all-tasks!
+  "Cancel all pending tasks and make a clean atom"
+  []
+  (doseq [outer (keys @tasks)
+          inner (keys (get @tasks outer []))]
+    (cancel-task [outer inner])
+    (reset! tasks {})))
+
+(defn schedule-task
+  "schedules a task under `keyvec` to occur at `time`.
+  If the task exists already, it will be cancelled/rescheduled"
+  [keyvec time f]
+  ;; do not schedule tasks in the past
+  (let [now (inst/now)]
+    (when-not (inst/is-before time now)
+      (cancel-task keyvec)
+      (let [stop-chan (async/chan)
+            delay-ms (* 1000  (- (inst/get-epoch-second time) (inst/get-epoch-second now)))
+            task-chan (async/go
+                        (let [timeout-chan (async/timeout delay-ms)]
+                          (async/alt!
+                            timeout-chan (do (f) :done)
+                            stop-chan :cancelled)))]
+        (swap! tasks assoc-in keyvec {:stop-chan stop-chan :task-chan task-chan})
+        task-chan))))
+
+(defn- alert-lobby
+  [{:keys [gameid] :as lobby} msg]
+  (when-let [actual-lobby (app-state/get-lobby gameid)]
+    (if (:started actual-lobby)
+      ;; in game - use the in-game thing
+      (handle-message-and-send-diffs! actual-lobby nil nil (str "[!] " msg))
+      (lobby/lobby-thread
+        (let [timestamp (inst/now)
+              message (core/make-message {:user {:username "TOURNAMENT SCHEDULER" :uid "TOURNAMENT SCHEDULER"} :text msg})
+              new-app-state (swap! app-state/app-state
+                                   update :lobbies #(-> %
+                                                        (lobby/handle-send-message gameid message)
+                                                        (lobby/handle-set-last-update gameid "TOURNAMENT SCHEDULER")))
+              lobby? (get-in new-app-state [:lobbies gameid])]
+          (lobby/send-lobby-state lobby?)
+          (lobby/log-delay! timestamp :tournament-alert-lobby))))))
+
+(defn- offset-time
+  [time minutes seconds]
+  (inst/plus (inst/plus time (duration/of-minutes (or minutes 0))) (duration/of-seconds (or seconds 0))))
+
+(defn- schedule-lobby!
+  [{:keys [gameid time-extension] :as lobby}]
+  (when-let [{:keys [round-start round-start-alert round-start-1m-alert
+                     round-20m-warning round-5m-warning round-1m-warning round-end
+                     round-time-call round-time-explainer report-match]
+              :as round} (app-state/tournament-state)]
+    (when round-start-alert    (schedule-task [gameid :round-start] round-start (fn [] (alert-lobby lobby "The round has begun!"))))
+    (when round-start-1m-alert (schedule-task [gameid :round-start-1m] (inst/minus round-start (duration/of-minutes 1)) (fn [] (alert-lobby lobby "The round will begin in one minute."))))
+
+    (when round-end            (schedule-task [gameid :round-end]      (offset-time round-end time-extension 0) (fn [] (alert-lobby lobby round-time-call))))
+    (when round-time-explainer (schedule-task [gameid :round-explain]  (offset-time round-end time-extension 5) (fn [] (alert-lobby lobby round-time-explainer))))
+    (when round-1m-warning     (schedule-task [gameid :round-1m-warn]  (inst/plus round-end (duration/of-minutes (- (or time-extension 0) 1))) (fn [] (alert-lobby lobby "1 minute remaining in the round"))))
+    (when round-5m-warning     (schedule-task [gameid :round-5m-warn]  (inst/plus round-end (duration/of-minutes (- (or time-extension 0) 5))) (fn [] (alert-lobby lobby "5 minutes remaining in the round"))))
+    (when round-20m-warning    (schedule-task [gameid :round-20m-warn] (inst/plus round-end (duration/of-minutes (- (or time-extension 0) 20))) (fn [] (alert-lobby lobby "20 minutes remaining in the round"))))
+    (when report-match         (schedule-task [gameid :report-match]   (offset-time round-end time-extension 10) (fn [] (alert-lobby lobby (str "Report your match here: " report-match)))))))
+
+(defmethod lobby/assign-tournament-properties :default [{:keys [gameid] :as lobby}]
+  (when-let [lobby? (app-state/get-lobby gameid)]
+    (when (and (= "competitive" (:room lobby))
+               (not (:exclude? lobby)))
+      (schedule-lobby! lobby?))))
+
+(defn- conclude-round
+  [{uid :uid}]
+  (swap! app-state/app-state assoc :tournament nil)
+  (cancel-all-tasks!)
+  (view-tables {:uid uid}))
+
+(defn- declare-round
+  [{{:keys [tournament-settings]} :?data
+    uid :uid}]
+  (if nil ;;(= 2 (app-state/tournament-state))
+    (do (ws/broadcast-to! [uid] :tournament/declare-round {:error "A round is already underway"})
+        (view-tables {:uid uid}))
+    ;; we need to convert the tournament settings to timestamps
+    (let [now (inst/truncated-to (inst/now) chrono/seconds)
+          start-in (get-in tournament-settings [:round-start :start-in] 0)
+          ;; start of round?
+          round-start          (inst/plus now (duration/of-minutes start-in))
+          round-start-alert    (get-in tournament-settings [:round-start :alert] nil)
+          round-start-1m-alert (when (pos? start-in)
+                                 (get-in tournament-settings [:round-start :one-minute-warning] nil))
+          ;; round itself
+          round-length         (get-in tournament-settings [:round :time-in-round] 0)
+          round-end            (inst/plus now (duration/of-minutes round-length))
+          round-20-minute-warning (when (get-in tournament-settings [:round :twenty-minute-warning] false) (inst/minus round-end (duration/of-minutes 20)))
+          round-5-minute-warning  (when (get-in tournament-settings [:round :five-minute-warning]    true) (inst/minus round-end (duration/of-minutes 5)))
+          round-1-minute-warning  (when (get-in tournament-settings [:round :one-minute-warning]    false) (inst/minus round-end (duration/of-minutes 1)))
+          round-time-call        (get-in tournament-settings [:round :time-expiry-text] "-- TIME IN ROUND --")
+          round-explain-time-resolution? (get-in tournament-settings [:round :explain-time-resolution] true)
+          round-time-expiry-rules-text (get-in tournament-settings [:round :time-expiry-rules-text] "Time has been called. The active player finishes their turn, then the opposing player takes a turn. If the game has not concluded by the end of that turn, then the game is decided on agenda points.")
+
+          ;; reporting of the matches
+          show-report-match-url? (get-in tournament-settings [:reporting :self-reporting] false)
+          report-match-url (get-in tournament-settings [:reporting :self-reporting-url] nil)
+
+          ;; final config
+          tournament-config     {:source-uid uid
+                                 :round-start round-start
+                                 :round-start-alert   round-start-alert
+                                 :round-start-1m-alert round-start-1m-alert
+                                 :round-end   round-end
+                                 :round-20m-warning round-20-minute-warning
+                                 :round-5m-warning  round-5-minute-warning
+                                 :round-1m-warning  round-1-minute-warning
+                                 :round-time-call round-time-call
+                                 :round-time-explainer (when round-explain-time-resolution? round-time-expiry-rules-text)
+                                 :report-match (when show-report-match-url? report-match-url)
+                                 }]
+      (do  ;;when-not (app-state/tournament-state)
+        (println "configuring")
+        (swap! app-state/app-state assoc :tournament tournament-config)
+        (doseq [lobby (->> (app-state/get-lobbies)
+                           (filter #(and (= (:room %) "competitive")
+                                         (not (:excluded? %)))))]
+          (schedule-lobby! lobby)))
+        ;; schedule
+      (view-tables {:uid uid}))))
+
+(defmethod ws/-msg-handler :tournament/conclude-round
+  tournament--conclude-round
+  [event]
+  ((wrap-with-to-handler conclude-round) event))
+
+(defmethod ws/-msg-handler :tournament/declare-round
+  tournament--declare-round
+  [event]
+  ((wrap-with-to-handler declare-round) event))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1988,8 +1988,7 @@
 (defn- time-until
   "Helper method for timer. Computes how much time is left until `end`"
   [end]
-  (let [
-        now (inst/now)
+  (let [now (inst/now)
         diff (duration/between now end)
         total-seconds (duration/get diff chrono/seconds)
         minutes (abs (quot total-seconds 60))
@@ -2046,6 +2045,18 @@
         seconds (mod (abs total-seconds) 60)]
     {:minutes minutes :seconds seconds}))
 
+(defn- time-left-in-round
+  "Helper method for match duration. Computes how much time since game start"
+  [end]
+  (let [end-time (-> end
+                     (inst/parse))
+        now (inst/now)
+        diff (duration/between end-time now)
+        total-seconds (duration/get diff chrono/seconds)
+        minutes (abs (quot total-seconds 60))
+        seconds (mod (abs total-seconds) 60)]
+    {:minutes minutes :seconds seconds}))
+
 (defn match-duration
   "Component which displays a readout of the time since the start of the match."
   [start-date hidden]
@@ -2068,22 +2079,40 @@
             (:minutes @duration) (tr [:game_minutes "m:"])
             (:seconds @duration) (tr [:game_seconds "s"])]))})))
 
+(defn- adjusted-round-end [app-state]
+  (let [{:keys [room round-end-time excluded? time-extension]} (:current-game @app-state)]
+    (when (and (= room "competitive")
+               (not excluded?)
+               round-end-time)
+      (inst/plus round-end-time (duration/of-minutes (or time-extension 0))))))
+
 (defn starting-timestamp [start-date timer]
   ;; I don't like using js/Date, but `toLocalTimeString`
   ;; is just too convenient
   (let [hide-timer (r/atom false)]
     (fn []
-      [:div.panel.blue-shade.timestamp
-       [:span.float-center
-        (tr [:game_game-start "Game start"] {:timestamp (.toLocaleTimeString (js/Date. start-date))})]
-       [:<>
-        [:span.pm {:on-click #(swap! hide-timer not)}
-         (if @hide-timer "+" "-")]
-        (if timer [:span {:on-click #(swap! hide-timer not)}
-                        [time-remaining start-date timer hide-timer]]
-                  [:span {:on-click #(swap! hide-timer not)}
-                        [match-duration start-date hide-timer]])]])))
+      (let [round-end (adjusted-round-end app-state)
+            round-end-date (when round-end (js/Date. (inst/to-epoch-milli round-end)))
+            extension (get-in @app-state [:current-game :time-extension] 0)]
+        (if round-end
+          [:div.panel.blue-shade.timestamp
+           [:span.float-center
+            (tr [:game_round-end "Round end"] {:timestamp (.toLocaleTimeString round-end-date)})]
+           (when (pos? extension)
+             [:span.float-center
+              (tr [:game_round-extension (str "(includes " extension "m time extension)")]
+                  {:extension extension})])]
 
+          [:div.panel.blue-shade.timestamp
+           [:span.float-center
+            (tr [:game_game-start "Game start"] {:timestamp (.toLocaleTimeString (js/Date. start-date))})]
+           [:<>
+            [:span.pm {:on-click #(swap! hide-timer not)}
+             (if @hide-timer "+" "-")]
+            (if timer [:span {:on-click #(swap! hide-timer not)}
+                       [time-remaining start-date timer hide-timer]]
+                [:span {:on-click #(swap! hide-timer not)}
+                 [match-duration start-date hide-timer]])]])))))
 
 (defn- handle-click [{:keys [render-board?]} e]
   (when render-board?

--- a/src/cljs/nr/tournament.cljs
+++ b/src/cljs/nr/tournament.cljs
@@ -1,229 +1,210 @@
 (ns nr.tournament
-  (:require [nr.appstate :refer [app-state]]
-            [nr.ws :as ws]
-            [nr.avatar :refer [avatar]]
-            [nr.stats :refer [faction-icon-memo]]
-            [jinteki.utils :refer [slugify str->int]]
-            [reagent.core :as r]))
+  (:require
+   [nr.appstate :refer [app-state]]
+   [nr.ws :as ws]
+   [nr.avatar :refer [avatar]]
+   [nr.stats :refer [faction-icon-memo]]
+   [jinteki.utils :refer [slugify str->int]]
+   [nr.utils :refer [cond-button non-game-toast]]
+   ["react" :as react]
+   [reagent.core :as r]
+   [clojure.string :as str]))
 
-(defn change-cobra-link
-  [state value]
-  (swap! state dissoc :cobra-link)
-  (swap! state assoc :url value))
+;; STATE MANAGEMENT
 
-(defn cobra-link
-  [state]
+(defonce active-round
+  ^{:doc "State of any active tournament timer from the appstate (remote)"}
+  (r/atom nil))
+
+(defonce stored-tables
+  ^{:doc "State of all competitive lobbies as of last load"}
+  (r/atom []))
+
+(defonce action-summary
+  ^{:doc "State of all tables that do not follow normal settings - ie have a time extension, or are excluded"}
+  (r/atom []))
+
+(defonce tournament-state
+  ^{:doc "State of the timer to be created"}
+  (r/atom {:reporting {:self-reporting false
+                       :self-reporting-url "https://tournaments.nullsignal.games/"}
+           :round-start {:alert true
+                         :one-minute-warning true
+                         :start-in 5}
+           :round {:time-in-round 40
+                   :time-expiry-text "TIME IN ROUND"
+                   :time-expiry-rules-text "Time has been called. The active player finishes their turn, then the opposing player takes a turn. If the game has not concluded by the end of that turn, then the game is decided on agenda points."
+                   :explain-time-resolution true
+                   :twenty-minute-warning false
+                   :five-minute-warning true
+                   :one-minute-warning false}}))
+
+;; SOME HELPER FUNCTIONS FOR THE INPUTS
+
+(defn- check-helper
+  [state keyseq label]
   [:div
-   [:h3 "Public Cobr.ai tournament"]
-   [:input {:placeholder "cobr.ai tournament link"
-            :type "text"
-            :value (:url @state)
-            :on-change #(change-cobra-link state (-> % .-target .-value))}]])
+   [:label
+    [:input {:type "checkbox"
+             :value true
+             :checked (get-in @state (vec keyseq) true)
+             :on-change #(let [checked (.. % -target -checked)]
+                           (swap! state assoc-in (vec keyseq) checked))}]
+    label]])
 
-(defn parse-id
-  [{value :url}]
-  (let [link (first (next (re-find #"(?:tournaments/)(\d+)" value)))
-        number (re-find #"\d+" value)]
-    (or link number)))
-
-(defn process-link
-  [state]
-  (when (not-empty (:url @state))
-    (swap! state assoc :cobra-link (parse-id @state))
-    (ws/ws-send! [:tournament/fetch {:cobra-link (:cobra-link @state)}])))
-
-(defn load-tournament-button
-  [state]
-  [:button {:on-click #(process-link state)} "Load tournament"])
-
-(defn missing-players
-  [state]
-  (when (:cobra-link @state)
-    (let [players (:missing-players @state)]
-      [:div
-       [:h3 "Players in Cobra with no registered jnet accounts"]
-       [:ul.missing-players
-        (doall
-          (map-indexed
-            (fn [idx player]
-              ^{:key idx} [:li player])
-            players))]])))
-
-(defn delete-all-tables
-  [state]
-  (ws/ws-send! [:tournament/delete {:cobra-link (:cobra-link @state)}]))
-
-(defn delete-tournament-button
-  [state]
-  (when (:cobra-link @state)
-    [:div
-     [:h4 "Delete all tables for this tournament?"]
-     [:button {:on-click #(delete-all-tables state)} "Delete tables"]]))
-
-(defn round-selector
-  [state]
-  (when (:cobra-link @state)
-    [:div
-     [:h3 "Select round"]
-     [:select {:value (or (:selected-round @state) (count (:rounds @state)))
-               :on-change #(swap! state assoc :selected-round (.. % -target -value))}
-      (doall
-        (for [round (range 1 (inc (count (:rounds @state))))]
-          ^{:key round}
-          [:option {:value (dec round)}
-           (str "Round " round)]))]]))
-
-(defn create-tables
-  [state]
-  (ws/ws-send! [:tournament/create (select-keys @state
-                                     [:cobra-link :selected-round :save-replays? :timer :single-sided?])]))
-
-(defn select-round-button
-  [state]
-  (when (:cobra-link @state)
-    [:button {:on-click #(create-tables state)}
-     "Create tables for this round"]))
-
-(defn success
-  [state]
-  (let [results (:results @state)
-        result-type (:result-type @state)]
-    (when results
-      [:<>
-       [:h2 "Success!"]
-       [:p (str results " tables have been " result-type)]])))
-
-(defn save-replay-option
-  [state]
-  (when (:cobra-link @state)
-    [:p
-     [:label
-      [:input {:type "checkbox" :checked (:save-replays? @state)
-               :on-change #(swap! state assoc :save-replays? (.. % -target -checked))}]
-      (str "🟢 Save replays")]]))
-
-(defn timed-option
-  [s]
-  (when (:cobra-link @s)
-    [:<> [:p
-          [:label
-           [:input {:type "checkbox" :checked (:timed @s)
-                    :on-change #(let [checked (.. % -target -checked)]
-                                  (swap! s assoc :timed checked)
-                                  (swap! s assoc :timer (if checked 35 nil)))}]
-           "Round timer"]]
-     (when (:timed @s)
-       [:p
-        [:input.game-title {:on-change #(swap! s assoc :timer (-> % (.. -target -value) str->int))
-                            :type "number"
-                            :value (:timer @s)
-                            :placeholder "Timer length (minutes)"}]])
-     [:div.infobox.blue-shade {:style {:display (if (:timed @s) "block" "none")}}
-      [:p "Timer is only for convenience: the game will not stop when timer runs out."]]]))
-
-(defn single-sided-option
-  [state]
-  (when (:cobra-link @state)
-    [:<>
-     [:p
-      [:label
-       [:input {:type "checkbox" :checked (:single-sided? @state)
-                :on-change #(swap! state assoc :single-sided? (.. % -target -checked))}]
-       (str "Single-sided round?")]]
-     [:div.infobox.blue-shade {:style {:display (if (:single-sided? @state) "block" "none")}}
-      [:p "A second game will not be created when the first is completed."]]]))
-
-(defn tournament-container
-  [state]
-  [:div.panel.tournament-settings-container
-   [:h1 "Tournament stuff"]
-   (when (:cobra-link @state)
-     [:h2 (:tournament-name @state)])
-   [cobra-link state]
-   [load-tournament-button state]
-   [missing-players state]
-   [delete-tournament-button state]
-   [round-selector state]
-   [timed-option state]
-   [save-replay-option state]
-   [single-sided-option state]
-   [select-round-button state]
-   [success state]])
-
-(defn load-players
-  [state json]
-  (swap! state merge (:data json)))
-
-(defn store-results
-  [state result-type json]
-  (let [json-key (keyword (str result-type "-rounds"))]
-    (swap! state assoc
-           :results (get-in json [:data json-key])
-           :result-type result-type)))
-
-(defn deck-info
-  [deck]
+(defn- minutes-helper
+  [state keyseq label-pre label-post]
   [:div
-   [:div.id-info
-    [:span.id-label "ID: "]
-    [:span.id-title.influence {:class (slugify (get-in deck [:identity :faction]))}
-     (get-in deck [:identity :title])]]
-   [:div.hash-info
-    [:span.hash-label "Hash: "]
-    [:span.hash-value (:hash deck)]]])
+   [:label
+    label-pre
+    [:input {:type "number"
+             :min 0
+             :step 1
+             :style {:width "10ch"}
+             :value (get-in @state (vec keyseq) 5)
+             :on-change #(swap! state assoc-in (vec keyseq) (.. % -target -valueAsNumber))}]
+    label-post]])
 
-(defn player-info
-  [player]
+(defn- dividerlabel
+  [text]
+  [:div {:style {:display "flex"
+                 :align-items "center"
+                 :margin "12px 0"}}
+   [:div {:style {:flex "1" :height "1px" :background "#ccc"}}]
+   [:span {:style {:margin "0 8px"}} text]
+   [:div {:style {:flex "1" :height "1px" :background "#ccc"}}]])
+
+(defn- text-helper
+  [state keyseq label]
   [:div
-   [:span.player
-    [avatar player {:opts {:size 24}}]
-    (get-in player [:player :username]) " - "
-    (when-let [id (get-in player [:deck :identity])]
-      (str (faction-icon-memo (:faction id) (:title id)) " " (:title id)))]]
-  [:div.player-info
-   [:div.user-info
-    [:span.username-label "Username: "]
-    [:span.username-value (get-in player [:user :username])]]
-   [:div.side-info
-    [:span.side-label "Side: "]
-    [:span.side-value (:side player)]]
-   (when (:deck player)
-     [deck-info (:deck player)])])
+   [:label
+    label
+    [:input {:type "text"
+             :style {:width "100%"}
+             :value (get-in @state (vec keyseq) "placeholder")
+             :on-change #(swap! state assoc-in (vec keyseq) (.. % -target -value))}]]])
 
-(defn game-info
-  [game]
-  [:div.gameline
-   [:div [:span.game-title (str (:title game))]]
-   [:div.game-status
-    (if (:started game)
-        [:span.started (str "Started " (.toLocaleTimeString (js/Date. (:start-date game))))]
-        [:span.not-started (str "Not started")])]
-   [:div.players
-    [player-info (first (:players game))]
-    [player-info (second (:players game))]]])
+;; FORMATTING/BODY
 
-(defonce state (r/atom {:selected-round "0"}))
+(defn timer-management
+  []
+  [:div
+   [:h3 "Set up a round"]
+   [:form
+    ;; print a message that the round is starting
+    [:fieldset
+     [:legend "Reporting"]
+     [check-helper tournament-state [:reporting :self-reporting] "Encourage self-reporting?"]
+     [text-helper tournament-state [:reporting :self-reporting-url] "Link for reporting: "]]
+    [:fieldset
+     [:legend "Round start"]
+     [check-helper tournament-state [:round-start :alert] "Inform players about round start?"]
+     [check-helper tournament-state [:round-start :one-minute-warning] "Inform players 1 minute before round start?"]
+     [minutes-helper tournament-state [:round-start :start-in] "Round starts in " " minutes"]]
+    [:fieldset
+     [:legend "Round properties"]
+     [minutes-helper tournament-state [:round :time-in-round] "Round is " " minutes long"]
+     [text-helper tournament-state [:round :time-expiry-text] "Time call: "]
+     [check-helper tournament-state [:round :explain-time-resolution] "Explain resolution when calling time in round (text below)?"]
+     [text-helper tournament-state [:round :time-expiry-rules-text] "Time rules explainer: "]
+     [dividerlabel "Warnings"]
+     [check-helper tournament-state [:round :twenty-minute-warning] "Give players a 20-minute warning (half-way for 40 minute rounds)"]
+     [check-helper tournament-state [:round :five-minute-warning] "Give players a 5-minute warning"]
+     [check-helper tournament-state [:round :one-minute-warning] "Give players a 1-minute warning"]]]
+   [:p]
+   [cond-button "Declare Round"
+    (not @active-round)
+    (fn []
+      (non-game-toast "locking in a round structure..." "info" nil)
+      (ws/ws-send! [:tournament/declare-round {:tournament-settings @tournament-state}]))]
+   [:p]])
 
-(defmethod ws/event-msg-handler :tournament/loaded [{data :?data}]
-  (load-players state data))
+(defn tournament-lobbies-container
+  []
+  [:div
+   [:h3 "Tournament lobbies"]
+   [:div "Here you can load all lobbies in the competitive channel, set time extensions on specific lobbies, and exclude lobbies from timers and announcements."]
+   [:p]
+   [:div
+    [:button
+     {:type "button"
+      ;; TODO - sent a thing to refresh the tournament lobbies
+      :on-click (fn []
+                  (do (ws/ws-send! [:tournament/update-tables {:competitive-lobbies @stored-tables}])
+                      (non-game-toast "locking in changes..." "info" nil)))}
+     "Commit Changes"]]
+   [:p]
 
-(defmethod ws/event-msg-handler :tournament/created [{data :?data}]
-  (store-results state "created" data))
+   ;; table of all active competitive lobbies
+   [:table {:style {:border-collapse "collapse"
+                    :text-align "center"
+                    :width "100%"}}
+    [:thead
+     [:tr
+      (for [h ["Lobby name" "Corporation" "Runner" "Excluded?" "Time ext (min)"]]
+        ^{:key h} [:th {:style {:border "1px solid #ccc" :padding "4px"}} h])]]
 
-(defmethod ws/event-msg-handler :tournament/deleted [{data :?data}]
-  (store-results state "deleted" data))
+    [:tbody
+     (doall
+       (for [{:keys [gameid title corp runner excluded? time-extension] :as row} @stored-tables
+             :let [idx (.indexOf @stored-tables row)]]
+         ^{:key gameid}
+         [:tr
+          [:td title]
+          [:td corp]
+          [:td runner]
+          [:td [:input {:type "checkbox"
+                        :checked (if excluded? true false)
+                        :on-change #(swap! stored-tables update-in [idx :excluded?] not)}]]
+          [:td [:input {:type "number"
+                        :min 0
+                        :step 1
+                        :value (or time-extension 0)
+                        :on-change #(let [v (.. % -target -valueAsNumber)]
+                                      (swap! stored-tables assoc-in [idx :time-extension] v))
+                        :style {:width "10ch"}}]]]))]]])
+
+(defn- split-players [competitive-lobbies]
+  (mapv (fn [lobby]
+          (let [corp   (filter #(= (:side % nil) "Corp")   (:players lobby))
+                runner (filter #(= (:side % nil) "Runner") (:players lobby))]
+            (-> lobby
+                (assoc :corp (:uid corp "-") :runner (:uid runner "-"))
+                (dissoc :players))))
+        competitive-lobbies))
+
+(defn active-round-section []
+  [:div
+   [:h3 "Active Round"]
+   [:div [:button
+          {:type "button"
+           ;; TODO - sent a thing to refresh the tournament lobbies
+           :on-click (fn []
+                       (ws/ws-send! [:tournament/view-tables {}])
+                       (non-game-toast "refreshing tables..." "info" nil))}
+          "Refresh State"]]
+   (if-not @active-round
+     [:div "There is no currently active round. Set one up below."]
+     [:div "There is currently an active round. TODO: fixme"]
+     ;; TODO
+     )
+   [:p]])
+
+(defmethod ws/event-msg-handler :tournament/view-tables [{{:keys [competitive-lobbies tournament-state]} :?data}]
+  (let [player-split (split-players competitive-lobbies)]
+    (reset! stored-tables player-split)
+    (reset! action-summary (filter #(or (pos? (:time-extension % 0))(:excluded? %)) player-split)))
+  (reset! active-round tournament-state)
+  (non-game-toast "tables refreshed!" "info" nil))
 
 (defn tournament []
-  (r/with-let [user (r/cursor app-state [:user])
-               cobra-link (r/cursor state [:cobra-link])
-               games (r/cursor app-state [:games])]
+  (r/with-let [user (r/cursor app-state [:user])]
+    ;; this is bad practice I think? I will fix it later
     [:div.container
      [:div.about-bg]
      (when (:tournament-organizer @user)
-       [:div.lobby.panel.blue-shade
-        [tournament-container state]
-        [:ul.game-list
-         (let [filtered-games (filter #(and @cobra-link (= @cobra-link (:cobra-link %))) @games)]
-           (doall (for [game filtered-games]
-                    ^{:key (:gameid game)}
-                    [game-info game])))]])]))
+       [:div.container.panel.blue-shade.content-page
+        [:h1 "Tournament Manager"]
+        [:hr] [active-round-section]
+        [:hr] [timer-management]
+        [:hr] [tournament-lobbies-container]])]))


### PR DESCRIPTION
I finally decided to tackle a user friendly tournament helper.

Essentially:
* This is functionality to help manage rounds
* You can set the round time, time until start, end message, rules reminder, etc
* You can manage time extensions, and exclude tables from the ongoing timer if you like (ie some asynch is playing at the same time, you don't want to bother those players)
* players get notified on any alerts given, and when the round ends
* players that join after you set up the thing get registered, active lobbies beforehand get registered, only applies to comp lobby
* Round end time (and time extensions) get displayed to users in the gameboard
* summary of actions is displayed in the top of the TO area

WIP example:
<img width="238" height="178" alt="alerts" src="https://github.com/user-attachments/assets/0bec2d11-3af8-4165-9ce4-68cfb91548d5" />
<img width="514" height="801" alt="manager" src="https://github.com/user-attachments/assets/63f8bb94-fab1-4554-be54-ca04078e6685" />

Closes #4046 (the feature already exists in that you can time games, but this will be a definitive close - note that strict enforcement is bad because TO's have discretion over their time policies)
Closes #7454
