### PR TITLE
fix #8436.

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1023,7 +1023,7 @@
           [facedown-card (:side @identity) ["bg"] nil])
         ;; todo - again, can we pass the server count into the tr?
         [:div.header {:class "darkbg server-label"}
-         [tr-span tr-vec {:cnt deck-count-number}]]
+         [tr-span tr-vec {:cnt deck-count-number}]]]
        (when (and (= render-side player-side) (not (is-replay?)))
          [:div.panel.blue-shade.menu {:ref #(swap! board-dom assoc menu-ref %)}
           [:div {:on-click #(do (send-command "shuffle")
@@ -1041,7 +1041,7 @@
           (doall
             (for [card @deck]
               ^{:key (:cid card)}
-              [card-view card]))])]])))
+              [card-view card]))])])))
 
 (defn discard-view-runner [player-side discard]
   (let [s (r/atom {})]


### PR DESCRIPTION
fix #8436 

I think the problem is that `deck-view` mistakenly adds `div.panel.blue-shade.menu` as the child node of `div.blue-shade.deck`. So when players click `Show` button of that menu, they also trigger the `on-click` event of `div.blue-shade.deck`, causing the opening popup window hides itself back.