### PR TITLE
Support meta-data when copying in a decklist

### DIFF
--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -1121,9 +1121,9 @@
          (:display-name card)]))]])
 
 (defn- lookup-identity-by-code
-  "Look up an identity card by card code. Returns nil if not found or not an identity."
-  [code]
-  (first (filter #(and (= (:code %) code) (= (:type %) "Identity"))
+  "Look up an identity card by card code and side. Returns nil if not found or not an identity."
+  [side code]
+  (first (filter #(and (= (:code %) code) (= (:type %) "Identity") (= (:side %) side))
                  (vals @all-cards))))
 
 (defn- lookup-identity-by-title
@@ -1151,7 +1151,7 @@
   (let [{:keys [cards meta]} (deck-string->list deck-string)
         parsed-cards (lookup-deck side cards)
         found-identity (or (when-let [c (:identity-code meta)]
-                             (lookup-identity-by-code c))
+                             (lookup-identity-by-code side c))
                            (when-let [t (:identity meta)]
                              (lookup-identity-by-title side t)))]
     {:cards parsed-cards


### PR DESCRIPTION
Added support for setting the identity, title, and notes of a deck in the decklist editor.
```
;; identity: Andromeda
;; identity-code: 36009
;; title: My world's winning deck
;; notes: probably not
```
You only need to specify one of `identity` or `identity-code`. If you use both, whichever one is last will take precedence.

Will make a PR against NRDB to export this info in the Jinetki copyable format.

Fixes #5775 