### PR TITLE
Host cards left to right

### DIFF
--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -60,7 +60,7 @@
            target (update target :hosted #(map (fn [h] (assoc h :host target)) %))
            cdef (card-def card)
            tdef (card-def target)]
-       (update! state side (update card :hosted conj target))
+       (update! state side (update card :hosted concat [target]))
        (if (and installed
                   (or (runner? target)
                       (and (corp? target)

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -8039,6 +8039,20 @@
       (play-from-hand state :runner "Fall Guy")
       (is (no-prompt? state :runner) "Can't host non-program"))))
 
+(deftest scheherazade-hosted-card-order
+  ;; Scheherazade - hosted cards appear in installation order (oldest left, newest right)
+  (do-game
+    (new-game {:runner {:hand ["Scheherazade" "Inti" "Cache"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Scheherazade")
+    (let [sch (get-program state 0)]
+      (play-from-hand state :runner "Inti")
+      (click-prompt state :runner "Scheherazade")
+      (play-from-hand state :runner "Cache")
+      (click-prompt state :runner "Scheherazade")
+      (is (= "Inti" (:title (first (:hosted (refresh sch))))) "First installed program is first in hosted list")
+      (is (= "Cache" (:title (second (:hosted (refresh sch))))) "Second installed program is second in hosted list"))))
+
 (deftest self-modifying-code-trash-pay-2-to-search-deck-for-a-program-and-install-it-shuffle
     ;; Trash & pay 2 to search deck for a program and install it. Shuffle
     (do-game

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5001,7 +5001,7 @@
         (click-prompt state :runner "Street Peddler")
         (let [ped1 (first (:hosted (refresh oca)))]
           (card-ability state :runner ped1 0)
-          (click-prompt state :runner (last (prompt-buttons :runner))) ; choose Street Peddler
+          (click-prompt state :runner (first (prompt-buttons :runner))) ; choose Street Peddler
           (click-prompt state :runner (:title oca))
           (click-prompt state :runner (:title oca))
           (let [ped2 (first (:hosted (refresh oca)))]


### PR DESCRIPTION
Mimic paper play by placing hosted cards on top of and to the right of existing hosted cards.

Fixes #8615 