### PR TITLE
Replay timestamp handling

### DIFF
--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -332,7 +332,9 @@
                 (= username (get-in runner [:player :username]))))
       (if (empty? replay)
         (response 404 {:message "Replay not found"})
-        (json-response 200 replay))
+        (json-response 200 (json/generate-string
+                             (assoc (json/parse-string replay true)
+                                    :replay-shared replay-shared))))
       (response 401 {:message "Unauthorized"}))))
 
 (defn share-replay
@@ -366,7 +368,7 @@
 (defn replay-handler
   [{db :system/db
     {:keys [gameid bugid]}        :path-params
-    {:keys [n d b]}               :query-params
+    {n "n", d "d", b "b"}         :query-params
     scheme                        :scheme
     headers                       :headers
     :as req}]

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -368,7 +368,7 @@
 (defn replay-handler
   [{db :system/db
     {:keys [gameid bugid]}        :path-params
-    {n "n", d "d", b "b"}         :query-params
+    {:strs [n d b]}               :query-params
     scheme                        :scheme
     headers                       :headers
     :as req}]

--- a/src/cljs/nr/gameboard/replay.cljs
+++ b/src/cljs/nr/gameboard/replay.cljs
@@ -343,7 +343,8 @@
                          :title "Forward to next log entry (→)"} "⏩︎"]
          [:button.small {:on-click #(replay-step-forward) :type "button"
                          :title "Forward one click (Ctrl + → )"} "⏭︎"]]
-        (when-not (= "local-replay" (:gameid @game-state)) ; when saved replay
+        (when (and (not= "local-replay" (:gameid @game-state))
+                   (:replay-shared @game-state))
           [:div.sharing
            [:input {:style (if @show-replay-link {:display "inline"} {:display "none"})
                     :type "text" :read-only true

--- a/src/cljs/nr/lobby.cljs
+++ b/src/cljs/nr/lobby.cljs
@@ -282,7 +282,7 @@
       (.replaceState (.-history js/window) {} "" "/play")
       (if bug-report?
         (start-shared-replay s replay-id {:bug (or b 0)})
-        (if (and (some? n) (some? d))
+        (if (and n d)
           (start-shared-replay s replay-id {:n n :d d})
           (start-shared-replay s replay-id nil)))
       (resume-sound)

--- a/src/cljs/nr/lobby.cljs
+++ b/src/cljs/nr/lobby.cljs
@@ -76,8 +76,9 @@
                200
                (let [replay (js->clj json :keywordize-keys true)
                      history (:history replay)
+                     replay-shared (:replay-shared replay)
                      init-state (first history)
-                     init-state (assoc init-state :gameid gameid)
+                     init-state (assoc init-state :gameid gameid :replay-shared replay-shared)
                      init-state (assoc-in init-state [:options :spectatorhands] true)
                      diffs (rest history)
                      init-state (assoc init-state :replay-diffs diffs)]
@@ -281,7 +282,7 @@
       (.replaceState (.-history js/window) {} "" "/play")
       (if bug-report?
         (start-shared-replay s replay-id {:bug (or b 0)})
-        (if (and n d)
+        (if (and (some? n) (some? d))
           (start-shared-replay s replay-id {:n n :d d})
           (start-shared-replay s replay-id nil)))
       (resume-sound)


### PR DESCRIPTION
Hide the `Share Timestamp` button in the replay UI if the replay is not already shared.
Handle passing in a timestamped replay link - parse the offset correctly.

Fixes #5580 