### PR TITLE
Add multi-deck deletion feature

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -138,9 +138,18 @@ deck-builder_card-name = Card name
 
 deck-builder_clear-stats = Clear Stats
 
+deck-builder_cleanup-decks = Cleanup decks...
+
+deck-builder_cannot-be-undone = This cannot be undone.
+
 deck-builder_completed = Completed: {$completed}
 
 deck-builder_confirm-delete = Confirm Delete
+
+deck-builder_confirm-delete-multiple = Delete {$cnt ->
+    [one] {$cnt} selected deck
+    *[other] {$cnt} selected decks
+}?
 
 deck-builder_copy = Copy
 
@@ -171,6 +180,20 @@ deck-builder_decklist = Decklist
 deck-builder_decklist-inst = (Type or paste a decklist, it will be parsed)
 
 deck-builder_delete = Delete
+
+deck-builder_delete-selected = Delete Selected
+
+deck-builder_deleted-decks-success = Deleted {$cnt ->
+    [one] {$cnt} deck
+    *[other] {$cnt} decks
+}
+
+deck-builder_deletion-success-and-or-failure = Deleted {$success ->
+    [one] {$success} deck
+    *[other] {$success} decks
+}. {$failed} failed.
+
+deck-builder_deletion-in-progress = Deck deletion in progress. Leaving this page may cause issues.
 
 deck-builder_edit = Edit
 
@@ -218,9 +241,13 @@ deck-builder_reset = Reset
 
 deck-builder_save = Save
 
+deck-builder_select-all = Select All
+
 deck-builder_show-credit-cost = Show Credit Cost
 
 deck-builder_show-memory-cost = Show Memory Cost
+
+deck-builder_unselect-all = Unselect All
 
 deck-builder_view-options = View Options
 

--- a/resources/public/i18n/fr.ftl
+++ b/resources/public/i18n/fr.ftl
@@ -116,9 +116,18 @@ deck-builder_card-name = Nom de la carte
 
 deck-builder_clear-stats = Effacer les statistiques
 
+deck-builder_cleanup-decks = Nettoyer les decks...
+
+deck-builder_cannot-be-undone = Ceci ne peut pas être annulé.
+
 deck-builder_completed = Terminées: {$completed}
 
 deck-builder_confirm-delete = Confirmer l'effacement
+
+deck-builder_confirm-delete-multiple = Supprimer {$cnt ->
+    [one] {$cnt} deck sélectionné
+    *[other] {$cnt} decks sélectionnés
+}?
 
 deck-builder_create-game = Créer une partie
 
@@ -145,6 +154,20 @@ deck-builder_decklist = Liste de cartes
 deck-builder_decklist-inst = (Saisissez ou copiez une liste, elle sera analysée)
 
 deck-builder_delete = Effacer
+
+deck-builder_delete-selected = Supprimer la sélection
+
+deck-builder_deleted-decks-success = Supprimé {$cnt ->
+    [one] {$cnt} deck
+    *[other] {$cnt} decks
+}
+
+deck-builder_deletion-success-and-or-failure = Supprimé {$success ->
+    [one] {$success} deck
+    *[other] {$success} decks
+}. {$failed} ont échoué.
+
+deck-builder_deletion-in-progress = Suppression de deck en cours. Quitter cette page peut causer des problèmes.
 
 deck-builder_edit = Éditer
 
@@ -189,6 +212,10 @@ deck-builder_new-runner = Nouveau deck Runner
 deck-builder_notes = Notes
 
 deck-builder_reset = Réinitialiser
+
+deck-builder_select-all = Tout sélectionner
+
+deck-builder_unselect-all = Tout désélectionner
 
 deck-builder_save = Sauvegarder
 

--- a/resources/public/i18n/ja.ftl
+++ b/resources/public/i18n/ja.ftl
@@ -67,9 +67,15 @@ deck-builder_card-name = カード名
 
 deck-builder_clear-stats = 統計を削除
 
+deck-builder_cleanup-decks = デッキを整理...
+
+deck-builder_cannot-be-undone = これは元に戻せません。
+
 deck-builder_completed = 完了: {$completed}
 
 deck-builder_confirm-delete = 削除の実行
+
+deck-builder_confirm-delete-multiple = 選択した{$cnt}個のデッキを削除しますか？
 
 deck-builder_copy = コピー
 
@@ -98,6 +104,14 @@ deck-builder_decklist = カードリスト
 deck-builder_decklist-inst = ({"{"}枚数{"}"}[半角スペース]{"{"}カード名（英語）{"}"}で入力)
 
 deck-builder_delete = 削除
