### PR TITLE
Add marker to central server to indicate Melies U selection

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -351,7 +351,8 @@
 (defn corp-summary
   [corp state side]
   (let [corp-player? (= side :corp)
-        install-list (:install-list corp)]
+        install-list (:install-list corp)
+        melies-target (get-in corp [:identity :melies-target])]
     (-> (player-summary corp state side corp-player? corp-keys)
         (assoc :agenda-point-req (agenda-points-required-to-win state :corp))
         (update :deck deck-summary corp-player? corp)
@@ -361,7 +362,9 @@
           :deck-count (count (:deck corp))
           :hand-count (count (:hand corp))
           :servers (servers-summary state side))
-        (cond-> (and corp-player? install-list) (assoc :install-list install-list)))))
+        (cond-> (and corp-player? install-list) (assoc :install-list install-list))
+        (cond-> (and corp-player? melies-target)
+                (assoc-in [:identity :melies-target] melies-target)))))
 
 (def runner-keys
   [:rig

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -960,6 +960,10 @@
   (-> ((keyword (str ref "-menu")) @board-dom) js/$ .fadeOut)
   (send-command "view-deck"))
 
+(defn- melies-marker [identity server-name]
+  (when (= (:melies-target @identity) server-name)
+    [:div.melies-marker "M"]))
+
 (defn identity-view [render-side identity hand-count]
   (let [is-runner (= :runner render-side)
         hand-count-str (str " (" hand-count ")")
@@ -968,6 +972,7 @@
                 [:game_hq-count (str "HQ" hand-count-str)])]
     [:div.blue-shade.identity
      [card-view @identity]
+     [melies-marker identity "HQ"]
      [:div.header {:class "darkbg server-label"}
       ;; TODO - can the tr take in hand count?
       [tr-span title {:cnt hand-count}]]]))
@@ -993,6 +998,7 @@
                                                (close-popup % (content-ref @board-dom) "stops looking at their deck" false true))))}
         (when (pos? deck-count-number)
           [facedown-card (:side @identity) ["bg"] nil])
+        [melies-marker identity "R&D"]
         ;; todo - again, can we pass the server count into the tr?
         [:div.header {:class "darkbg server-label"}
          [tr-span tr-vec {:cnt deck-count-number}]]]
@@ -1037,9 +1043,9 @@
             ^{:key (:cid card)}
             [card-view card]))]])))
 
-(defn discard-view-corp [player-side discard]
+(defn discard-view-corp [player-side identity discard]
   (let [s (r/atom {})]
-    (fn [player-side discard]
+    (fn [player-side identity discard]
       (let [draw-card #(if (faceup? %1)
                          [card-view %1 nil %2]
                          (if (or (= player-side :corp)
@@ -1050,6 +1056,7 @@
          [:div.blue-shade.discard {:on-click #(-> (:popup @s) js/$ .fadeToggle)}
           (when-not (empty? @discard)
             [:<> {:key "discard"} (draw-card (last @discard) true)])
+          [melies-marker identity "Archives"]
           [:div.header {:class (str "server-label "
                                     (if (some (if (or (= player-side :corp) (spectator-view-hidden?))
                                                 graveyard-highlight-card?
@@ -1293,7 +1300,7 @@
                     :run (when (= server-type "rd") @run)}]
       [server-view {:key "archives"
                     :server (:archives @servers)
-                    :central-view [discard-view-corp player-side discard]
+                    :central-view [discard-view-corp player-side identity discard]
                     :run (when (= server-type "archives") @run)}]]]))
 
 (defn- ghost-card

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -306,6 +306,22 @@
     .additional-subtypes
         background-color: gray-mid
 
+    .melies-marker
+        position: absolute
+        z-index: 10
+        top: 3px
+        right: 3px
+        padding: 0
+        text-align: center
+        line-height: 1.5rem
+        font-size: .75rem
+        height: 24px
+        width: 24px
+        border-radius: 4px
+        background: rgba(177, 65, 87, 0.8)
+        color: white-solid
+        font-weight: bold
+
     .abilities, .servers-menu, .menu, .runner-abilities, .corp-abilities, .encounter-info, .popup
         left: 0
         bottom: 100%


### PR DESCRIPTION
Update the corp diff to include the selected Melies U server. Add an `M` to that server (similar to how Boomerang marks the selected ice).

<img width="280" height="166" alt="melies" src="https://github.com/user-attachments/assets/832a9271-409a-443a-b6f3-7cec48145a24" />

