### PR TITLE
add configurable password reset email parameters

### DIFF
--- a/resources/dev.edn
+++ b/resources/dev.edn
@@ -25,7 +25,10 @@
  :web/email {:host nil
              :user nil
              :pass nil
-             :ssl  nil}
+             :ssl  nil
+             :from "support@jinteki.net"
+             :reset-subject "Jinteki Password Reset"
+             :confirm-reset-subject "Your password has been changed"}
  :web/app {:server-mode #ig/ref :server/mode
            :mongodb/connection #ig/ref :mongodb/connection
            :web/auth #ig/ref :web/auth

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -225,9 +225,9 @@
     (let [code (set-password-reset-code! db email)
           msg (mail/send-message
                 email-settings
-                {:from    "support@jinteki.net"
+                {:from    (get email-settings :from "support@jinteki.net")
                  :to      email
-                 :subject "Jinteki Password Reset"
+                 :subject (get email-settings :reset-subject "Jinteki Password Reset")
                  :body    (str "You are receiving this because you (or someone else) have requested the reset of the password for your account " (user :username) ".\n\n"
                                "Please click on the following link, or paste this into your browser to complete the process:\n\n"
                                "http://" (headers "host") "/reset/" code "\n\n"
@@ -254,9 +254,9 @@
                             :resetPasswordToken   nil}})
         (mail/send-message
           email-settings
-          {:from    "support@jinteki.net"
+          {:from    (get email-settings :from "support@jinteki.net")
            :to      email
-           :subject "Your password has been changed"
+           :subject (get email-settings :confirm-reset-subject "Your password has been changed")
            :body    (str "Hello,\n\n"
                          "This is a confirmation that the password for your account "
                          email " has just been changed.\n")})


### PR DESCRIPTION
Allow private servers to customize password reset emails sender and subject. Maintains backward compatibility with hardcoded defaults.