### PR TITLE
Deregister user synchronously on websocket close

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -431,6 +431,7 @@
     ?reply-fn :?reply-fn
     id :id
     timestamp :timestamp}]
+  (app-state/deregister-user! uid)
   (lobby/lobby-thread
     (let [{:keys [started state] :as lobby} (app-state/uid->lobby uid)]
       (when (and started state)
@@ -438,9 +439,7 @@
         (when-let [lobby? (lobby/leave-lobby! db user uid nil lobby)]
           (handle-message-and-send-diffs!
             lobby? nil nil (str (:username user) " has left the game.")))))
-    (lobby/send-lobby-list uid)
     (lobby/broadcast-lobby-list)
-    (app-state/deregister-user! uid)
     (when ?reply-fn (?reply-fn true))
     (lobby/log-delay! timestamp id)))
 


### PR DESCRIPTION
This commit move user deregistration from the lobby thread to a synchronous update when the websocket closes, mirroring the synchronous registration when a websocket opens.

It also removes the dead code `send-lobby-list`, as there is no socket to receive the message.

This should eliminate a data race between deregistration of an old socket and registration of a new socket that could, in theory, be responsible for reports that blocked users appear in the sent lobby list.