### PR TITLE
Migrate :reveal-spent-credits Event

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1258,9 +1258,10 @@
 (defcard "Fumiko Yamamori"
   {:events [{:event :reveal-spent-credits
              :async true
-             :req (req (and (some? (first targets))
-                            (some? (second targets))
-                            (not= (first targets) (second targets))))
+             :req (req (let [{:keys [corp-credits runner-credits]} context]
+                         (and (some? corp-credits)
+                              (some? runner-credits)
+                              (not= corp-credits runner-credits))))
              :msg "do 1 meat damage"
              :effect (effect (damage eid :meat 1 {:card card}))}]})
 
@@ -1450,11 +1451,11 @@
 
 (defcard "Hyoubu Research Facility"
   {:events [{:event :reveal-spent-credits
-             :req (req (and (some? (first targets))
+             :req (req (and (some? (:corp-credits context))
                             (first-event? state side :reveal-spent-credits)))
-             :msg (msg "gain " target " [Credits]")
+             :msg (msg "gain " (:corp-credits context) " [Credits]")
              :async true
-             :effect (effect (gain-credits :corp eid target))}]})
+             :effect (effect (gain-credits :corp eid (:corp-credits context)))}]})
 
 (defcard "Ibrahim Salem"
   (let [trash-ability (fn [card-type]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3059,7 +3059,7 @@
                               (system-msg state :corp (str (if correct-guess " " " in")
                                                            "correctly guesses " (decapitalize target)))
                               (wait-for
-                                (trigger-event-simult state side :reveal-spent-credits nil nil spent)
+                                (trigger-event-simult state side :reveal-spent-credits nil {:runner-credits spent})
                                 (if correct-guess
                                   (effect-completed state side eid)
                                   (do (system-msg state :runner (str "gains " (* 2 spent) " [Credits]"))
@@ -3326,7 +3326,7 @@
                             (lose-credits state :runner (make-eid state eid) spent)
                             (system-msg state :runner (str "spends " spent " [Credit]"))
                             (system-msg state :corp (str " guesses " target " [Credit]"))
-                            (wait-for (trigger-event-simult state side :reveal-spent-credits nil nil spent)
+                            (wait-for (trigger-event-simult state side :reveal-spent-credits nil {:runner-credits spent})
                                       (if (not= spent (str->int target))
                                         (continue-ability state :runner (choose-ice) card nil)
                                         (effect-completed state side eid)))))})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1903,8 +1903,8 @@
 
 (defcard "Nisei Division: The Next Generation"
   {:events [{:event :reveal-spent-credits
-             :req (req (and (some? (first targets))
-                            (some? (second targets))))
+             :req (req (and (some? (:corp-credits context))
+                            (some? (:runner-credits context))))
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits :corp eid 1))}]})

--- a/src/clj/game/core/psi.clj
+++ b/src/clj/game/core/psi.clj
@@ -32,7 +32,7 @@
           (pay state side (make-eid state eid) card (->c :credit bet))
           (system-msg state side (:msg async-result))
           (clear-wait-prompt state opponent)
-          (wait-for (trigger-event-simult state side (make-eid state eid) :reveal-spent-credits nil (get-in @state [:psi :corp]) (get-in @state [:psi :runner]))
+          (wait-for (trigger-event-simult state side (make-eid state eid) :reveal-spent-credits nil {:corp-credits (get-in @state [:psi :corp]) :runner-credits (get-in @state [:psi :runner])})
                     (let [card-side (if (corp? card) :corp :runner)]
                       (if-let [ability (if (= bet opponent-bet) (:equal psi) (:not-equal psi))]
                         (do (swap! state update-in [:stats card-side :psi-game :wins] (fnil + 0) 1)


### PR DESCRIPTION
The `:reveal-spent-credits` event now passes a map instead of a list. This one is actually a good use of the map, with multiple values not all of which are always passed.