### PR TITLE
Migrate the :pre-resolve-damage Event

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -2672,11 +2672,10 @@
    :leave-play (req (swap! state update :damage dissoc :damage-choose-runner))
    :events [{:event :pre-resolve-damage
              :async true
-             :req (req (and (pos? (last targets))
+             :req (req (and (pos? (:amount context))
                             (runner-can-choose-damage? state)
                             (not (get-in @state [:damage :damage-replace]))))
-             :effect (req (let [dtype target
-                                dmg (last targets)
+             :effect (req (let [{dtype :damage-type dmg :amount} context
                                 hand (:hand runner)]
                             (continue-ability
                               state :runner

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -643,10 +643,10 @@
              :effect (effect (enable-corp-damage-choice))}
             {:event :pre-resolve-damage
              :optional
-             {:req (req (and (= target :net)
+             {:req (req (and (= :net (:damage-type context))
                              (corp-can-choose-damage? state)
-                             (pos? (last targets))
-                             (empty? (filter #(= :net (:damage-type (first %))) (turn-events state :runner :damage)))
+                             (pos? (:amount context))
+                             (no-event? state :runner :damage #(= :net (:damage-type (first %))))
                              (pos? (count (:hand runner)))))
               :waiting-prompt true
               :prompt "Choose the first card to trash?"

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -62,7 +62,7 @@
   [state side eid dmg-type n {:keys [card cause suppress-checkpoint]}]
   (swap! state dissoc-in [:damage :chosen-damage])
   (damage-choice-priority state)
-  (wait-for (trigger-event-simult state side :pre-resolve-damage nil dmg-type side n)
+  (wait-for (trigger-event-simult state side :pre-resolve-damage nil {:damage-type dmg-type :amount n})
             (if (not (pos? n))
               (do ;; shouldn't be possible, should be handled before getting here
                 (timbre/error (str "attempted to resolve 0 damage: \n" (n-last-logs state 5) "\n"))


### PR DESCRIPTION
Usually deal for the event migration, we have a few notes of minor interest:
- A 1-to-1 migration would have included a `:from-side side` context key along but we already pass side along, so I dropped it.
- One of the locations was refactored to use the `no-events?` because it basically had that code in-lined.
