### PR TITLE
fix: show card preview on button hover too

### DIFF
--- a/src/cljs/nr/gameboard/card_preview.cljs
+++ b/src/cljs/nr/gameboard/card_preview.cljs
@@ -4,9 +4,15 @@
 
 (defonce zoom-channel (chan))
 
+(defn- safe-get-attribute [target attribute]
+  (when (.-getAttribute target)
+    (.getAttribute target attribute)))
+
 (defn- get-card-data-title [e]
   (let [target (.. e -target)
-        title (.getAttribute target "data-card-title")]
+        title (or (safe-get-attribute target "data-card-title")
+                  (when (= "BUTTON" (.-tagName target))
+                    (some-> target .-firstChild (safe-get-attribute "data-card-title"))))]
     (not-empty title)))
 
 (defn put-game-card-in-channel


### PR DESCRIPTION
This PR changes the preview to work on buttons, given the only child of that button would have triggered a preview.

I don't feel super confident this is the right approach, but `nr.utils/card-patterns-impl` is used in a lot of places and it felt risky to edit it.

Fix #8488
