### PR TITLE
Migrate the :breach-server event.

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1851,10 +1851,10 @@
                             state side
                             {:req (req
                                     (and tagged
-                                         (> (:random-access-limit (num-cards-to-access state :runner target nil)) 1)
+                                         (> (:random-access-limit (num-cards-to-access state :runner (:server context) nil)) 1)
                                          (not (get-only-card-to-access state))))
                              :msg (msg "make the runner access 1 card fewer")
-                             :effect (req (access-bonus state :runner target -1))}
+                             :effect (req (access-bonus state :runner (:server context) -1))}
                             card targets))}]})
 
 (defcard "Luana Campos"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -663,7 +663,7 @@
     {:makes-run true
      :on-play (run-server-ability :archives)
      :events [{:event :breach-server
-               :req (req (= target :archives))
+               :req (req (= :archives (:server context)))
                :silent true
                :effect (req (let [ts (distinct (map :title (:discard corp)))]
                               (update! state side
@@ -1891,7 +1891,7 @@
    :events [{:event :breach-server
              :automatic :pre-breach
              :async true
-             :req (req (and (= target :archives)
+             :req (req (and (= :archives (:server context))
                             ;; don't prompt unless there's at least 1 rezzed piece of ice matching one in Archives
                             (not-empty (set/intersection
                                          (into #{} (map :title (filter ice? (:discard corp))))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -186,7 +186,7 @@
      :automatic :pre-breach
      :async true
      :interactive (req true)
-     :req (req (and (= target :archives)
+     :req (req (and (= :archives (:server context))
                     (not= (:max-access run) 0)
                     (not-empty (:discard corp))))
      :effect (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
@@ -824,8 +824,8 @@
 (defcard "Docklands Pass"
   {:events [(breach-access-bonus
              :hq 1
-             {:req (req (and (= :hq target)
-                             (first-event? state side :breach-server #(= :hq (first %)))))
+             {:req (req (and (= :hq (:server context))
+                             (first-event? state side :breach-server #(= :hq (:server (first %))))))
               :msg "access 1 additional card from HQ"})]})
 
 (defcard "Doppelgänger"
@@ -2235,11 +2235,11 @@
   {:static-abilities [(mu+ 1)]
    :events [{:event :breach-server
              :automatic :pre-breach
-             :optional {:req (req (or (= target :rd) (= target :hq)))
+             :optional {:req (req (#{:hq :rd} (:server context)))
                         :prompt "Tag 1 tag to see an additional card?"
                         :yes-ability {:cost [(->c :gain-tag 1)]
-                                      :msg (msg "access 1 additional card from " (zone->name target))
-                                      :effect (effect (access-bonus target 1))}}}]
+                                      :msg (msg "access 1 additional card from " (zone->name (:server context)))
+                                      :effect (effect (access-bonus (:server context) 1))}}}]
    :corp-abilities [{:action true
                      :label "Trash Rotary"
                      :async true
@@ -2549,7 +2549,7 @@
   {:static-abilities [(mu+ 2)]
    :events [{:event :breach-server
              :automatic :pre-breach
-             :req (req (= :hq target))
+             :req (req (= :hq (:server context)))
              :effect (req (let [evs (run-events state side :subroutines-broken)
                                 relevant (filter #(let [context (first %)
                                                         t (get-card state (:ice context))]
@@ -2817,14 +2817,14 @@
             {:event :breach-server
              :automatic :pre-breach
              :async true
-             :req (req (and (= :rd target)
+             :req (req (and (= :rd (:server context))
                             (pos? (get-counters card :power))))
              :effect (req (continue-ability
                             state side
                             {:prompt "How many additional R&D accesses do you want to make?"
                              :choices {:number (req (min 3 (get-counters card :power)))
                                        :default (req (min 3 (get-counters card :power)))}
-                             :msg (msg "access " (quantify target "additional card") " from R&D")
+                             :msg (msg "access " (quantify (:server context) "additional card") " from R&D")
                              :waiting-prompt true
                              :async true
                              :effect (req (access-bonus state :runner :rd (max 0 target))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -315,7 +315,7 @@
   {:events [{:event :breach-server
              :automatic :pre-breach
              :interactive (req true)
-             :psi {:req (req (= target :rd))
+             :psi {:req (req (= :rd (:server context)))
                    :equal {:msg "access 1 additional card"
                            :async true
                            :effect (effect (access-bonus :rd 1)
@@ -1571,9 +1571,9 @@
              :automatic :pre-breach
              :req (req (and run
                             (empty? (run-events state side :subroutines-broken))
-                            (#{:hq :rd} target)))
+                            (#{:hq :rd} (:server context))))
              :async true
-             :effect (req (let [breached-server target]
+             :effect (req (let [breached-server (:server context)]
                             (continue-ability
                               state side
                               {:optional

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1076,7 +1076,7 @@
             {:event :breach-server
              :automatic :pre-breach
              :async true
-             :optional {:req (req (and (= :hq target)
+             :optional {:req (req (and (= :hq (:server context))
                                        (seq (filter corp? (:hosted card)))))
                         :prompt "1 [Credits]: Trash this program to access 2 additional cards from HQ?"
                         :yes-ability {:async true
@@ -1271,7 +1271,7 @@
              :skippable true
              :optional
              {:req (req (and (pos? (get-counters card :power))
-                             (= target :rd)))
+                             (= :rd (:server context))))
               :waiting-prompt true
               :prompt "Spend 1 hosted power counter to access 1 additional card?"
               :autoresolve (get-autoresolve :auto-fire)
@@ -1661,7 +1661,7 @@
              :automatic :pre-breach
              :async true
              :interactive (req true)
-             :req (req (and (= target :archives)
+             :req (req (and (= :archives (:server context))
                             (not-empty (:discard corp))))
              :effect (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                           (update! state side (assoc-in card [:special :host-available] true))
@@ -2233,7 +2233,7 @@
             {:event :breach-server
              :automatic :pre-breach
              :async true
-             :req (req (= target :rd))
+             :req (req (= :rd (:server context)))
              :effect (effect (continue-ability
                                {:req (req (< 1 (get-virus-counters state card)))
                                 :prompt "How many additional cards from R&D do you want to access?"
@@ -2390,7 +2390,7 @@
             {:event :breach-server
              :automatic :pre-breach
              :async true
-             :req (req (= target :hq))
+             :req (req (= :hq (:server context)))
              :effect (effect (continue-ability
                                {:req (req (< 1 (get-virus-counters state card)))
                                 :prompt "How many additional cards from HQ do you want to access?"
@@ -2457,7 +2457,7 @@
              :skippable true
              :optional
              {:req (req (and (pos? (get-counters card :power))
-                             (= target :rd)))
+                             (= :rd (:server context))))
               :waiting-prompt true
               :prompt "Spend 1 hosted power counter to access 1 additional card?"
               :autoresolve (get-autoresolve :auto-fire)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -856,10 +856,10 @@
                                      [{:event :breach-server
                                        :automatic :pre-breach
                                        :duration :until-runner-turn-ends
-                                       :req (req (#{:hq :rd} target))
+                                       :req (req (#{:hq :rd} (:server context)))
                                        :once :per-turn
                                        :msg (msg "access 2 additional cards from " (zone->name target))
-                                       :effect (effect (access-bonus :runner target 2))}]))}})]
+                                       :effect (effect (access-bonus :runner (:server context) 2))}]))}})]
     {:events [{:event :runner-turn-begins
                :async true
                :interactive (req true)
@@ -1447,7 +1447,7 @@
   {:events [{:event :breach-server
              :automatic :pre-breach
              :req (req (and (threat-level 3 state)
-                            (= :rd target)
+                            (= :rd (:server context))
                             (= :archives (first (:server run)))))
              :msg "access 1 additional card"
              :effect (effect (access-bonus :rd 1))}]
@@ -2263,9 +2263,9 @@
    :events [{:event :breach-server
              :automatic :pre-breach
              :req (req (and tagged
-                            (or (= target :rd) (= target :hq))))
-             :msg (msg "access 1 additional card from " (zone->name target))
-             :effect (effect (access-bonus target 1))}]})
+                            (#{:hq :rd} (:server context))))
+             :msg (msg "access 1 additional card from " (zone->name (:server context)))
+             :effect (effect (access-bonus (:server context) 1))}]})
 
 (defcard "\"Pretty\" Mary da Silva"
   {:implementation "only works after other abilities increasing the number of accesses have resolved"
@@ -2273,7 +2273,7 @@
              :automatic :last
              :async true
              :interactive (req true)
-             :req (req (and (= :rd target)
+             :req (req (and (= :rd (:server context))
                             (not (get-only-card-to-access state))))
              :effect (req
                        (let [num-access (:random-access-limit (num-cards-to-access state side :rd nil))]
@@ -2443,7 +2443,7 @@
 (defcard "Neutralize All Threats"
   {:events [(breach-access-bonus :hq 1)
             {:event :breach-server
-             :req (req (and (= target :archives)
+             :req (req (and (= :archives (:server context))
                             (seq (filter :trash (:discard corp)))))
              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
             {:event :pre-trash
@@ -3801,10 +3801,10 @@
              :automatic :pre-breach
              :async true
              :interactive (req true)
-             :req (req (#{:rd :hq} target))
+             :req (req (#{:rd :hq} (:server context)))
              :change-in-game-state {:silent true :req (req (pos? (get-counters card :power)))}
              :effect (req
-                       (let [target-server target]
+                       (let [target-server (:server context)]
                          (continue-ability
                            state side
                            {:prompt (msg "How many additional " (zone->name target-server) " accesses do you want to make?")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1402,7 +1402,9 @@
   ;; but another access is forced or credits are paid twice with something like
   ;; ganked into shiro or ganked into kitsune -nbkelly, 2022
   (let [mwanza-gain-creds
-        {:silent (req true)
+        {:event :end-breach-server
+         :duration :end-of-run
+         :silent (req true)
          :async true
          :unregister-once-resolved true
          :effect (req (if-let [accessed-cards (reduce + (vals (:cards-accessed target)))]
@@ -1412,38 +1414,34 @@
                             (gain-credits state :corp eid (* 2 accessed-cards)))
                         (effect-completed state side eid)))}
         unboost-access (fn [bonus-server]
-                         {:req (req (= (:from-server target) bonus-server))
+                         {:event :end-breach-server
+                          :duration :end-of-run
+                          :req (req (= (:from-server target) bonus-server))
                           :unregister-once-resolved true
                           :effect (req (access-bonus state :runner bonus-server -3))})
         boost-access-when-trashed (fn [bonus-server]
-                                    {:req (req (= target bonus-server))
+                                    {:event :breach-server
+                                     :duration :end-of-run
+                                     :req (req (= (:server context) bonus-server))
                                      :msg "force the runner to access 3 additional cards"
                                      :effect (req (access-bonus state :runner bonus-server 3)
                                                   (register-events
                                                    state side
                                                    card
-                                                   [(assoc mwanza-gain-creds
-                                                           :event :end-breach-server
-                                                           :duration :end-of-run)
-                                                    (assoc (unboost-access bonus-server)
-                                                           :event :end-breach-server
-                                                           :duration :end-of-run)]))})
-        boost-access-by-3 {:req (req (= target (second (get-zone card))))
+                                                   [mwanza-gain-creds
+                                                    (unboost-access bonus-server)]))})
+        boost-access-by-3 {:event :breach-server
+                           :req (req (= (:server context) (second (get-zone card))))
                            :msg "force the Runner to access 3 additional cards"
                            :effect (req (let [bonus-server (-> card :zone second)]
-
                                           (access-bonus state :runner bonus-server 3)
                                           (register-events
                                            state side
                                            card
-                                           [(assoc mwanza-gain-creds
-                                                           :event :end-breach-server
-                                                           :duration :end-of-run)
-                                            (assoc (unboost-access bonus-server)
-                                                   :event :end-breach-server
-                                                   :duration :end-of-run)])))}]
+                                           [mwanza-gain-creds
+                                            (unboost-access bonus-server)])))}]
     {:install-req (req (filter #{"HQ" "R&D"} targets))
-     :events [(assoc boost-access-by-3 :event :breach-server)]
+     :events [boost-access-by-3]
      ;; if there is a run, mark mwanza effects to remain active until the run
      :on-trash  {:req (req (and (= :runner side)
                                 (:run @state)))
@@ -1452,9 +1450,7 @@
                             (register-events
                              state side
                              card
-                             [(assoc (boost-access-when-trashed bonus-server)
-                                     :event :breach-server
-                                     :duration :end-of-run)])))}}))
+                             [(boost-access-when-trashed bonus-server)])))}}))
 
 (defcard "Nanisivik Grid"
   {:events [{:event :approach-server

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -1375,7 +1375,7 @@
   ([state side eid server] (breach-server state side eid server nil))
   ([state side eid server args]
    (system-msg state side (str "breaches " (zone->name server)))
-   (wait-for (trigger-event-simult state side :breach-server nil (first server))
+   (wait-for (trigger-event-simult state side :breach-server nil {:server (first server)})
              (swap! state assoc :breach {:breach-server (first server) :from-server (first server)})
              (let [args (clean-access-args args)
                    access-amount (num-cards-to-access state side (first server) nil)]

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -125,7 +125,7 @@
     :duration duration
     :req (if (:req args)
            (:req args)
-           (req (= server target)))
+           (req (= server (:server context))))
     :msg msg
     :effect (effect (access-bonus :runner server bonus))}))
 


### PR DESCRIPTION
Following some instructions given to be my NoahTheDuke in chat I have migrated the `:breach-server` event to use the new context map system. This was not the most interesting example of it (with only one argument) but the pattern works.

Although not required the implementation of Mwanza City Grid made this change harder, but obscuring which maps where connected to which events, so I inlined those assoc calls to make it more obvious. It also saved some lines of code.