### PR TITLE
set ws keepalive to 5 seconds

### DIFF
--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -19,7 +19,8 @@
 
 (let [chsk-server (sente/make-channel-socket-server!
                     (get-sch-adapter)
-                    {:user-id-fn (fn [ring-req]
+                    {:ws-kalive-ms 2500
+                     :user-id-fn (fn [ring-req]
                                    (or (-> ring-req :session :uid)
                                        (:client-id ring-req)))})
       {:keys [ch-recv send-fn connected-uids

--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -16,6 +16,7 @@
           "/chsk"
           ?csrf-token
           {:type (if (get-in @app-state [:options :disable-websockets]) :ajax :auto)
+           :ws-kalive-ms 2500 ;; note - supposedly this will help SEA/LATAM connections
            :wrap-recv-evs? false})]
     (def chsk chsk)
     (def ch-chsk ch-recv)


### PR DESCRIPTION
This sets the WS keepalive to 5 seconds, instead of the default 50 seconds (25000 x 2).

I know it says 2500ms, and not 5000ms - for info on that, see here: https://github.com/taoensso/sente/issues/455.

My local testing has the keepalives at about a millisecond away from 5 seconds.

## But why?

Supposedly this will help SEA and LATTAM players get less disconnects from their hostile networks.