### PR TITLE
Add Unshare Replay option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ data/cards-zh-hant.edn
 
 # Coding agents
 .claude/
+.playwright-cli/

--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -115,6 +115,7 @@
         ["/publish/:gameid" {:get #'stats/publish-annotations}]
         ["/delete/:gameid" {:delete #'stats/delete-annotations}]]
        ["/share/:gameid" {:get #'stats/share-replay}]
+       ["/unshare/:gameid" {:get #'stats/unshare-replay}]
        ["/full/:gameid" {:get #'stats/fetch-replay}]]]
      ["/tournament-auth/:username" {:middleware [::auth ::tournament-auth ::forgery]
                                     :get #'tournament/auth}]

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -352,6 +352,23 @@
         (response 500 {:message "Server error"})))
     (response 401 {:message "Unauthorized"})))
 
+(defn unshare-replay
+  [{db :system/db
+    {username :username} :user
+    {:keys [gameid]} :path-params}]
+  (if username
+    (try
+      (mc/update db :game-logs
+                 {$and [{:gameid (str gameid)}
+                        {$or [{:corp.player.username username}
+                              {:runner.player.username username}]}]}
+                 {$set {:replay-shared false}})
+      (response 200 {:message "Unshared"})
+      (catch Exception e
+        (timbre/error e "Caught exception unsharing game")
+        (response 500 {:message "Server error"})))
+    (response 401 {:message "Unauthorized"})))
+
 (defn- get-winner-card
   [winner corp runner host]
   (let [default-img (str host "/img/icons/jinteki_167.png")]

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -34,11 +34,25 @@
   (update-deck-stats deck-id deckstats)
   (fetch-game-history))
 
+(defn- set-replay-shared [state gameid shared?]
+  (swap! state (fn [s]
+                 (-> s
+                     (assoc :view-game (assoc (:view-game s) :replay-shared shared?))
+                     (update :games (fn [games]
+                                      (mapv #(if (= (:gameid %) gameid)
+                                               (assoc % :replay-shared shared?)
+                                               %)
+                                            games)))))))
+
 (defn share-replay [state gameid]
   (go (let [{:keys [status]} (<! (GET (str "/profile/history/share/" gameid)))]
         (when (= 200 status)
-          (swap! state assoc :view-game
-                 (assoc (:view-game @state) :replay-shared true))))))
+          (set-replay-shared state gameid true)))))
+
+(defn unshare-replay [state gameid]
+  (go (let [{:keys [status]} (<! (GET (str "/profile/history/unshare/" gameid)))]
+        (when (= 200 status)
+          (set-replay-shared state gameid false)))))
 
 (defn- replay-link [game]
   (str (.-origin (.-location js/window)) "/replay/" (:gameid game)))
@@ -62,9 +76,10 @@
       (when (:stats game)
         [build-game-stats (get-in game [:stats :corp]) (get-in game [:stats :runner])])
       [:p
-       (when (and (:has-replay game)
-                  (not (:replay-shared game)))
-         [:button {:on-click #(share-replay state (:gameid game))} (tr [:stats_share "Share replay"])])
+       (when (:has-replay game)
+         (if (:replay-shared game)
+           [:button {:on-click #(unshare-replay state (:gameid game))} (tr [:stats_unshare "Unshare replay"])]
+           [:button {:on-click #(share-replay state (:gameid game))} (tr [:stats_share "Share replay"])]))
        (if (:has-replay game)
          [:span
           [:button {:on-click #(launch-replay game)} (tr [:stats_launch "Launch Replay"])]


### PR DESCRIPTION
Toggles `Share Replay/Unshare Replay` button. 
Adds new api endpoint to handle unshare call.

Fixes #6461 