### PR TITLE
translations: Add card language option

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1360,6 +1360,8 @@ settings_card-iamge = Card Image
 
 settings_card-images = Card images
 
+settings_card-language = Card language
+
 settings_card-preview-zoom = Card preview zoom
 
 settings_card-text = Card Text

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -391,6 +391,7 @@
    :corp-card-sleeve
    :runner-card-sleeve
    :language
+   :card-language
    :pronouns
    :show-alt-art])
 

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -118,6 +118,11 @@
     :sync? true
     :validate-fn #(contains? valid-card-back-display %)
     :doc "Which card backs to display (them/me/ffg/nsg)"}
+   {:key :card-language
+    :default "en"
+    :sync? true
+    :validate-fn #(contains? valid-languages %)
+    :doc "Card language preference"}
    {:key :card-resolution
     :default "default"
     :sync? false  ; device-specific

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -126,7 +126,7 @@
 
 (defn- reset-card-art [s]
   (let [art (:all-art-select @s)
-        lang (keyword (get-in @app-state [:options :language] "en"))
+        lang (keyword (get-in @app-state [:options :card-language] "en"))
         res (keyword (get-in @app-state [:options :card-resolution] "default"))]
     (doseq [card (vals @all-cards)]
       (update-card-art card art lang res s))))
@@ -318,10 +318,10 @@
               (for [option [{:name "English" :ref "en"}
                             {:name "Spanish" :ref "es"}
                             {:name "中文 (Simplified)" :ref "zh-simp"}
-                            {:name "中文 (Traditional) (Cards only)" :ref "zh-trad"}
+                            {:name "中文 (Traditional)" :ref "zh-trad"}
                             {:name "Français" :ref "fr"}
-                            {:name "Deutsch (Cards only)" :ref "de"}
-                            {:name "Italiano (Cards only)" :ref "it"}
+                            {:name "Deutsch" :ref "de"}
+                            {:name "Italiano" :ref "it"}
                             {:name "日本語" :ref "ja"}
                             {:name "한국어" :ref "ko"}
                             {:name "Polski" :ref "pl"}
@@ -331,6 +331,28 @@
                             {:name "Igpay Atinlay" :ref "la-pig"}]]
                 [:option {:value (:ref option) :key (:ref option)} (:name option)]))]
            [:div (tr [:settings_language-tip "Some languages are not fully translated yet. If you would like to help with translations, please contact us."])]]
