### PR TITLE
Migrated Draw Events

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3580,12 +3580,12 @@
               {:event :pre-runner-draw
                :req (req (and (first-event? state :runner :pre-runner-draw)
                               (< 1 (count (:deck runner)))
-                              (pos? target)))
+                              (pos? (:count context))))
                :once :per-turn
                :once-key :the-class-act-put-bottom
                :async true
                :effect
-               (req (let [cards (set-aside-for-me state :runner eid (take (inc target) (:deck runner)))]
+               (req (let [cards (set-aside-for-me state :runner eid (take (inc (:count context)) (:deck runner)))]
                       (continue-ability
                         state side
                         {:waiting-prompt true

--- a/src/clj/game/core/drawing.clj
+++ b/src/clj/game/core/drawing.clj
@@ -59,7 +59,7 @@
   ([state side eid n {:keys [suppress-event no-update-draw-stats]}]
    (if (zero? n)
      (effect-completed state side eid)
-     (wait-for (trigger-event-simult state side (make-eid state eid) (if (= side :corp) :pre-corp-draw :pre-runner-draw) nil n)
+     (wait-for (trigger-event-simult state side (make-eid state eid) (if (= side :corp) :pre-corp-draw :pre-runner-draw) nil {:count n})
        (let [n (+ n (get-in @state [:bonus :draw] 0))
              draws-wanted n
              active-player (get-in @state [:active-player])
@@ -104,7 +104,7 @@
                      (checkpoint state nil (make-eid state eid) nil)
                      (doseq [c (get-set-aside state side set-aside-eid)]
                        (move state side c :hand))
-                     (wait-for (trigger-event-sync state side (make-eid state eid) (if (= side :corp) :post-corp-draw :post-runner-draw) drawn-count)
+                     (wait-for (trigger-event-sync state side (make-eid state eid) (if (= side :corp) :post-corp-draw :post-runner-draw) {:count drawn-count})
                                (let [eid (make-result eid (-> @state side :register :currently-drawing (peek)))]
                                  (swap! state update-in [side :register :currently-drawing] pop)
                                  (effect-completed state side eid))))))


### PR DESCRIPTION
Migrated `:pre-corp-draw`, `:pre-runner-draw`, `:post-corp-draw` and `:post-runner-draw`. The central two events of `:corp-draw` and `:runner-draw` have already been migrated. Other than taking the `:count` key name from those events, I don't think there is much interesting about this one.