### PR TITLE
option check yes-ability is valid

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2886,7 +2886,7 @@
 (defcard "Shattered Remains"
   (advance-ambush 1 {:async true
                      :waiting-prompt true
-                     :req (req (pos? (get-counters (get-card state card) :advancement)))
+                     :change-in-game-state {:req (req (pos? (get-counters (get-card state card) :advancement)))}
                      :prompt (msg "Choose " (quantify (get-counters (get-card state card) :advancement) "piece") " of hardware to trash")
                      :msg (msg "trash " (enumerate-cards targets))
                      :choices {:max (req (get-counters (get-card state card) :advancement))

--- a/src/clj/game/core/optional.clj
+++ b/src/clj/game/core/optional.clj
@@ -32,7 +32,10 @@
      (let [autoresolve-fn (:autoresolve ability)
            autoresolve-answer (when autoresolve-fn
                                 (autoresolve-fn state side eid card targets))
-           choices [(when (can-pay? state side eid card (:title card) (:cost (:yes-ability ability)))
+           choices [(when (and (can-pay? state side eid card (:title card) (:cost (:yes-ability ability)))
+                               (if-let [yesreq (-> ability :yes-ability :req)]
+                                 (yesreq state side eid card targets)
+                                 true))
                       "Yes")
                     "No"]]
        (case autoresolve-answer

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -5220,7 +5220,7 @@
       (take-credits state :corp)
       (run-empty-server state :remote1)
       (click-prompt state :corp "Yes")
-      (is (no-prompt? state :corp) "Corp shouldn't get Shattered Remains ability prompt when no counters")
+      (is (no-prompt? state :corp) "NCIGS because no counters, but you paid a credit to do that")
       (click-prompt state :runner "No action")
       (run-empty-server state :remote2)
       (let [credits (:credit (get-corp))]


### PR DESCRIPTION
Only unit test which failed was shattered remains, but that should be an ncigs blunder and not a do nothing blunder anyway so I fixed that.

Closes #8516
