### PR TITLE
Sort show decklists by card type then alphabetically

### DIFF
--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -125,10 +125,22 @@
                      :type "Basic Action"
                      :title "Runner Basic Action Card"})))
 
+(defn- sort-deck-for-display
+  "Sorts deck cards by type then title for display in decklist"
+  [deck]
+  (->> deck
+       (group-by :title)
+       (map (fn [[title cards]]
+              [title (count cards) (:type (first cards))]))
+       (sort-by (fn [[title _qty card-type]]
+                  [card-type title]))
+       (map (fn [[title qty _type]]
+              [title qty]))))
+
 (defn- set-deck-lists
   [state]
-  (let [runner-cards (sort-by key (frequencies (map :title (get-in @state [:runner :deck]))))
-        corp-cards (sort-by key (frequencies (map :title (get-in @state [:corp :deck]))))]
+  (let [runner-cards (sort-deck-for-display (get-in @state [:runner :deck]))
+        corp-cards (sort-deck-for-display (get-in @state [:corp :deck]))]
     (swap! state assoc :decklists {:corp corp-cards :runner runner-cards})))
 
 (defn init-game


### PR DESCRIPTION
This commit sorts the "show decklists" list in the usual Agenda/Asset/Ice/Operation/Upgrade type order (and same for Runner).  This makes it easier for people to scan decklists for all the agendas or all the ice etc.