### PR TITLE
Fix log display. Block unauthorized access to stats actions.

### DIFF
--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -154,6 +154,14 @@
 
 (def game-log-coll "game-logs")
 
+(defn- filter-log-for-side [log side]
+  (when (sequential? log)
+    (into [] (keep (fn [entry]
+                     (if (:user entry)
+                       entry                                  ;; old format: message object directly
+                       (or (side entry) (:public entry))))    ;; new format: side-keyed map
+                   log))))
+
 (defn delete-old-replay
   [db {:keys [username]}]
   (let [games (mq/with-collection db game-log-coll
@@ -247,10 +255,12 @@
     {username :username} :user
     {:keys [gameid]} :path-params}]
   (if username
-    (let [{:keys [corp runner log]} (mc/find-one-as-map db :game-logs {:gameid gameid} ["corp" "runner" "log"])]
+    (let [{:keys [corp runner log]} (mc/find-one-as-map db game-log-coll {:gameid gameid} ["corp" "runner" "log"])]
       (if (or (= username (get-in corp [:player :username]))
               (= username (get-in runner [:player :username])))
-        (response 200 (or log {}))
+        (let [side (if (= username (get-in corp [:player :username])) :corp :runner)
+              filtered-log (filter-log-for-side log side)]
+          (response 200 (or filtered-log [])))
         (response 401 {:message "Unauthorized"})))
     (response 401 {:message "Unauthorized"})))
 

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -244,11 +244,14 @@
 
 (defn fetch-log
   [{db :system/db
-    user :user
+    {username :username} :user
     {:keys [gameid]} :path-params}]
-  (if (active-user? user)
-    (let [{:keys [log]} (mc/find-one-as-map db :game-logs {:gameid gameid} ["log"])]
-      (response 200 (or log {})))
+  (if username
+    (let [{:keys [corp runner log]} (mc/find-one-as-map db :game-logs {:gameid gameid} ["corp" "runner" "log"])]
+      (if (or (= username (get-in corp [:player :username]))
+              (= username (get-in runner [:player :username])))
+        (response 200 (or log {}))
+        (response 401 {:message "Unauthorized"})))
     (response 401 {:message "Unauthorized"})))
 
 (defn fetch-annotations

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -29,11 +29,14 @@
 (defn clear-deckstats-handler
   "Clear any statistics for a given deck-id contained in a request"
   [{db :system/db
+    {username :username} :user
     {id :id} :path-params}]
-  (if id
-    (if (acknowledged? (mc/update db :decks {:_id (->object-id id)} {$unset {:stats ""}}))
-      (response 200 {:message "Deleted"})
-      (response 403 {:message "Forbidden"}))
+  (if (and id username)
+    (if (mc/find-one-as-map db :decks {:_id (->object-id id) :username username})
+      (if (acknowledged? (mc/update db :decks {:_id (->object-id id)} {$unset {:stats ""}}))
+        (response 200 {:message "Deleted"})
+        (response 403 {:message "Forbidden"}))
+      (response 401 {:message "Unauthorized"}))
     (response 401 {:message "Unauthorized"})))
 
 (defn stats-for-deck

--- a/test/clj/web/stats_test.clj
+++ b/test/clj/web/stats_test.clj
@@ -1,6 +1,9 @@
 (ns web.stats-test
   (:require
    [clojure.test :refer :all]
+   [monger.collection :as mc]
+   [monger.result :refer [acknowledged?]]
+   [web.mongodb :refer [->object-id]]
    [web.stats :refer :all]))
 
 (deftest strip-opponent-deck-name-test
@@ -14,3 +17,27 @@
       (let [result (strip-opponent-deck-name game "bob")]
         (is (= "Stealth Andy" (get-in result [:runner :deck-name])))
         (is (nil? (get-in result [:corp :deck-name])))))))
+
+(deftest clear-deckstats-handler-ownership-test
+  (testing "only allow clearing deck stats for your decks"
+    (with-redefs [mc/find-one-as-map (fn [& _] nil)  ; deck not found for this user
+                  mc/update          (fn [& _] :mock-result)
+                  acknowledged?      (fn [_] true)
+                  ->object-id        identity]
+      (let [;; alice is authenticated but targets a deck that belongs to bob
+            request {:system/db   :mock-db
+                     :user        {:username "alice"}
+                     :path-params {:id "bobs-deck-id"}}
+            result  (clear-deckstats-handler request)]
+        (is (= 401 (:status result))
+            "handler must reject requests where the user does not own the deck"))))
+  (testing "owner can clear stats for their own deck"
+    (with-redefs [mc/find-one-as-map (fn [& _] {:_id "alices-deck-id" :username "alice"})
+                  mc/update          (fn [& _] :mock-result)
+                  acknowledged?      (fn [_] true)
+                  ->object-id        identity]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "alice"}
+                     :path-params {:id "alices-deck-id"}}
+            result  (clear-deckstats-handler request)]
+        (is (= 200 (:status result)))))))

