### PR TITLE
Fix api key creation strings

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1521,9 +1521,9 @@ settings_always = Always
 
 settings_api-keys = API Keys
 
-settings_api-keys-not-updated = Updated API keys
+settings_api-keys-not-updated = Failed to update API keys
 
-settings_api-keys-updated = Fauled to update API keys
+settings_api-keys-updated = Updated API keys
 
 settings_avatar = Avatar
 

--- a/resources/public/i18n/it.ftl
+++ b/resources/public/i18n/it.ftl
@@ -1510,9 +1510,9 @@ settings_always = Sempre
 
 settings_api-keys = API Key
 
-settings_api-keys-not-updated = API key aggiornata 
+settings_api-keys-not-updated = Aggiornamento API key fallito
 
-settings_api-keys-updated = Aggiornamento API key fallito
+settings_api-keys-updated = API key aggiornata
 
 settings_avatar = Avatar
 

--- a/resources/public/i18n/zh-simp.ftl
+++ b/resources/public/i18n/zh-simp.ftl
@@ -1542,9 +1542,9 @@ settings_always = 总是
 
 settings_api-keys = API密钥
 
-settings_api-keys-not-updated = 更新API密钥
+settings_api-keys-not-updated = 更新API密钥失败
 
-settings_api-keys-updated = 更新API密钥失败
+settings_api-keys-updated = 更新API密钥
 
 settings_avatar = 头像
 

--- a/resources/public/i18n/zh-trad.ftl
+++ b/resources/public/i18n/zh-trad.ftl
@@ -1449,9 +1449,9 @@ settings_always = 皆保留
 
 settings_api-keys = API Keys
 
-settings_api-keys-not-updated = 更新API keys
+settings_api-keys-not-updated = Failed to update API keys
 
-settings_api-keys-updated = Fauled to update API keys
+settings_api-keys-updated = 更新API keys
 
 settings_avatar = 頭像
 


### PR DESCRIPTION
API creation success/failure translation strings were swapped in a few languages.
Fixed typo in English translation.