### PR TITLE
disable turmoil

### DIFF
--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -78,7 +78,7 @@
 
 (defn- init-game-state
   "Initialises the game state"
-  [{:keys [players gameid timer spectatorhands api-access save-replay room turmoil] :as game}]
+  [{:keys [players gameid timer spectatorhands api-access save-replay room] :as game}]
   (let [corp (some #(when (corp? %) %) players)
         runner (some #(when (runner? %) %) players)
         corp-deck (create-deck (:deck corp))
@@ -106,7 +106,6 @@
         (inst/now)
         {:timer timer
          :spectatorhands spectatorhands
-         :turmoil turmoil
          :api-access api-access
          :save-replay save-replay}
         (new-corp (:user corp) corp-identity corp-options (map #(assoc % :zone [:deck]) corp-deck) corp-deck-id corp-quote)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -15,7 +15,6 @@
     [game.core.say :refer [system-msg]]
     [game.core.set-aside :refer [clean-set-aside!]]
     [game.core.toasts :refer [toast]]
-    [game.core.turmoil :as turmoil]
     [game.core.update :refer [update!]]
     [game.core.winning :refer [flatline]]
     [game.macros :refer [continue-ability req wait-for]]
@@ -73,10 +72,6 @@
     (swap! state assoc :click-states [])
     (swap! state dissoc :paid-ability-state)
     (swap! state assoc :turn-state (dissoc @state :log :history :turn-state))
-
-    ;; resolve turmoil (april fools)
-    (when (get-in @state [:options :turmoil])
-      (turmoil/shuffle-cards-for-side state side))
 
     (when (= side :corp)
       (swap! state update-in [:turn] inc))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -106,8 +106,7 @@
     user :user
     {:keys [gameid now
             allow-spectator api-access format mute-spectators password room save-replay
-            precon gateway-type side singleton spectatorhands timer title open-decklists
-            turmoil]
+            precon gateway-type side singleton spectatorhands timer title open-decklists]
      :or {gameid (random-uuid)
           now (inst/now)}} :options}]
   (let [player {:user user
@@ -131,7 +130,6 @@
      :mute-spectators mute-spectators
      :password (when (not-empty password) (bcrypt/encrypt password))
      :room room
-     :turmoil turmoil
      :save-replay save-replay
      :spectatorhands spectatorhands
      :singleton (when (some #{format} `("standard" "startup" "casual" "eternal")) singleton)
@@ -212,7 +210,6 @@
    :save-replay
    :singleton
    :spectators
-   :turmoil
    :corp-spectators
    :runner-spectators
    :spectatorhands

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -214,13 +214,12 @@
   (when (and open-decklists (not precon))
     [:span.open-decklists " " [tr-span [:lobby_open-decklists-b "(open decklists)"]]]))
 
-(defn game-format [{fmt :format singleton? :singleton turmoil? :turmoil precon :precon open-decklists :open-decklists}]
+(defn game-format [{fmt :format singleton? :singleton precon :precon open-decklists :open-decklists}]
   [:div {:class "game-format"}
    [:span.format-label [tr-span [:lobby_format "Format"]] ":  "]
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
    [precon-span precon]
    (when singleton? [:span.format-singleton " " [tr-span [:lobby_singleton-b "(singleton)"]]])
-   (when turmoil? [:span.turmoil " " [tr-span [:lobby_span-turmoil "(turmoil)"]]])
    [open-decklists-span precon open-decklists]
    [precon-under-span precon]])
 

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -18,7 +18,6 @@
    :save-replay
    :side
    :singleton
-   :turmoil
    :spectatorhands
    :precon
    :gateway-type
@@ -83,12 +82,6 @@
             :on-change #(swap! options assoc :singleton (.. % -target -checked))}]
    [tr-span [:lobby_singleton "Singleton"]]])
 
-(defn turmoil-mode [options]
-  [:span [:label
-          [:input {:type "checkbox" :checked (:turmoil @options)
-                   :on-change #(swap! options assoc :turmoil (.. % -target -checked))}]
-          [tr-span [:lobby_turmoil "Turmoil"]]]])
-
 (defn open-decklists [options]
   [:label
    [:input {:type "checkbox" :checked (:open-decklists @options)
@@ -135,13 +128,8 @@
         ^{:key k}
         [:option {:value k} (tr-format v)]))]
    [singleton-only options fmt-state]
-   [turmoil-mode options]
    [gateway-constructed-choice fmt-state gateway-type]
    [precon-choice fmt-state precon]
-   [:div.infobox.blue-shade
-    {:style {:display (if (:turmoil @options) "block" "none")}}
-    [tr-element :p [:lobby_turmoil-details "The fickle winds of fate shall decide your future."]]
-    [tr-element :p [:lobby_turmoil-theme "\"FINUKA DISPOSES\""]]]
    [:div.infobox.blue-shade
     {:style {:display (if (:singleton @options) "block" "none")}}
     [tr-element :p [:lobby_singleton-details "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."]]
@@ -264,7 +252,6 @@
                                 :protected false
                                 :save-replay (not= "casual" (:room @lobby-state))
                                 :singleton false
-                                :turmoil false
                                 :spectatorhands false
                                 :open-decklists false
                                 :timed false

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -110,11 +110,6 @@
     [:div.infobox.blue-shade
      [tr-element :p [:lobby_singleton-restriction "This lobby is running in singleton mode. This means decklists will be restricted to only those which do not contain any duplicate cards."]]]))
 
-(defn turmoil-info-box [current-game]
-  (when (:turmoil-mode @current-game)
-    [:div.infobox.blue-shade
-     [tr-element :p [:lobby_turmoil-info "This lobby is running in turmoil mode. The winds of fate shall decide your path to the future."]]]))
-
 (defn swap-sides-button [user gameid players]
   (when (first-user? @players @user)
     (if (< 1 (count @players))
@@ -221,7 +216,6 @@
       [:h2 (:title @current-game)]
       [precon-info-box current-game]
       [singleton-info-box current-game]
-      [turmoil-info-box current-game]
       (when-not (or (every? :deck @players)
                     (not (is-constructed? current-game)))
         [tr-element :div.flash-message [:lobby_waiting "Waiting players deck selection"]])


### PR DESCRIPTION
Disables the april fools mode from earlier this year.

I don't think it's used, and all I've seen it do recently is confuse new players :joy:. This should be easy to reverse whenever, and I left the `turmoil.clj` class around (and the css fragment because it's good) just incase I want to refer to it later.