### PR TITLE
fix: fallback to :printed-title on preview

### DIFF
--- a/src/cljs/nr/gameboard/card_preview.cljs
+++ b/src/cljs/nr/gameboard/card_preview.cljs
@@ -17,7 +17,7 @@
 
 (defn put-game-card-in-channel
   [card channel]
-  (if-let [server-card (get-in @app-state [:all-cards-and-flips (:title card)])]
+  (if-let [server-card (get-in @app-state [:all-cards-and-flips (or (:title card) (:printed-title card))])]
     (put! channel (merge server-card card))
     (put! channel card))
   nil)


### PR DESCRIPTION
Cards added to the score area as agenda via `convert-to-agenda` don't
have a title, but they have a printed title.

Fix #8562
Fix #8547
