### PR TITLE
Touch up to interface

### DIFF
--- a/src/clj/web/admin.clj
+++ b/src/clj/web/admin.clj
@@ -94,6 +94,7 @@
            (or (:isadmin user)
                (and (:ismoderator user)
                     (or (= user-type :specials)
+                        (= user-type :tos)
                         (= user-type :banned))))
            (not-empty username))
     (let [field (user-type->field user-type)

--- a/src/clj/web/tournament.clj
+++ b/src/clj/web/tournament.clj
@@ -53,7 +53,7 @@
   [keyvec]
   (when-let [{:keys [stop-chan]} (get-in @tasks keyvec nil)]
     (async/close! stop-chan)
-    (swap! tasks dissoc key)))
+    (swap! tasks assoc-in keyvec nil)))
 
 (defn cancel-tasks-for-lobby!
   "Cancel tasks for a given lobby"
@@ -66,8 +66,8 @@
   []
   (doseq [outer (keys @tasks)
           inner (keys (get @tasks outer []))]
-    (cancel-task! [outer inner])
-    (reset! tasks {})))
+    (cancel-task! [outer inner]))
+  (reset! tasks {}))
 
 (defn schedule-task
   "schedules a task under `keyvec` to occur at `time`.

--- a/src/cljs/nr/tournament.cljs
+++ b/src/cljs/nr/tournament.cljs
@@ -246,6 +246,22 @@
 
    [:p]])
 
+(defn announce-section []
+  (r/with-let [announce-text (r/atom {:msg ""})]
+    [:div
+     [:h3 "Announcements"]
+     ;; print a message that the round is starting
+     [:fieldset
+      [:legend "Announce"]
+      [text-helper announce-text [:msg]
+       "Make an announcement to all non-excluded tournament lobbies"]
+      [cond-button "Announce"
+       (not (str/blank? (:msg @announce-text)))
+       (fn []
+         (non-game-toast "announcing..." "info" nil)
+         (ws/ws-send! [:tournament/announce @announce-text])
+         (reset! announce-text {:msg ""}))]]]))
+
 (defn tournament []
   (r/with-let [user (r/cursor app-state [:user])]
     [:div.container
@@ -253,6 +269,7 @@
      (when (:tournament-organizer @user)
        [:div.container.panel.blue-shade.content-page
         [:h1 "Tournament Manager"]
+        [:hr] [announce-section]
         [:hr] [active-round-section]
         [:hr] [timer-management]
         [:hr] [tournament-lobbies-container]])]))


### PR DESCRIPTION
A few touch-ups to the TO interface.
* Pending messages get flushed when the round is concluded
* You can explicitly announce things to tournament lobbies
* Visibility is better
* Uses the game-thread when announcing to avoid double-sending message diffs to the frontend with competing atom updates