### PR TITLE
allow reading rules inserts

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -152,6 +152,7 @@ card-type_name = {$type ->
     [program] Program
     [resource] Resource
     [upgrade] Upgrade
+    [rules-insert] Rules Insert
     *[unknown] Unknown card type ({$type})
 }
 
@@ -1442,6 +1443,7 @@ set_name = {$name ->
     [red-sand-cycle] Red Sand Cycle
     [reign-and-reverie] Reign and Reverie
     [revised-core-set] Revised Core Set
+    [rules] Rules Inserts
     [salsette-island] Salsette Island
     [salvaged-memories] Salvaged Memories
     [sansan-cycle] SanSan Cycle

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -361,9 +361,8 @@
        [:div.heading (tr [:card-browser_implementation-note "Implementation note"] {:impl impl})])
 
      [:div.text.card-body
-      (when (:type card)
-        [:p [:span.type (tr-type (:type card))]
-         (if-not subtypes "" (str ": " subtypes))])
+      [:p [:span.type (tr-type (:type card))]
+       (if-not subtypes "" (str ": " subtypes))]
       [:pre (render-icons (tr-data :text (get @all-cards (:title card))))]
 
       (when show-extra-info


### PR DESCRIPTION
Shockingly, all I needed to do was add a couple of translation keys and it's good to go.

~~They have the type `Rules Insert` in netrunner-data, but that seems to get lost somewhere along the way.~~

See Also:
https://github.com/NoahTheDuke/netrunner-data/pull/78
And I'm adding the inserts into my card translation pipeline, so we can fetch the images that way.

Closes #8470
