### PR TITLE
Have i18n loader to skip empty translation files

### DIFF
--- a/src/cljc/jinteki/i18n.cljc
+++ b/src/cljc/jinteki/i18n.cljc
@@ -27,8 +27,9 @@
                               (let [res-path (str dir "/" lang ".ftl")
                                     ;; Try to load from classpath (including jar)
                                     res (io/resource res-path)]
-                                (when res
-                                  [lang (slurp res)])))))
+                                ;; Skip empty placeholder files
+                                (when-let [content (some-> res slurp not-empty)]
+                                  [lang content])))))
            errors (volatile! [])]
        (doseq [[lang content] langs]
          (try (insert-lang! lang content)


### PR DESCRIPTION
This prevents warnings when executing `lein run`.