+
+deck-builder_delete-selected = 選択したものを削除
+
+deck-builder_deleted-decks-success = {$cnt}個のデッキを削除しました
+
+deck-builder_deletion-success-and-or-failure = {$success}個のデッキを削除しました。{$failed}個は失敗しました。
+
+deck-builder_deletion-in-progress = デッキの削除中です。このページを離れると問題が発生する可能性があります。
 
 deck-builder_edit = 編集
 
@@ -134,6 +148,10 @@ deck-builder_new-runner = 新規ランナー
 deck-builder_notes = メモ
 
 deck-builder_reset = リセット
+
+deck-builder_select-all = すべて選択
+
+deck-builder_unselect-all = すべて選択解除
 
 deck-builder_save = 保存
 

--- a/resources/public/i18n/ko.ftl
+++ b/resources/public/i18n/ko.ftl
@@ -111,9 +111,15 @@ deck-builder_card-name = 카드 이름
 
 deck-builder_clear-stats = 기록 초기화
 
+deck-builder_cleanup-decks = 덱 정리...
+
+deck-builder_cannot-be-undone = 이것은 복구할 수 없습니다.
+
 deck-builder_completed = 완료됨: {$completed}
 
 deck-builder_confirm-delete = 삭제 확인
+
+deck-builder_confirm-delete-multiple = 선택한 {$cnt}개의 덱을 삭제하시겠습니까?
 
 deck-builder_create-game = 게임 생성
 
@@ -136,6 +142,14 @@ deck-builder_decklist = 덱 리스트
 deck-builder_decklist-inst = (덱 리스트를 입력하거나 붙여 넣으십시오)
 
 deck-builder_delete = 삭제
+
+deck-builder_delete-selected = 선택 항목 삭제
+
+deck-builder_deleted-decks-success = {$cnt}개의 덱을 삭제했습니다
+
+deck-builder_deletion-success-and-or-failure = {$success}개의 덱을 삭제했습니다. {$failed}개가 실패했습니다.
+
+deck-builder_deletion-in-progress = 덱 삭제가 진행 중입니다. 이 페이지를 벗어나면 문제가 발생할 수 있습니다.
 
 deck-builder_edit = 편집
 
@@ -176,6 +190,10 @@ deck-builder_new-runner = 새로운 러너 덱
 deck-builder_notes = 메모
 
 deck-builder_reset = 리셋
+
+deck-builder_select-all = 모두 선택
+
+deck-builder_unselect-all = 모두 선택 해제
 
 deck-builder_save = 저장
 

--- a/resources/public/i18n/la-pig.ftl
+++ b/resources/public/i18n/la-pig.ftl
@@ -95,9 +95,18 @@ deck-builder_card-name = Ardcay amenay
 
 deck-builder_clear-stats = Earclay Atsstay
 
+deck-builder_cleanup-decks = Eanupclway ecksday...
+
+deck-builder_cannot-be-undone = Isthay annotcay ebay undoneway.
+
 deck-builder_completed = Ompletedcay: {$completed}
 
 deck-builder_confirm-delete = Onfirmcay Eleteday
+
+deck-builder_confirm-delete-multiple = Eleteday {$cnt ->
+    [one] {$cnt} electedsay eckday
+    *[other] {$cnt} electedsay ecksday
+}?
 
 deck-builder_create-game = Eatecray Amegay
 
@@ -124,6 +133,20 @@ deck-builder_decklist = Ecklistday
 deck-builder_decklist-inst = (Ypetay oryay astepay ayay ecklistday, ityay illway ebay arsedpay)
 
 deck-builder_delete = Eleteday
+
+deck-builder_delete-selected = Eleteday Electedsay
+
+deck-builder_deleted-decks-success = Eletedday {$cnt ->
+    [one] {$cnt} eckday
+    *[other] {$cnt} ecksday
+}
+
+deck-builder_deletion-success-and-or-failure = Eletedday {$success ->
+    [one] {$success} eckday
+    *[other] {$success} ecksday
+}. {$failed} ailedfay.
+
+deck-builder_deletion-in-progress = Eckday eletiond-ay in-ay ogrespay-ay. Eavinglay isthay agepay aymay ausecay issuesway.
 
 deck-builder_edit = Edityay
 
@@ -166,6 +189,10 @@ deck-builder_new-runner = Ewnay Unnerray eckday
 deck-builder_notes = Otesnay
 
 deck-builder_reset = Esetray
+
+deck-builder_select-all = Electsay Allway
+
+deck-builder_unselect-all = Unselectway Allway
 
 deck-builder_save = Avesay
 

