### PR TITLE
Fix MU display not updating when programs installed

### DIFF
--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -38,13 +38,12 @@
 (defn- display-memory
   ([memory] (display-memory memory false))
   ([memory icon?]
-   (let [ctrl (stat-controls-for-side :runner)]
-     (fn []
-       (let [{:keys [available used only-for]} memory
-             unused (- available used)
-             label (if icon? [:<> unused "/" available " " [:span.anr-icon.mu]]
-                       [tr-span [:game_mu-count] {:unused unused :available available}])]
-         (ctrl :memory [:div label (when (neg? unused) [:div.warning "!"])]))))))
+   (let [ctrl (stat-controls-for-side :runner)
+         {:keys [available used]} memory
+         unused (- available used)
+         label (if icon? [:<> unused "/" available " " [:span.anr-icon.mu]]
+                   [tr-span [:game_mu-count] {:unused unused :available available}])]
+     (ctrl :memory [:div label (when (neg? unused) [:div.warning "!"])]))))
 
 (defn- display-special-memory
   ([memory] (display-special-memory memory false))


### PR DESCRIPTION
Fixes #8445. The display-memory function is a Reagent Form-2 component where the inner render function wasn't receiving updated memory parameters, causing the MU count to remain stale when programs were installed or uninstalled.

Moved the let bindings inside the inner render function so it receives and processes updated memory values on each render.

This fix is identical in nature to fee21af52 which fixed deck count rendering with the same root cause.