### PR TITLE
strip image list and other useless info from engine cards

### DIFF
--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -204,6 +204,7 @@
                 :highlight-in-discard (:highlight-in-discard cdef)
                 :printed-title (:title card))
          (dissoc :setname :text :_id :influence :number :influencelimit
+                 :images :previous-versions :rotated
                  :image_url :factioncost :format :quantity)
          (map->Card)))))
 


### PR DESCRIPTION
This appears to work fine locally, but I'm not sure what it's going to do on an actual server, so I'm going to try it out on playtest tomorrow.

This should cut a big chunk of data out of our diffs so we don't need to send it over and over.