### PR TITLE
Ensure valid alt-art collection index

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -196,7 +196,9 @@
          art (if (sequential? alt-art) (first alt-art) alt-art)
          art-index (if (sequential? alt-art) (second alt-art) 0)
          images (image-or-face card)]
-     (nth (get-image-path images (keyword lang) (keyword res) (keyword art)) art-index))))
+     (let [art-urls (get-image-path images (keyword lang) (keyword res) (keyword art))
+           safe-index (min art-index (dec (count art-urls)))]
+       (nth art-urls safe-index)))))
 
 (defn- base-image-url
   "The default card image. Displays an alternate image if the card is specified as one."

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -69,7 +69,8 @@
          images (image-or-face card)]
      (if (sequential? art)
        (let [art-urls (get-image-path images (keyword lang) (keyword res) (keyword (first art)))
-             chosen-art (nth art-urls (second art))]
+             safe-index (min (second art) (dec (count art-urls)))
+             chosen-art (nth art-urls safe-index)]
          [chosen-art])
        (first (get-image-path images (keyword lang) (keyword res) (keyword art)))))))
 


### PR DESCRIPTION
It appears that some alt arts have invalid indexes in the `[collection index]` form. Perhaps from some earlier implementation. Clamp the index value to the last value in the collection.

This error causes a black screen in the deckbuilder and chat area when hovering over the card or card name. In game it causes a black screen for either player the card is visible to (assuming alt arts are configured to be seen by the other player).

Fixes #8601 
Fixes #8589 