### PR TITLE
cart art works for central cards again

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -251,7 +251,7 @@
   (when same-side?
     (-> prompt
         (update :eid #(when (:eid %) (select-keys % [:eid])))
-        (update :card #(not-empty (card-summary % state side)))
+        (update :card #(not-empty (select-keys % [:cid :title :printed-title :code :side])))
         (update :choices (fn [choices]
                            (if (sequential? choices)
                              (->> choices


### PR DESCRIPTION
Makes the card preview work on centrals again, but without the excessive amount of data it had previously.

Closes #8564