### PR TITLE
Metrics for end of game

### DIFF
--- a/src/clj/game/core/winning.clj
+++ b/src/clj/game/core/winning.clj
@@ -26,6 +26,7 @@
                            :loser (other-side side)
                            :winning-user (get-in state [side :user :username])
                            :losing-user (get-in state [(other-side side) :user :username])
+                           :losing-score (get-in state [(other-side side) :agenda-point])
                            :reason reason
                            :end-time now
                            :winning-deck-id (get-in state [side :deck-id])

--- a/src/clj/web/analytics.clj
+++ b/src/clj/web/analytics.clj
@@ -1,0 +1,62 @@
+(ns web.analytics
+  (:require
+   [clojure.set :as set]
+   [monger.collection :as mc]
+   [clojure.java.io :as io]
+   [taoensso.encore :as enc]
+   [clojure.core.async :refer [<! go timeout]]
+   [cljc.java-time.temporal.chrono-unit :as chrono]
+   [cljc.java-time.duration :as duration]
+   [cljc.java-time.instant :as inst]))
+
+(defonce daily-analytics
+  (atom {}))
+
+(def log-analytics-frequency (enc/ms :hours 24))
+
+(defn- write-analytic [k v]
+  (when v
+    (let [date-str (str (java.time.LocalDate/now))
+          filename (str (name k) "-" date-str ".edn")
+          dir (io/file (System/getProperty "user.home") "jinteki" "analytics")
+          file (io/file dir filename)]
+      (.mkdirs dir)
+      (spit file (pr-str v)))))
+
+(defn- anonymize-engagement
+  [data]
+  (update-in data [:users] (fn [users] (if users (count users) 0))))
+
+(defonce write-analytics
+  (go (while true
+        (<! (timeout log-analytics-frequency))
+        (let [analytics @daily-analytics]
+          (swap! daily-analytics assoc :engagement nil)
+          (write-analytic :smogon (:smogon analytics))
+          (write-analytic :engagement (anonymize-engagement (:engagement analytics)))))))
+
+(defn- merge-analytics
+  [a b]
+  (cond
+    (and (number? a) (number? b))
+    (+ a b)
+    (and (map? a) (map? b))
+    (merge-with merge-analytics a b)
+    (and (vector? a) (vector? b))
+    (mapv merge-analytics a b)
+    (and (set? a) (set? b))
+    (set/union a b)
+    :else (or a b)))
+
+(defn- update-analytic
+  [key data]
+  (swap! daily-analytics update key (fn [old-data]
+                                      (if-not old-data
+                                        data
+                                        (merge-analytics old-data data)))))
+
+(defn update-analytics
+  [key data]
+  (case key
+    :smogon (update-analytic :smogon data)
+    :engagement (update-analytic :engagement data)))

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -13,6 +13,7 @@
    [monger.result :refer [acknowledged?]]
    [postal.core :as mail]
    [ring.util.response :refer [redirect]]
+   [web.analytics :refer [update-analytics]]
    [web.app-state :as app-state]
    [web.mongodb :refer [->object-id find-one-as-map-case-insensitive]]
    [web.user :refer [active-user? create-user user-keys valid-username?]]
@@ -92,6 +93,7 @@
                                               (dissoc :_id)
                                               (assoc :username username))
                                          demo-decks)))
+      (update-analytics :engagement {:new-user 1})
       (response 200 {:message "ok"}))))
 
 (defn find-non-banned-user

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -10,6 +10,7 @@
    [monger.query :as mq]
    [monger.result :refer [acknowledged?]]
    [ring.util.request :refer [request-url]]
+   [web.analytics :refer [update-analytics]]
    ;;[web.angel-arena.stats :as angel-arena-stats]
    [web.mongodb :refer [->object-id]]
    [web.pages :as pages]
@@ -71,6 +72,32 @@
                         {:stats.loses 1}))]
     record))
 
+(defn- smogon
+  "gets a smogon map for the game"
+  [state player]
+  (let [deck (get-in player [:deck])]
+    (when (= "standard" (:format deck))
+      ;; get all cards by name
+      (let [ident (-> deck :identity :title)
+            cards (->> deck :cards (mapv (fn [{:keys [qty card]}] [(:title card) qty card])))
+            cards (concat cards [[ident 3 (-> deck :identity)]])
+            point-mult (if (= (:_id deck) (:winning-deck-id @state))
+                         3.5
+                         (- (or (:losing-score @state) 0) 3.5))
+            ;; the winner has 3.5 points
+            ;; the loser has however many points they had, -3.5
+            ;; relevant data: in faction, id {used*qty used?}, score
+            card-data (fn [qty card]
+                        [(if (= (:faction card) (-> deck :identity :faction)) qty 0)
+                         {ident [qty 1]}
+                         (* qty point-mult)])
+            mapped (map (fn [[title qty card]]
+                          [title (card-data qty card)])
+                        cards)
+            adjusted-data {:data (into {} mapped)
+                           :players 1}]
+        (update-analytics :smogon adjusted-data)))))
+
 (defn update-deck-stats
   "Update stats for player decks on game ending"
   [db {:keys [original-players ending-players state precon]}]
@@ -81,6 +108,7 @@
         (when (and enable-deckstats deck-id)
           (inc-deck-stats db deck-id {:stats.games-started 1}))))
     (doseq [player ending-players]
+      (smogon state player)
       (inc-deck-stats db (get-in player [:deck :_id]) (deck-record-end state player)))))
 
 (defn inc-game-stats
@@ -117,7 +145,8 @@
       (timbre/error (str "NULL start player side in stats for gameid " gameid))))
   (doseq [player ending-players]
     (if (:side player)
-      (inc-game-stats db (get-in player [:user :_id]) (game-record-end state player))
+      (do (update-analytics :engagement {:games-played 0.5 :users #{(get-in player [:user :username])}})
+          (inc-game-stats db (get-in player [:user :_id]) (game-record-end state player)))
       (timbre/error (str "NULL end player side in stats for gameid " gameid)))))
 
 (defn push-stats-update


### PR DESCRIPTION
This adds a couple of functions to gather some anonymous data (fully compliant with the GDPR).

Essentially what we're gathering is:
1) Number of players who play, number of games played, number of new accounts made -> daily
2) An index of cards, their playrate, the faction and id they're played in, and a tiny metric for scoring those cards -> just compound the data until we get restarted, but log it daily

These are stored in `~/jinteki/analytics/...`, and will not be publicly accessible.

Why?
1) Closes #8582. This is both legal and ethical. No personally identifiable information is used whatsoever.
2) A couple of users wanted this for a research project, and I think it's both legal and ethical to provide in this case. The data is all mixed in such a way that it's impossible to identify any information about any player from it.

My metric for scoring:
* 3.5 points for a win
* If you lose, your agenda point total - 3.5