### PR TITLE
Added bounds checking when doing indexed lookups

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -2701,9 +2701,10 @@
                          :effect (req (if (get-only-card-to-access state)
                                         (effect-completed state nil eid)
                                         (let [deck (:deck corp)
-                                              idx (dec (str->int target))]
-                                          (if (< idx (count deck))
-                                            (access-card state side eid (nth deck idx) "an unseen card")
+                                              idx (dec (str->int target))
+                                              selected_card (nth deck idx nil)]
+                                          (if selected_card
+                                            (access-card state side eid selected_card "an unseen card")
                                             (effect-completed state side eid)))))}})]})
 
 (defcard "Touchstone"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -2700,7 +2700,11 @@
                          :async true
                          :effect (req (if (get-only-card-to-access state)
                                         (effect-completed state nil eid)
-                                        (access-card state side eid (nth (:deck corp) (dec (str->int target))) "an unseen card")))}})]})
+                                        (let [deck (:deck corp)
+                                              idx (dec (str->int target))]
+                                          (if (< idx (count deck))
+                                            (access-card state side eid (nth deck idx) "an unseen card")
+                                            (effect-completed state side eid)))))}})]})
 
 (defcard "Touchstone"
   {:events [{:event :play-event

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -98,9 +98,10 @@
   ([state side eid {:keys [card] ability-idx :ability :as args}]
    (let [card (get-card state card)
          args (assoc args :card card)
-         ability (nth (:abilities card) ability-idx)
+         ability (nth (:abilities card) ability-idx nil)
          blocking-prompt? (not (no-blocking-prompt? state side))
-         cannot-play (or (:disabled card)
+         cannot-play (or (nil? ability)
+                         (:disabled card)
                          ;; cannot play actions during runs
                          (and (:action ability) (:run @state))
                          ;; while resolving another ability or promppt

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -531,7 +531,7 @@
                                              (:subroutines ice))
                          idx (:idx (first targets))
                          sub (if (number? idx)
-                               (nth subroutines idx)
+                               (nth subroutines idx nil)
                                (first (filter #(= target (make-label (:sub-effect %))) subroutines)))
                          ice (break-subroutine ice sub)
                          broken-subs (cons sub broken-subs)

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -15,9 +15,12 @@
 
 (defn percentile [vector percentile]
   ;; see: https://scicloj.github.io/stats-with-clojure/stats_with_clojure.basic_statistics.html
-  (let [sorted-vector (sort vector)
-        idx (int (* percentile (/ (count sorted-vector) 100)))]
-    (str (nth sorted-vector idx) "ms")))
+  (let [sorted-vector (sort vector)]
+    (if (empty? sorted-vector)
+      "0ms"
+      (let [idx (min (int (* percentile (/ (count sorted-vector) 100)))
+                     (dec (count sorted-vector)))]
+        (str (nth sorted-vector idx) "ms")))))
 
 (defn- format-percentiles [data percentiles]
   (apply str (interpose "/" (map #(percentile (vec data) %) percentiles))))

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -206,8 +206,10 @@
    (let [lang (get-in @app-state [:options :card-language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
          art (if (keyword? (:art card)) (:art card) :stock)
-         art-index (get card :art-index 0)]
-     [(nth (get-image-path (:images card) (keyword lang) (keyword res) art) art-index)]))
+         art-index (get card :art-index 0)
+         art-urls (get-image-path (:images card) (keyword lang) (keyword res) art)
+         safe-index (min art-index (dec (count art-urls)))]
+     [(nth art-urls safe-index)]))
 
 (defn- alt-version-from-string
   "Given a string name, get the keyword version or nil"

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -595,7 +595,8 @@
       (9 13) (when-not (= (:query @s) (:title (first matches)))
                (.preventDefault event)
                (-> ".deckedit .qty" js/$ .select)
-               (swap! s assoc :query (:title (nth matches selected))))
+               (when-let [m (nth matches selected nil)]
+                 (swap! s assoc :query (:title m))))
       (swap! s assoc :selected 0))))
 
 (defn update-decklist-cards

--- a/src/cljs/nr/gameboard/replay.cljs
+++ b/src/cljs/nr/gameboard/replay.cljs
@@ -372,14 +372,16 @@
                               "error" {:time-out 3 :close-button true})))))
 
 (defn load-remote-annotations [pos]
-  (let [anno (nth (:remote-annotations @replay-status) pos)]
-    (swap! replay-status assoc :annotations anno)))
+  (when (< pos (count (:remote-annotations @replay-status)))
+    (let [anno (nth (:remote-annotations @replay-status) pos)]
+      (swap! replay-status assoc :annotations anno))))
 
 (defn delete-remote-annotations [pos]
-  (let [anno (nth (:remote-annotations @replay-status) pos)]
-    (go (let [{:keys [status json]} (<! (DELETE (str "/profile/history/annotations/delete/" (:gameid @game-state) "?date=" (:date anno))))]
-          (if (= 200 status)
-            (get-remote-annotations (:gameid @game-state)))))))
+  (when (< pos (count (:remote-annotations @replay-status)))
+    (let [anno (nth (:remote-annotations @replay-status) pos)]
+      (go (let [{:keys [status json]} (<! (DELETE (str "/profile/history/annotations/delete/" (:gameid @game-state) "?date=" (:date anno))))]
+            (if (= 200 status)
+              (get-remote-annotations (:gameid @game-state))))))))
 
 (defn publish-annotations []
   (go (let [{:keys [status json]} (<! (PUT (str "/profile/history/annotations/publish/" (:gameid @game-state))


### PR DESCRIPTION
Found a few places where `nth` wasn't checking bounds on indexes and didn't have a default value. Prevents an exception from being thrown.