--- a/test/clj/web/stats_test.clj
+++ b/test/clj/web/stats_test.clj
@@ -47,6 +47,23 @@
    :runner {:player {:username "bob"}}
    :log    [{:text "some log entry"}]})
 
+(def public-msg {:user "__system__" :text "public message"})
+(def corp-msg {:user "__system__" :text "corp only"})
+(def runner-msg {:user "__system__" :text "runner only"})
+
+(def game-with-new-format-log
+  {:corp   {:player {:username "alice"}}
+   :runner {:player {:username "bob"}}
+   :log    [{:public public-msg}
+            {:corp corp-msg}
+            {:runner runner-msg}]})
+
+(def game-with-old-format-log
+  {:corp   {:player {:username "alice"}}
+   :runner {:player {:username "bob"}}
+   :log    [{:user "__system__" :text "Game started"}
+            {:user {:username "alice" :emailhash "abc"} :text "Hello"}]})
+
 (deftest fetch-log-ownership-test
   (testing "non-player cannot fetch a game log"
     (with-redefs [mc/find-one-as-map (fn [& _] game-with-alice-and-bob)]
@@ -70,3 +87,51 @@
                      :path-params {:gameid "some-game-id"}}
             result  (fetch-log request)]
         (is (= 200 (:status result)))))))
+
+(deftest fetch-log-new-format-test
+  (testing "corp player receives public and corp-only messages, not runner-only"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-new-format-log)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "alice"}
+                     :path-params {:gameid "g1"}}
+            result  (fetch-log request)
+            log     (:body result)]
+        (is (= 200 (:status result)))
+        (is (= 2 (count log)))
+        (is (some #(= "public message" (:text %)) log))
+        (is (some #(= "corp only" (:text %)) log))
+        (is (not (some #(= "runner only" (:text %)) log))))))
+  (testing "runner player receives public and runner-only messages, not corp-only"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-new-format-log)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "bob"}
+                     :path-params {:gameid "g1"}}
+            result  (fetch-log request)
+            log     (:body result)]
+        (is (= 200 (:status result)))
+        (is (= 2 (count log)))
+        (is (some #(= "public message" (:text %)) log))
+        (is (some #(= "runner only" (:text %)) log))
+        (is (not (some #(= "corp only" (:text %)) log)))))))
+
+(deftest fetch-log-old-format-test
+  (testing "old-format logs are returned unchanged for corp player"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-old-format-log)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "alice"}
+                     :path-params {:gameid "g2"}}
+            result  (fetch-log request)
+            log     (:body result)]
+        (is (= 200 (:status result)))
+        (is (= 2 (count log)))
+        (is (= "Game started" (:text (first log)))))))
+  (testing "old-format logs are returned unchanged for runner player"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-old-format-log)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "bob"}
+                     :path-params {:gameid "g2"}}
+            result  (fetch-log request)
+            log     (:body result)]
+        (is (= 200 (:status result)))
+        (is (= 2 (count log)))
+        (is (= "Game started" (:text (first log))))))))

--- a/test/clj/web/stats_test.clj
+++ b/test/clj/web/stats_test.clj
@@ -41,3 +41,32 @@
                      :path-params {:id "alices-deck-id"}}
             result  (clear-deckstats-handler request)]
         (is (= 200 (:status result)))))))
+
+(def game-with-alice-and-bob
+  {:corp   {:player {:username "alice"}}
+   :runner {:player {:username "bob"}}
+   :log    [{:text "some log entry"}]})
+
+(deftest fetch-log-ownership-test
+  (testing "non-player cannot fetch a game log"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-alice-and-bob)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "eve" :_id "eve-id"}
+                     :path-params {:gameid "some-game-id"}}
+            result  (fetch-log request)]
+        (is (= 401 (:status result))
+            "handler must reject non-players from viewing game logs"))))
+  (testing "corp player can fetch their game log"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-alice-and-bob)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "alice" :_id "alice-id"}
+                     :path-params {:gameid "some-game-id"}}
+            result  (fetch-log request)]
+        (is (= 200 (:status result))))))
+  (testing "runner player can fetch their game log"
+    (with-redefs [mc/find-one-as-map (fn [& _] game-with-alice-and-bob)]
+      (let [request {:system/db   :mock-db
+                     :user        {:username "bob" :_id "bob-id"}
+                     :path-params {:gameid "some-game-id"}}
+            result  (fetch-log request)]
+        (is (= 200 (:status result)))))))


### PR DESCRIPTION
- Handle new side-based messages when displaying in the Stats/View Log interface
- Game logs endpoint requires user to be game participant for access
- Deck stats clearing action requires user to be deck owner  

Fixes #8681 