### PR TITLE
Add admin toggle to pause game creation for maintenance

### DIFF
--- a/resources/dev.edn
+++ b/resources/dev.edn
@@ -36,6 +36,8 @@
            :web/email #ig/ref :web/email}
  :web/banned-msg {:initial "Account Banned"
                   :mongo #ig/ref :mongodb/connection}
+ :web/pause-game-creation {:initial false
+                           :mongo #ig/ref :mongodb/connection}
  :web/i18n nil
  :frontend/version {:initial "1"
                     :mongo #ig/ref :mongodb/connection}

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -775,6 +775,8 @@ lobby_corp-perspective = Corp Perspective
 
 lobby_create = Create
 
+lobby_creation-paused = Game creation is currently paused for maintenance. Please try again later.
+
 lobby_deck-selected = Deck selected
 
 lobby_default-game-format = Default game format

--- a/resources/public/i18n/la-pig.ftl
+++ b/resources/public/i18n/la-pig.ftl
@@ -434,6 +434,8 @@ lobby_completion-rate = Amegay Ompletioncay Ateray
 
 lobby_create = Eatecray
 
+lobby_creation-paused = Amegay eationcray isyay urrentlycay ausedpay orfay aintenancemay. Easeplay itray againyay aterlay.
+
 lobby_deck-selected = Eckday electedsay
 
 lobby_delete = Eleteday Amegay

--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -80,6 +80,7 @@
       ["/language/:lang" {:get #'data/lang-handler}]]
      ["/chat/config" {:get #'chat/config-handler :middleware [::forgery]}]
      ["/messages/:channel" {:get #'chat/messages-handler :middleware [::forgery]}]
+     ["/pause-game-creation" {:get #'admin/pause-game-creation-handler :middleware [::forgery]}]
      ["/reset/:token" {:get #'pages/reset-password-page
                        :post #'auth/reset-password-handler}]
      ["/replay/:gameid" {:get #'stats/replay-handler :middleware [::forgery]}]
@@ -128,7 +129,8 @@
       ["/banned" {:get #'admin/banned-message-handler
                    :put #'admin/banned-message-update-handler}]
       ["/features" {:get #'admin/features-handler
-                    :put #'admin/features-update-handler}]]]
+                    :put #'admin/features-update-handler}]
+      ["/pause-game-creation" {:put #'admin/pause-game-creation-update-handler!}]]]
     {:reitit.middleware/registry
      {::auth auth/wrap-authentication-required
       ::tournament-auth auth/wrap-tournament-auth-required

--- a/src/clj/web/versions.clj
+++ b/src/clj/web/versions.clj
@@ -2,3 +2,4 @@
 
 (def frontend-version (atom nil))
 (def banned-msg (atom nil))
+(def pause-game-creation (atom false))

--- a/src/cljc/jinteki/messages.cljc
+++ b/src/cljc/jinteki/messages.cljc
@@ -1,0 +1,5 @@
+(ns jinteki.messages
+  "Shared UI message constants for client and server")
+
+(def ^:const game-creation-paused-msg
+  "Game creation is currently paused for maintenance. Please try again later.")

--- a/src/cljs/nr/admin.cljs
+++ b/src/cljs/nr/admin.cljs
@@ -14,7 +14,9 @@
 (def admin-state (r/atom {}))
 
 (go (swap! admin-state assoc :news (:json (<! (GET "/data/news")))))
-(go (when (:isadmin (:user @app-state)) (swap! admin-state assoc :version (:json (<! (GET "/admin/version"))))))
+(go (when (:isadmin (:user @app-state))
+      (swap! admin-state assoc :version (:json (<! (GET "/admin/version"))))
+      (swap! admin-state assoc :pause-game-creation (:json (<! (GET "/pause-game-creation"))))))
 
 (defn- post-data [url callback data]
   (go (let [response (<! (POST url data :json))]
@@ -70,9 +72,22 @@
                8000
                update-announce-response))
 
+(defn- update-pause-game-creation-response [response]
+  (if (= 200 (:status response))
+    (do
+      (go (swap! admin-state assoc :pause-game-creation (:json (<! (GET "/pause-game-creation")))))
+      (go (swap! app-state assoc :pause-game-creation (get-in response [:json :paused] false)))
+      (non-game-toast "Updated pause game creation setting" "success" nil))
+    (non-game-toast "Failed to update pause game creation" "error" nil)))
+
+(defn- update-pause-game-creation [paused]
+  (go (let [response (<! (PUT "/admin/pause-game-creation" {:paused paused} :json))]
+        (update-pause-game-creation-response response))))
+
 (defn admin-container []
   (r/with-let [news (r/cursor admin-state [:news])
                version (r/cursor admin-state [:version])
+               pause-game-creation (r/cursor admin-state [:pause-game-creation])
                s (r/atom {})]
     [:div.container.panel.blue-shade.content-page
      [:h3 "Site News"]
@@ -157,7 +172,16 @@
             disabled (s/blank? msg)]
         [:button {:disabled disabled
                   :class (if disabled "disabled" "")}
-         "Send"])]]))
+         "Send"])]
+
+     [:br]
+     [:h3 "Game Creation Control"]
+     [:div.panel.blue-shade
+      [:label
+       [:input {:type "checkbox"
+                :checked (get @pause-game-creation :paused false)
+                :on-change #(update-pause-game-creation (.. % -target -checked))}]
+       " Pause new game creation (allows draining games before maintenance)"]]]))
 
 
 (defn admin []

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -53,12 +53,17 @@
              :visible-formats (load-visible-formats)
              :channels {:general [] :america [] :europe [] :asia-pacific [] :united-kingdom [] :français []
                         :español [] :italia [] :polska [] :português [] :sverige [] :stimhack-league [] :русский []}
-             :games [] :current-game nil})))
+             :games [] :current-game nil
+             :pause-game-creation false})))
 
 (go (let [lang (get-in @app-state [:options :language] "en")
           response (<! (GET (str "/data/language/" lang)))]
       (when (= 200 (:status response))
         (i18n/insert-lang! lang (:json response)))))
+
+(go (let [response (<! (GET "/pause-game-creation"))]
+      (when (= 200 (:status response))
+        (swap! app-state assoc :pause-game-creation (get-in response [:json :paused] false)))))
 
 (defn current-gameid [app-state]
   (get-in @app-state [:current-game :gameid]))

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -1,11 +1,12 @@
 (ns nr.new-game
   (:require
+   [jinteki.messages :refer [game-creation-paused-msg]]
    [jinteki.utils :refer [str->int]]
    [jinteki.preconstructed :refer [all-matchups matchup-by-key]]
    [nr.appstate :refer [app-state]]
    [nr.auth :refer [authenticated] :as auth]
    [nr.translations :refer [tr tr-format tr-side]]
-   [nr.utils :refer [slug->format]]
+   [nr.utils :refer [slug->format cond-button]]
    [nr.ws :as ws]
    [reagent.core :as r]))
 
@@ -42,9 +43,12 @@
 
 (defn button-bar [state lobby-state options]
   [:div.button-bar
-   [:button {:type "button"
-             :on-click #(create-game state lobby-state options)}
-    (tr [:lobby_create "Create"])]
+   [cond-button (tr [:lobby_create "Create"])
+    (not (:pause-game-creation @app-state))
+    #(create-game state lobby-state options)
+    (when (:pause-game-creation @app-state)
+      {:class "paused"
+       :title (tr [:lobby_creation-paused game-creation-paused-msg])})]
    [:button {:type "button"
              :on-click #(do (.preventDefault %)
                             (swap! lobby-state assoc :editing false))}

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -332,10 +332,14 @@
     "log-player-highlight-red-blue"))
 
 (defn cond-button
-  [text cond f]
-  (if cond
-    [:button {:on-click f :key text} text]
-    [:button.disabled {:key text} text]))
+  "Conditional button component. Renders enabled/disabled button based on condition.
+  Accepts optional attributes map to merge into button element."
+  ([text cond f]
+   (cond-button text cond f nil))
+  ([text cond f attrs]
+   (if cond
+     [:button (merge {:on-click f :key text} attrs) text]
+     [:button.disabled (merge {:key text} attrs) text])))
 
 (defn checkbox-button [on-text off-text on-cond f]
   (if on-cond

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -345,6 +345,13 @@ span.small
         box-shadow(none)
         border-color: gold-base
 
+    &.paused
+        background-color: rgba(255, 100, 100, 0.2)
+        border-color: #ff6b6b
+
+        &:hover, &:focus
+            border-color: #ff6b6b
+
 .rotated
     color: white-solid
     background-color: gray


### PR DESCRIPTION
Adds ability for admins to pause new game/lobby creation to allow draining active games before maintenance windows. Includes admin UI toggle, backend state management with persistence, and real-time broadcast of pause status to all connected users.  In addition to disabling buttons on the front-end, back-end handlers also check for paused game creation and reject creating lobbies or starting games when creation is paused.

Disclaimer: this was written with the assistance of Claude Code.  As always, I have reviewed the code thoroughly to the best of my ability and have prompted Claude to review for idiomatic Clojure that matches existing Clojure style within the repo.

<img width="692" height="631" alt="2025-10-05_13-03-26" src="https://github.com/user-attachments/assets/ec356f69-bc2e-4e66-9343-49d9be8084f8" />
<img width="834" height="258" alt="2025-10-05_13-04-21" src="https://github.com/user-attachments/assets/0b3cf4e1-b553-45a7-a36e-c6d340411ef6" />
