### PR TITLE
Handle html tags in card text

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -13,9 +13,9 @@
    [nr.local-storage :as ls]
    [nr.translations :refer [clean-input tr tr-data tr-faction tr-format tr-set
                             tr-side tr-type]]
-   [nr.utils :refer [banned-span buildable-format->slug deck-points-card-span faction-icon
-                     get-image-path image-or-face influence-dots
-                     non-game-toast render-icons restricted-span rotated-span
+   [nr.utils :refer [banned-span deck-points-card-span faction-icon
+                     buildable-format->slug get-image-path image-or-face influence-dots
+                     non-game-toast render-safe-html restricted-span rotated-span
                      set-scroll-top slug->buildable-format store-scroll-top
                      tr-non-game-toast]]
    [reagent.core :as r]))
@@ -381,7 +381,7 @@
      [:div.text.card-body
       [:p [:span.type (tr-type (:type card))]
        (if-not subtypes "" (str ": " subtypes))]
-      [:pre (render-icons (tr-data :text (get @all-cards (:title card))))]
+      [:pre (render-safe-html (tr-data :text (get @all-cards (:title card))))]
 
       (when show-extra-info
         [:<>

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -314,6 +314,41 @@
   [input]
   (render-input input icon-patterns))
 
+(defn- apply-single-tag
+  "Split text on <tag-name>content</tag-name> pairs. Returns a vector of
+  surrounding text and [tag-kw (render-fn content)] elements."
+  [tag-name tag-kw render-fn text]
+  (let [pattern (re-pattern (str "(?s)<" tag-name ">(.*?)</" tag-name ">"))
+        parts (vec (.split text pattern))]
+    (loop [result [] parts parts is-content false]
+      (if (empty? parts)
+        result
+        (let [part (first parts)]
+          (recur
+            (cond
+              is-content  (conj result [tag-kw (render-fn part)])
+              (seq part)  (conj result part)
+              :else       result)
+            (rest parts)
+            (not is-content)))))))
+
+(defn- expand-tag
+  "Expand a single html tag and render the content"
+  [tag-name tag-kw segs]
+  (mapcat #(if (string? %) (apply-single-tag tag-name tag-kw render-icons %) [%]) segs))
+
+(defn render-safe-html
+  "Convert a safe subset of HTML tags found in card text to Reagent elements,
+  applying icon rendering to all text segments. Only handles the four tags
+  present in NetrunnerDB card data: <strong>, <em>, <ul>, <li>."
+  [text]
+  (when (string? text)
+    (->> (apply-single-tag "ul" :ul #(into [:ul] (apply-single-tag "li" :li render-icons %)) text)
+         (expand-tag "strong" :strong)
+         (expand-tag "em" :em)
+         (map #(if (string? %) (render-icons %) %))
+         (into [:<>]))))
+
 (defn render-cards
   "Render all cards in a given text or HTML fragment input"
   [input]

--- a/src/css/cardbrowser.styl
+++ b/src/css/cardbrowser.styl
@@ -146,6 +146,11 @@
         right: 10px
         height: 245px
 
+        ul
+            padding-left: 1.2em
+            margin: 0
+            margin-top: -0.5em
+
     > img
         position: absolute
         top: 0px


### PR DESCRIPTION
Handle `<strong>`, `<em>`, and `<ul><li>` tags in the card text displays in the card browser and the in-game card zoom window (when the `display zoomed card as text` option is selected).

<img width="265" height="359" alt="image" src="https://github.com/user-attachments/assets/2e1bdbc4-c925-41b1-b577-703d3220bf37" />

<img width="264" height="363" alt="image" src="https://github.com/user-attachments/assets/b2d9b104-0c7d-4a4c-ab43-7bcbffd45941" />

<img width="262" height="360" alt="image" src="https://github.com/user-attachments/assets/013572fc-8d3a-49e2-92d1-89bed5e8f73a" />


Fixes #8645 
Fixes #8309 