### PR TITLE
Improved Output of Quotes Test

### DIFF
--- a/test/clj/game/quotes_test.clj
+++ b/test/clj/game/quotes_test.clj
@@ -8,8 +8,9 @@
 
 (deftest load-quotes-test
   (is (sut/load-quotes!))
-  (doseq [id (keys @sut/identity-quotes)]
-    (is (get @all-cards id)))
+  (doseq [id (keys @sut/identity-quotes)
+          :let [known-id? (get @all-cards id)]]
+    (is known-id? (format "%s is mispelled" (pr-str id))))
   (doseq [[id pairs] @sut/identity-quotes
           [pair-id pair-quotes] pairs
           :let [pair? (or (get @all-cards pair-id)


### PR DESCRIPTION
While I was doing some quote work I got some errors that the four new ids were unknown. Since I didn't have the Vantage Point spoilers loaded, that makes sense. However the errors were unreadable and took up 5.7M, due to the fact they contain the string showing all-cards.

I don't know much about this test framework, but this doesn't happen with the other misspelled key check (down to misspelling "mispelled"), so I just copied the format from there. Running it against my new quotes, the errors are the same but the messages are much more readable.