### PR TITLE
Added Vantage Point Quotes

### DIFF
--- a/data/quotes-corp.edn
+++ b/data/quotes-corp.edn
@@ -117,6 +117,13 @@
   "Default" ["Thinking of going up without paying fare? Take em' down."]
   "Shaper"
   ["A crafty one getting this far, but they won't go so far once the gravity flips."]}
+ "Editorial Division: Ad Nihilum"
+ {"Anarch"
+  ["We will be cleaning up your mess soon enough. No one will even notice."]
+  "Criminal"
+  ["You will find no worthy prize here. But the consequences remain."]
+  "Default" ["This battle will not be remembered."]
+  "Shaper" ["Most people would rather not find out what we can do."]}
  "Epiphany Analytica: Nations Undivided"
  {"Anarch" ["It will be easy enough to spin the story once they make a mess."]
   "Criminal"
@@ -299,6 +306,10 @@
   ["You may appreciate what you find, but that will not let you master it."]}
  "LEO Construction: Labor Solutions"
  {"Default" ["Workers of the World, Delivered"]}
+ "Méliès U: Only the Brightest"
+ {"Default" ["Who are you to interrupt our exploration of new ideas?"
+             "This is just another problem in the project to be solved."
+             "There are some questions you just shouldn't ask."]}
  "MirrorMorph: Endless Iteration"
  {"Anarch"
   ["Our subroutines estimate an 92.2% chance of such a reckless runner flatlining themself before even catching a glimpse of our servers. Simulations upon simulations wind up the same."]

--- a/data/quotes-runner.edn
+++ b/data/quotes-runner.edn
@@ -215,6 +215,16 @@
   "NBN"
   ["Such an astounding amount of data they collect and process. I think the professor would quite enjoy a term paper on this. Lets get to research!"]
   "Weyland Consortium" ["300% uptick in their strike force mobilisations? Oops...Did I do that?"]}
+ "Hiram \"0mission\" Svensson: Shadow of the Past"
+ {"Default" ["Old Hiram still has a few tricks left."]
+  "Editorial Division: Ad Nihilum" ["Don't tell me you have forgotten me too?"]
+  "Haas-Bioroid"
+  ["Every version comes with changes, some are improvements, but there is something about that one version that was almost made for you."]
+  "Jinteki"
+  ["Any dynamic system will change in unexpected ways if you leave it alone for a time."]
+  "NBN" ["They might be surprised by the things left behind."]
+  "Weyland Consortium"
+  ["The taller the towers get, the more they overlook those around the foundations."]}
  "Hoshiko Shiro: Untold Protagonist"
  {"Default" ["Do i have to?"]
   "Haas-Bioroid"
@@ -590,6 +600,8 @@
   ["I'd love to expose all your dirty truths to the world. Unfortunately, I don't have a year to spare."]
   "Weyland Consortium: Builder of Nations"
   ["They eradicate culture to build their towers. The only nation they've ever built is a throne for the highest bidder to oppress the masses."]}
+ "Virtual Intelligence, P.I.: \"You Can Call Me Vic\""
+ {"Default" ["I'll take the case."]}
  "Whizzard: Master Gamer"
  {"Default"
   ["This game is played in four dimensions. Never interupt your opponent while they are making a mistake."]


### PR DESCRIPTION
Added the default quotes for all Vantage Point ids, the full set for Hiram and Editorial Division (Hiram also got an identity quote for the Editorial Division).

This will probably fail the tests until the Vantage Point identities are added. But then it should all pass, I've checked the names as best I can manually.