### PR TITLE
trimmed down info sent a little

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -244,18 +244,18 @@
    :runner-credits])
 
 (defn prompt-summary
-  [prompt same-side?]
+  [prompt state side same-side?]
   (when same-side?
     (-> prompt
         (update :eid #(when (:eid %) (select-keys % [:eid])))
-        (update :card #(not-empty (select-non-nil-keys % card-keys)))
+        (update :card #(not-empty (card-summary % state side)))
         (update :choices (fn [choices]
                            (if (sequential? choices)
                              (->> choices
                                   (mapv
                                    (fn [choice]
                                      (if (-> choice :value :cid)
-                                       (update choice :value select-non-nil-keys card-keys)
+                                       (update choice :value #(not-empty (card-summary % state side)))
                                        choice)))
                                   (not-empty))
                              choices)))
@@ -303,7 +303,7 @@
       (update :rfg cards-summary state side)
       (update :scored cards-summary state side)
       (update :set-aside cards-summary state side)
-      (update :prompt-state prompt-summary same-side?)
+      (update :prompt-state prompt-summary state side same-side?)
       (update :toast toast-summary same-side?)
       (select-non-nil-keys (into player-keys additional-keys))))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -790,8 +790,6 @@
                  :on-mouse-enter #(reset! icon-hovered source-cid)
                  :on-mouse-leave #(reset! icon-hovered nil)}
                 char]))])
-        (when-let [c icon]
-          (prn icon))
         ;; (when-let [{:keys [char cid color]} icon]
         ;;   [:div.darkbg.icon {:class color} char])
       (when card-target [:div.darkbg.card-target card-target])


### PR DESCRIPTION
I made the card and buttons in prompts use card-summary when appropriate.
This should stop us sending so many anonymous functions and other useless things.

I think right now, `:msg` keys can still send anonymous functions to the client, so maybe we should tweak that.

Closes #8541