### PR TITLE
Removed Extra Checkpoint in Installation

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1802,26 +1802,7 @@
              :req (req (first-event? state :corp :server-created))
              :async true
              :msg "draw 1 card"
-             :effect (req
-                      (if-not (some #(= % :deck) (:zone target))
-                        (draw state :corp eid 1)
-                        (do
-                          ;; Register the draw to go off when the card is finished installing -
-                          ;;  this is after the checkpoint when it should go off, but is needed to
-                          ;;  fix the interaction between architect (and any future install from R&D
-                          ;;  cards) and NEH, where the card would get drawn before the install,
-                          ;;  fizzling it in a confusing manner. Because we only do it in this
-                          ;;  special case, there should be no gameplay implications. -nbkelly, 2022
-                          (register-events
-                           state side
-                           card
-                           [{:event :corp-install
-                             :interactive (req true)
-                             :duration (req true)
-                             :unregister-once-resolved true
-                             :async true
-                             :effect (effect (draw :corp eid 1))}])
-                          (effect-completed state side eid))))}]})
+             :effect (effect (draw :corp eid 1))}]})
 
 (defcard "Nebula Talent Management: Making Stars"
   (let [flip-effect

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -347,11 +347,10 @@
       (wait-for
         (pay state side (make-eid state (assoc eid :action action)) card costs)
         (if-let [payment-str (:msg async-result)]
-          (if (= server "New remote")
-            (do (queue-event state :server-created nil)
-                (make-rid state)
-                (corp-install-continue state side eid card server args slot payment-str))
-            (corp-install-continue state side eid card server args slot payment-str))
+          (do (when (= server "New remote")
+                (queue-event state :server-created nil)
+                (make-rid state))
+              (corp-install-continue state side eid card server args slot payment-str))
           (effect-completed state side eid)))
       ;; NOTE - Diwan and Network Exchange both alter the cost of installs
       ;; if it's not ice AND we can't afford it, there's nothing we can do

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -9,7 +9,7 @@
     [game.core.cost-fns :refer [ignore-install-cost? install-additional-cost-bonus install-cost]]
     [game.core.costs :refer [total-available-credits]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
-    [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events trigger-event-simult unregister-events]]
+    [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events unregister-events]]
     [game.core.effects :refer [is-disabled-reg? register-static-abilities unregister-static-abilities update-disabled-cards]]
     [game.core.flags :refer [turn-flag? zone-locked?]]
     [game.core.hosting :refer [has-ancestor? host]]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -348,9 +348,9 @@
         (pay state side (make-eid state (assoc eid :action action)) card costs)
         (if-let [payment-str (:msg async-result)]
           (if (= server "New remote")
-            (wait-for (trigger-event-simult state side :server-created nil card)
-                      (make-rid state)
-                      (corp-install-continue state side eid card server args slot payment-str))
+            (do (queue-event state :server-created nil)
+                (make-rid state)
+                (corp-install-continue state side eid card server args slot payment-str))
             (corp-install-continue state side eid card server args slot payment-str))
           (effect-completed state side eid)))
       ;; NOTE - Diwan and Network Exchange both alter the cost of installs


### PR DESCRIPTION
The `:server-created` event was triggered too early in the installation process. Effectively, there was a checkpoint between creating the server and installing the card. I asked the rules team and these things should be resolved at the same time.

The only knock on effect of this was that Near-Earth Hub had a work that would make it resolve this way when it mattered, this has been removed and replaced with a simple draw effect.