### PR TITLE
Bangun shouldn't make agenda active when installing

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -538,9 +538,7 @@
 	        :choices {:req (req (and (agenda? target)
                                          (installed? target)))}
 		:msg (msg "turn " (card-str state target {:visible true}) " faceup")
-                :effect (req (update! state side (assoc target
-                                                        :seen true
-                                                        :rezzed true)))}]
+                :effect (req (update! state side (assoc target :seen true)))}]
    :events [{:event :access
              :req (req ((every-pred faceup? installed? agenda? :was-seen) target))
              :interactive (req true)
@@ -573,7 +571,7 @@
                                  {:prompt (str "Turn " (:title tcard) " faceup?")
                                   :waiting-prompt true
                                   :yes-ability {:msg (str "turn " (card-str state tcard {:visible true}) " faceup")
-                                                :effect (req (update! state side (assoc tcard :seen true :rezzed true)))}}}
+                                                :effect (req (update! state side (assoc tcard :seen true)))}}}
                                 {:prompt "Nothing to see here"
                                  :waiting-prompt true
                                  :choices ["OK"]})

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -4884,6 +4884,35 @@
       (play-from-hand state :runner "Respirocytes")
       (is (= 1 (count (:hand (get-runner)))) "Only 1 damage dealt to Runner from Cybernetics")))
 
+(deftest the-cleaners-not-active-when-turned-faceup-by-bangun
+  ;; The Cleaners should not boost meat damage when turned faceup by BANGUN but not scored
+  (do-game
+    (new-game {:corp {:id "BANGUN: When Disaster Strikes"
+                      :hand ["The Cleaners" "Scorched Earth"]
+                      :deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (play-from-hand state :corp "The Cleaners" "New remote")
+    (click-prompt state :corp "Yes")
+    (is (:seen (get-content state :remote1 0)) "The Cleaners is turned faceup by BANGUN")
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Scorched Earth")
+    (is (= 1 (count (:hand (get-runner)))) "Only 4 damage dealt - The Cleaners is not active while unscored")))
+
+(deftest the-cleaners-active-when-scored-after-being-turned-faceup-by-bangun
+  ;; The Cleaners should boost meat damage after being scored, even if previously turned faceup by BANGUN
+  (do-game
+    (new-game {:corp {:id "BANGUN: When Disaster Strikes"
+                      :hand ["The Cleaners" "Scorched Earth"]
+                      :deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (play-from-hand state :corp "The Cleaners" "New remote")
+    (click-prompt state :corp "Yes")
+    (is (:seen (get-content state :remote1 0)) "The Cleaners is turned faceup by BANGUN")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Scorched Earth")
+    (is (zero? (count (:hand (get-runner)))) "5 damage dealt - The Cleaners is active after being scored")))
+
 (deftest the-future-is-now-with-at-least-one-card-in-deck
     ;; With at least one card in deck
     (do-game

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1100,7 +1100,7 @@
     (play-from-hand state :corp "Hostile Takeover" "New remote")
     (click-prompt state :corp "Yes")
     (is (:seen (get-content state :remote1 0)) "HT is seen")
-    (is (:rezzed (get-content state :remote1 0)) "HT is considered rezzed")
+    (is (not (:rezzed (get-content state :remote1 0))) "HT is not considered rezzed")
     (take-credits state :corp)
     (run-empty-server state :remote1)
     (is (= 1 (count-tags state)) "Tagged")


### PR DESCRIPTION
Removed `:rezzed` from Bangun install action

Fixes #8519 