--- a/resources/public/i18n/pl.ftl
+++ b/resources/public/i18n/pl.ftl
@@ -113,9 +113,19 @@ deck-builder_card-name = Nazwa karty
 
 deck-builder_clear-stats = Usuń statystyki
 
+deck-builder_cleanup-decks = Wyczyść talie...
+
+deck-builder_cannot-be-undone = Nie można tego cofnąć.
+
 deck-builder_completed = Ukończone: {$completed}
 
 deck-builder_confirm-delete = Potwierdź usunięcie
+
+deck-builder_confirm-delete-multiple = Usunąć {$cnt ->
+    [one] {$cnt} wybraną talię
+    [few] {$cnt} wybrane talie
+    *[other] {$cnt} wybranych talii
+}?
 
 deck-builder_create-game = Stwórz stół
 
@@ -140,6 +150,22 @@ deck-builder_decklist = Lista kart
 deck-builder_decklist-inst = (Wpisz lub wklej listę kart z talii, zostanie przeanalizowana)
 
 deck-builder_delete = Usuń
+
+deck-builder_delete-selected = Usuń zaznaczone
+
+deck-builder_deleted-decks-success = Usunięto {$cnt ->
+    [one] {$cnt} talię
+    [few] {$cnt} talie
+    *[other] {$cnt} talii
+}
+
+deck-builder_deletion-success-and-or-failure = Usunięto {$success ->
+    [one] {$success} talię
+    [few] {$success} talie
+    *[other] {$success} talii
+}. {$failed} nie powiodło się.
+
+deck-builder_deletion-in-progress = Usuwanie talii w toku. Opuszczenie tej strony może spowodować problemy.
 
 deck-builder_edit = Edytuj
 
@@ -180,6 +206,10 @@ deck-builder_new-runner = Nowa talia Runnera
 deck-builder_notes = Notatki
 
 deck-builder_reset = Zresetuj
+
+deck-builder_select-all = Zaznacz wszystko
+
+deck-builder_unselect-all = Odznacz wszystko
 
 deck-builder_save = Zapisz
 

--- a/resources/public/i18n/pt.ftl
+++ b/resources/public/i18n/pt.ftl
@@ -111,9 +111,18 @@ deck-builder_card-name = Nome da carta
 
 deck-builder_clear-stats = Limpar estatísticas
 
+deck-builder_cleanup-decks = Limpar baralhos...
+
+deck-builder_cannot-be-undone = Isso não pode ser desfeito.
+
 deck-builder_completed = Completas: {$completed}
 
 deck-builder_confirm-delete = Confirmar exclusão
+
+deck-builder_confirm-delete-multiple = Excluir {$cnt ->
+    [one] {$cnt} deck selecionado
+    *[other] {$cnt} decks selecionados
+}?
 
 deck-builder_copy = Copiar
 
@@ -144,6 +153,20 @@ deck-builder_decklist = Lista
 deck-builder_decklist-inst = (Digite ou cole a lista do baralho, ela sera filtrada)
 
 deck-builder_delete = Deletar
+
+deck-builder_delete-selected = Excluir selecionados
+
+deck-builder_deleted-decks-success = Deletado {$cnt ->
+    [one] {$cnt} deck
+    *[other] {$cnt} decks
+}
+
+deck-builder_deletion-success-and-or-failure = Deletado {$success ->
+    [one] {$success} deck
+    *[other] {$success} decks
+}. {$failed} falharam.
+
+deck-builder_deletion-in-progress = Exclusão de deck em andamento. Sair desta página pode causar problemas.
 
 deck-builder_edit = Editar
 
@@ -184,6 +207,10 @@ deck-builder_new-runner = Novo baralho de Runner
 deck-builder_notes = Notas
 
 deck-builder_reset = Resetar
+
+deck-builder_select-all = Selecionar tudo
+
+deck-builder_unselect-all = Desmarcar tudo
 
 deck-builder_save = Salvar
 

--- a/resources/public/i18n/ru.ftl
+++ b/resources/public/i18n/ru.ftl
@@ -128,9 +128,19 @@ deck-builder_card-name = Название карты
 
 deck-builder_clear-stats = Сбросить статистику
 
+deck-builder_cleanup-decks = Очистить колоды...
+
+deck-builder_cannot-be-undone = Это нельзя отменить.
+
 deck-builder_completed = Зав.: {$completed}
 
 deck-builder_confirm-delete = Подтвердить удаление
+
+deck-builder_confirm-delete-multiple = Удалить {$cnt ->
+    [one] {$cnt} выбранную колоду
+    [few] {$cnt} выбранные колоды
+    *[other] {$cnt} выбранных колод
+}?
 
 deck-builder_copy = Скопировать
 
