### PR TITLE
logs destination fixes

### DIFF
--- a/src/clj/web/logs.clj
+++ b/src/clj/web/logs.clj
@@ -3,6 +3,8 @@
    [taoensso.timbre :as timbre]
    [clojure.java.io :as io]))
 
+(def home (System/getProperty "user.home"))
+
 (def default-appender
   {:enabled? true
    :async? true
@@ -10,7 +12,7 @@
    :output-fn timbre/default-output-fn
    :fn (fn [{:keys [level output_ context]}]
          (when-not (or (= level :error) (= level :fatal) (= (:type context) :moderator))
-           (spit "logs/clojure.log" (str @output_ "\n") :append true)))})
+           (spit (str home "/logs/jinteki-clojure.log") (str @output_ "\n") :append true)))})
 
 (def exceptions-appender
   {:enabled? true
@@ -19,7 +21,7 @@
    :output-fn timbre/default-output-fn
    :fn (fn [{:keys [output_]}]
          (println @output_)
-         (spit "logs/exceptions.log" (str @output_ "\n") :append true))})
+         (spit (str home "/logs/jinteki-exceptions.log") (str @output_ "\n") :append true))})
 
 (def mod-action-appender
   {:enabled? true
@@ -27,15 +29,15 @@
    :min-level :info
    :output-fn timbre/default-output-fn
    :fn (fn [{:keys [output_ context]}]
-         (when (= (:type context) :moderator))
-         (spit "logs/mod-actions.log" (str @output_ "\n") :append true))})
+         (when (= (:type context) :moderator)
+           (spit (str home "/logs/jinteki-mod-actions.log") (str @output_ "\n") :append true)))})
 
 (defn timbre-init!
   []
   (io/make-parents "logs/clojure.log")
   ;; clojure.log and exceptions.log can be cleaned up between each run
-  (when-let [f (io/file "logs/clojure.log")] (when (.exists f) (.delete f)))
-  (when-let [f (io/file "logs/exceptions.log")] (when (.exists f) (.delete f)))
+  (when-let [f (io/file (str home "/logs/jinteki-clojure.log"))] (when (.exists f) (.delete f)))
+  (when-let [f (io/file (str home "/logs/jinteki-exceptions.log"))] (when (.exists f) (.delete f)))
   ;; todo - back up the logs files or something like that
   ;; maybe we can actually just have an indexed html that points to different log files?
   ;; that would actually be sick as hell


### PR DESCRIPTION
I updated the logs destination so they live under ~/logs/...`

The mod actions one no longer captures all exceptions either.