### PR TITLE
Migrated :pre-trash-interrupt Event

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -2360,17 +2360,13 @@
                  :effect (req (update! state side (assoc-in card [:special :resolution-mode] x))
                               (toast state :corp (str "Set Skorpios resolution to " x " mode"))
                               (update! state side (assoc (get-card state card) :card-target x)))})
-        grip-or-stack-trash?
-        (fn [ctx]
-          (some #(and (runner? (:card %))
-                      (or (in-hand? (:card %))
-                          (in-deck? (:card %))))
-                ctx))
+        in-grip-or-stack? #(and (runner? %) (or (in-hand? %) (in-deck? %)))
+        grip-or-stack-trash? #(some in-grip-or-stack? (map :card %))
         relevant-cards-general #{"Labor Rights" "The Price"}
         relevant-cards-trashed #{"I've Had Worse" "Strike Fund" "Steelskin Scarring" "Crowdfunding"}
         trigger-ability-req (req (let [res-type (get-in (get-card state card) [:special :resolution-mode])
-                                       valid-cards (mapv #(get-card state %) (filter runner? context))]
-                                   (and (some runner? context)
+                                       trashed-cards (:trashed-cards context)]
+                                   (and (some runner? trashed-cards)
                                         (cond
                                           ;; manual: do nothing
                                           (= res-type "Automatic") true
@@ -2381,14 +2377,14 @@
                                             (contains? relevant-cards-general (->> runner :play-area first :title))
                                             ;; 2) a buffer drive that may resolve
                                             (and (some #(= (:title %) "Buffer Drive") (all-installed state :runner))
-                                                 (grip-or-stack-trash? (map (fn [x] {:card x}) context))
-                                                 (zero? (+ (event-count state nil :runner-trash grip-or-stack-trash?)
-                                                           (event-count state nil :corp-trash   grip-or-stack-trash?)
-                                                           (event-count state nil :game-trash   grip-or-stack-trash?))))
+                                                 (some in-grip-or-stack? trashed-cards)
+                                                 (no-event? state nil :runner-trash grip-or-stack-trash?)
+                                                 (no-event? state nil :corp-trash grip-or-stack-trash?)
+                                                 (no-event? state nil :game-trash grip-or-stack-trash?))
                                             ;; 3) a program among the trashed cards
-                                            (some #(->> % program?) context)
+                                            (some program? trashed-cards)
                                             ;; 4) a relevant card is trashed (Steelskin, Strike fund, I've Had Worse)
-                                            (some #(contains? relevant-cards-trashed %) (map #(->> % :title) context)))
+                                            (some #(contains? relevant-cards-trashed %) (map :title trashed-cards)))
                                           :else nil))))
         triggered-ability {:once :per-turn
                            :player :corp
@@ -2396,7 +2392,7 @@
                            :waiting-prompt true
                            :req trigger-ability-req
                            :prompt "Remove a card from the game?"
-                           :choices (req (cancellable context))
+                           :choices (req (cancellable (:trashed-cards context)))
                            :msg (msg "remove " (:title target) " from the game")
                            :async true
                            :effect (req (move state :runner target :rfg)

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -368,7 +368,7 @@
      (effect-completed state side eid)
      (wait-for (resolve-trash-prevention state side cards args)
                (let [trashlist (:remaining async-result)
-                     trashed-cards (map :card trashlist)
+                     trashed-cards (not-empty (mapv :card trashlist))
                      _ (update-current-ice-to-trash state trashed-cards)]
                  (wait-for
                    (trigger-event-sync state side :pre-trash-interrupt {:trashed-cards trashed-cards})

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -368,9 +368,10 @@
      (effect-completed state side eid)
      (wait-for (resolve-trash-prevention state side cards args)
                (let [trashlist (:remaining async-result)
-                     _ (update-current-ice-to-trash state (map :card trashlist))]
+                     trashed-cards (map :card trashlist)
+                     _ (update-current-ice-to-trash state trashed-cards)]
                  (wait-for
-                   (trigger-event-sync state side :pre-trash-interrupt (map :card trashlist))
+                   (trigger-event-sync state side :pre-trash-interrupt {:trashed-cards trashed-cards})
                    (let [trash-event (get-trash-event side game-trash)
                          ;; No card should end up in the opponent's discard pile, so instead
                          ;; of using `side`, we use the card's `:side`.
@@ -408,16 +409,16 @@
                        (trigger-event state side :corp-shuffle-deck))
                      ;; TODO - used exclusively for hellion beta test
                      (when (and (:access @state)
-                                (some #(same-card? (:access @state) %) (map :card trashlist))
+                                (some #(same-card? (:access @state) %) trashed-cards)
                                 (= :runner side))
                        (swap! state assoc-in [:runner :register :trashed-accessed-card] true))
                      ;; TODO - used exclusively for aumakua
                      (when (and (:breach @state)
-                                (some #(same-card? (:access @state) %) (map :card trashlist))
+                                (some #(same-card? (:access @state) %) trashed-cards)
                                 (= :runner side))
                        (swap! state assoc-in [:breach :did-trash] true))
                      (swap! state update-in [:trash :trash-list :card] dissoc eid)
-                     (when (and side (seq (remove #{side} (map #(to-keyword (:side %)) (map :card trashlist)))))
+                     (when (and side (seq (remove #{side} (map #(to-keyword (:side %)) trashed-cards))))
                        (swap! state assoc-in [side :register :trashed-card] true)
                        (when accessed
                          (swap! state assoc-in [side :register :trashed-accessed-card] true)))


### PR DESCRIPTION
Changed the `:pre-trash-interrupt` event to use a context map. Ended up going with `:trashed-cards` for the context key, even though the cards haven't been trashed yet.

I spent longer than usual staring at this one so it got some extra clean-up. Generally just removing extra bits of complexity that had a simpler form.