+
+          [:section
+           [:h3 (tr [:settings_card-language "Card language"])]
+           [:select {:value (:card-language @s "en")
+                     :on-change #(swap! s assoc :card-language (.. % -target -value))}
+            (doall
+              (for [option [{:name "English" :ref "en"}
+                            {:name "Spanish" :ref "es"}
+                            {:name "中文 (Simplified)" :ref "zh-simp"}
+                            {:name "中文 (Traditional)" :ref "zh-trad"}
+                            {:name "Français" :ref "fr"}
+                            {:name "Deutsch" :ref "de"}
+                            {:name "Italiano" :ref "it"}
+                            {:name "日本語" :ref "ja"}
+                            {:name "한국어" :ref "ko"}
+                            {:name "Polski" :ref "pl"}
+                            {:name "Português" :ref "pt"}
+                            {:name "Русский" :ref "ru"}
+                            {:name "Catalan" :ref "ca"}
+                            {:name "Igpay Atinlay" :ref "la-pig"}]]
+                [:option {:value (:ref option) :key (:ref option)} (:name option)]))]]
+
           [:section
            [:h3 (tr [:settings_bespoke-sounds "Card-Specific Sounds"] {:sound "header"})]
            (doall
@@ -698,7 +720,7 @@
         scroll-top (atom 0)
         state (r/atom
                (-> (:options @app-state)
-                   (select-keys [:pronouns :bespoke-sounds :language :sounds :default-format
+                   (select-keys [:pronouns :bespoke-sounds :language :card-language :sounds :default-format
                                  :lobby-sounds :sounds-volume :background :custom-bg-url :card-zoom
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
                                  :player-stats-icons :stacked-cards :ghost-trojans

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -35,7 +35,7 @@
                   {} (:cards format))))
 
 (go (let [server-version (get-in (<! (GET "/data/cards/version")) [:json :version])
-          lang (get-in @app-state [:options :language] "en")
+          lang (get-in @app-state [:options :card-language] "en")
           local-cards (ls/load "cards" {})
           need-update? (or (not local-cards)
                            (not= server-version (:version local-cards))
@@ -185,7 +185,7 @@
 (defn image-url
   ([card] (image-url card false))
   ([card allow-all-users]
-   (let [lang (get-in @app-state [:options :language] "en")
+   (let [lang (get-in @app-state [:options :card-language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
          art (if (show-alt-art? allow-all-users)
                (get-in @app-state [:options :alt-arts (keyword (:code card))] "stock")
@@ -196,7 +196,7 @@
 (defn- base-image-url
   "The default card image. Displays an alternate image if the card is specified as one."
   [card]
-   (let [lang (get-in @app-state [:options :language] "en")
+   (let [lang (get-in @app-state [:options :card-language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
          art (if (keyword? (:art card)) (:art card) :stock)
          art-index (get card :art-index 0)]
@@ -210,7 +210,7 @@
 
 (defn- card-arts-for-key
   [card key]
-  (let [lang (get-in @app-state [:options :language] "en")
+  (let [lang (get-in @app-state [:options :card-language] "en")
         res (get-in @app-state [:options :card-resolution] "default")]
     (if-let [arts (or (get-in card [:images (keyword lang) (keyword res) key])
                       (get-in card [:images (keyword lang) :default key])
@@ -221,7 +221,7 @@
 
 (defn- expand-alts
   [only-version acc card]
-   (let [lang (get-in @app-state [:options :language] "en")
+   (let [lang (get-in @app-state [:options :card-language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
          alt-versions (remove #{:prev} (map keyword (map :version (:alt-info @app-state))))
          images (select-keys (merge (get-in (:images card) [(keyword lang) :default])
@@ -405,7 +405,7 @@
       (concat runner-factions corp-factions))))
 
 (defn- filter-alt-art-cards [cards]
-  (let [lang (get-in @app-state [:options :language] "en")
+  (let [lang (get-in @app-state [:options :card-language] "en")
         res (get-in @app-state [:options :card-resolution] "default")]
     (filter #(or (not-empty (dissoc (get-in (:images %) [(keyword lang) (keyword res)]) :stock))
                  (contains? % :future-version)
@@ -416,7 +416,7 @@
   (when-let [alt-key (alt-version-from-string setname)]
     (if (= alt-key :prev)
       (filter #(or (contains? % :future-version) (contains? % :previous-versions)) cards)
-      (let [lang (get-in @app-state [:options :language] "en")
+      (let [lang (get-in @app-state [:options :card-language] "en")
             res (get-in @app-state [:options :card-resolution] "default")]
         (filter #(get-in (:images %) [(keyword lang) (keyword res) alt-key]) cards)))))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -51,7 +51,7 @@
     @runner-prompt-state))
 
 (defn- image-url [{:keys [side code] :as card}]
-  (let [lang (get-in @app-state [:options :language] "en")
+  (let [lang (get-in @app-state [:options :card-language] "en")
         res (get-in @app-state [:options :card-resolution] "default")
         special-user (get-in @game-state [(keyword (lower-case side)) :user :special])
         special-wants-art (get-in @game-state [(keyword (lower-case side)) :user :options :show-alt-art])


### PR DESCRIPTION
The new card language option controls the language used for card data (which currently influences card data displayed in the card browser and card names displayed during games). The current language option now controls the language for the UI rather than all language settings.

This allows users to select different languages for the UI and card names, which is particularly useful if localized names are not known and/or commonly used.