### PR TITLE
Fix player panels not swapping when changing view during replay

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -2401,11 +2401,11 @@
                 [:div.inner-leftpane
                  [:div.left-inner-leftpane
                   [:div
-                   [stats-view opponent]
+                   ^{:key [:opponent op-side]} [stats-view opponent]
                    [scored-view op-scored op-agenda-point op-agenda-point-req false]]
                   [:div
                    [scored-view me-scored me-agenda-point me-agenda-point-req true]
-                   [stats-view me]]]
+                   ^{:key [:me me-side]} [stats-view me]]]
 
                  [:div.right-inner-leftpane
                   (let [op-rfg (r/cursor game-state [op-side :rfg])


### PR DESCRIPTION
It's been throwing me off that if you swap between runner/corp view in a replay, all elements (including scored agendas) swap placement _except_ for the player info and stats panels. This fixes that by adding React keys to the `stats-view` component.