### PR TITLE
stoke remove wait

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -2447,7 +2447,6 @@
                          :req (req (and
                                      (not= [:hand] (:previous-zone card))
                                      (same-card? (:card target) card)))
-                         :waiting-prompt true
                          :yes-ability
                          {:msg (msg "reveal itself from " (zone->name (:previous-zone card)))
                           :async true


### PR DESCRIPTION
This doesn't fix the issue (#8678), but it makes it ~5% less obvious.

Short of adding a waiting prompt to every single corp install, there's no real fix for this.