@@ -165,6 +175,22 @@ deck-builder_decklist = Список карт
 deck-builder_decklist-inst = (Напишите или вставьте список карт, он будет распознан)
 
 deck-builder_delete = Удалить
+
+deck-builder_delete-selected = Удалить выбранные
+
+deck-builder_deleted-decks-success = Удалено {$cnt ->
+    [one] {$cnt} колода
+    [few] {$cnt} колоды
+    *[other] {$cnt} колод
+}
+
+deck-builder_deletion-success-and-or-failure = Удалено {$success ->
+    [one] {$success} колода
+    [few] {$success} колоды
+    *[other] {$success} колод
+}. {$failed} не удалось.
+
+deck-builder_deletion-in-progress = Удаление колоды в процессе. Покидание этой страницы может вызвать проблемы.
 
 deck-builder_edit = Изменить
 
@@ -207,6 +233,10 @@ deck-builder_new-runner = Создать Бегущего
 deck-builder_notes = Примечания
 
 deck-builder_reset = Сброс
+
+deck-builder_select-all = Выбрать все
+
+deck-builder_unselect-all = Снять выделение
 
 deck-builder_save = Сохранить
 

--- a/resources/public/i18n/zh-simp.ftl
+++ b/resources/public/i18n/zh-simp.ftl
@@ -138,9 +138,15 @@ deck-builder_card-name = 卡牌名称
 
 deck-builder_clear-stats = 清除统计数据
 
+deck-builder_cleanup-decks = 清理套牌...
+
+deck-builder_cannot-be-undone = 此操作无法撤销。
+
 deck-builder_completed = 完成: {$completed}
 
 deck-builder_confirm-delete = 确认删除
+
+deck-builder_confirm-delete-multiple = 删除已选择的{$cnt}个牌组吗？
 
 deck-builder_copy = 复制
 
@@ -171,6 +177,14 @@ deck-builder_decklist = 牌表
 deck-builder_decklist-inst = （在此输入或粘贴牌表，系统会自动解析）
 
 deck-builder_delete = 删除
+
+deck-builder_delete-selected = 删除所选
+
+deck-builder_deleted-decks-success = 已删除 {$cnt} 个牌组
+
+deck-builder_deletion-success-and-or-failure = 已删除 {$success} 个牌组。{$failed} 个失败。
+
+deck-builder_deletion-in-progress = 牌组删除进行中。离开此页面可能会导致问题。
 
 deck-builder_edit = 编辑
 
@@ -215,6 +229,10 @@ deck-builder_new-runner = 新建潜袭者牌组
 deck-builder_notes = 备注
 
 deck-builder_reset = 重置
+
+deck-builder_select-all = 全选
+
+deck-builder_unselect-all = 取消全选
 
 deck-builder_save = 保存
 

--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -73,6 +73,39 @@
                 button
                     width: 135px
 
+            .cleanup-link-container
+                text-align: right
+                float: right
+
+                .cleanup-link
+                    cursor: pointer
+                    color: gold-base // Override existing link styles
+                    font-weight: normal // Override existing link styles
+
+                    &:hover
+                        color: gold-light // Override existing link styles
+
+            .cleanup-button-bar
+                margin-bottom: 10px
+
+                button
+                    margin-right: 5px
+                    margin-bottom: 5px
+
+                    &.disabled
+                        opacity: 0.5 // Semi-transparent for disabled state
+                        cursor: not-allowed
+
+            .deckline
+                &.selected
+                    background-color: rgba(255, 215, 0, 0.1) // Subtle gold highlight for selected decks
+
+                .cleanup-checkbox
+                    margin-right: 8px // Space between checkbox and deck image
+                    margin-left: 2px // Small offset from left edge
+                    cursor: pointer
+                    vertical-align: middle
+
             .deckfilter
                 margin-bottom: 10px
 
@@ -247,7 +280,7 @@
         outline: none
         padding: 6px 12px
         color: white-solid
-        transition(all 0.2s ease-in-out) 
+        transition(all 0.2s ease-in-out)
         box-shadow(0 6px 12px alpha(black-solid, o-20))
 
         > div


### PR DESCRIPTION
This commit implements bulk deck deletion functionality in the deck builder:
- Add cleanup mode with deck selection checkboxes and selection controls
- Implement atomic bulk deletion with progress feedback and error handling
- Add confirmation modal with proper pluralization across 9 languages
- Discourages navigation during deletion to avoid data loss

Notes:
- This code was AI-assisted, but had several rounds of manual and AI review, focusing on adhering to Clojure style in the codebase.
- Translations were AI-generated and spot checked manually against Google Translate.