### PR TITLE
Hansei Review's credits and trash should be separate instructions

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1389,7 +1389,7 @@
     :effect (req (wait-for (gain-credits state :corp 10)
                            (continue-ability
                              state :corp
-                             (if (seq (:hand corp))
+                             (when (seq (:hand corp))
                                {:prompt "Choose a card in HQ to trash"
                                 :choices {:max 1
                                           :all true
@@ -1397,9 +1397,8 @@
                                 :msg {:public "trash a card from HQ"
                                       :corp (msg "trash " (card-str state target {:maybe-visible true}) " from HQ")}
                                 :async true
-                                :effect (trash-cards state side targets {:cause-card card})}
-                               (effect-completed state side eid))
-                              card nil)))}})
+                                :effect (req (trash-cards state side eid targets {:cause-card card}))})
+                             card nil)))}})
 
 (defcard "Hard-Hitting News"
   {:on-play

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1385,21 +1385,21 @@
 (defcard "Hansei Review"
   {:on-play
    {:async true
-    :effect (req (continue-ability
-                   state :corp
-                   (if (seq (:hand corp))
-                     {:prompt "Choose a card in HQ to trash"
-                      :choices {:max 1
-                                :all true
-                                :card #(and (corp? %) (in-hand? %))}
-                      :msg {:public "trash a card from HQ and gain 10 [Credits]"
-                            :corp (msg "trash " (card-str state target {:maybe-visible true})
-                                       " from HQ and gain 10 [Credits]")}
-                      :async true
-                      :effect (req (wait-for (trash-cards state side targets {:cause-card card})
-                                             (gain-credits state side eid 10)))}
-                     (gain-credits-ability 10))
-                   card nil))}})
+    :msg "gain 10 [Credits]"
+    :effect (req (wait-for (gain-credits state :corp 10)
+                           (continue-ability
+                             state :corp
+                             (if (seq (:hand corp))
+                               {:prompt "Choose a card in HQ to trash"
+                                :choices {:max 1
+                                          :all true
+                                          :card #(and (corp? %) (in-hand? %))}
+                                :msg {:public "trash a card from HQ"
+                                      :corp (msg "trash " (card-str state target {:maybe-visible true}) " from HQ")}
+                                :async true
+                                :effect (trash-cards state side targets {:cause-card card})}
+                               (effect-completed state side eid))
+                              card nil)))}})
 
 (defcard "Hard-Hitting News"
   {:on-play

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2243,7 +2243,6 @@
       (new-game {:corp {:hand ["Hansei Review" "IPO"]}})
       (is (= 5 (:credit (get-corp))) "Starting with 5 credits")
       (play-from-hand state :corp "Hansei Review")
-      (is (zero? (:credit (get-corp))) "Now at 0 credits")
       (click-card state :corp "IPO")
       (is (= 10 (:credit (get-corp))) "Now at 10 credits")
       (is (= 2 (count (:discard (get-corp)))))))


### PR DESCRIPTION
Based on some discussion in GLC, I think #6218 actually introduced a regression, in that [Hansei Review](https://netrunnerdb.com/en/card/30048)'s instructions _should_ be separate and so the Corp _should_ be given credits before choosing a card to trash from HQ - and for example [The Zwicky Group](https://netrunnerdb.com/en/card/35069) should trigger between these.

I've never used Clojure, so this was an experience, but hopefully it's not too wrong.