### PR TITLE
Fix hosting programs on unrezzed ice

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -818,7 +818,8 @@
 
      (when (pos? (count hosted))
        [:div.hosted
-        (if (and (not (ice? card))
+        (if (and (not (or (ice? card)
+                          (= "ices" (last (:zone card)))))
                  @as-stacked-cards)
         ; stacked mode
           (let [distinct-hosted (vals (group-by get-title hosted))]


### PR DESCRIPTION
Issue has good images of the failure. Type was getting stripped out for the runner, so checking if it's in the ice zone to make image stacking work correctly.


Fixes #6988