### PR TITLE
null is sayable

### DIFF
--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -215,11 +215,13 @@
      (->> (:all-cards-and-flips @app-state)
           (vals)
           (remove :replaced_by)
+          (filter :title)
           (map (fn [c] [(:title c) (span-of (:title c) (tr-data :title c))]))
           (sort-by (comp count str first) >))
      (->> (:all-cards-and-flips @app-state)
           (vals)
           (remove :replaced_by)
+          (filter :title)
           (map (fn [c] [(tr-data :title c) (span-of (:title c) (tr-data :title c))]))
           (sort-by (comp count str first) >))))))
 


### PR DESCRIPTION
The word `null` is currently not sayable because it tries to render a card named null with an empty span.

I *think* this is a consequence of how the tr-data interacts with the names, and specifically the rear-face names not being in the tr-data, and that returning nulls. I don't know any languages other than English, so this seems like the most straightforward solution.