### PR TITLE
Migrated :candidates-determined Event

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3414,7 +3414,7 @@
                                 [{:event :candidates-determined
                                   :duration :end-of-run
                                   :async true
-                                  :req (req (= :hq context))
+                                  :req (req (= :hq (:breached-server context)))
                                   :effect (effect (continue-ability add-cards-from-heap card nil))}]))}]}))
 
 (defcard "Ritual"

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -986,7 +986,7 @@
 (defmethod choose-access :hq
   [{:keys [total-mod] :as access-amount} _ {:keys [no-root] :as args}]
   {:async true
-   :effect (req (wait-for (trigger-event-sync state side :candidates-determined :hq)
+   :effect (req (wait-for (trigger-event-sync state side :candidates-determined {:breached-server :hq})
                           (let [only-card (get-only-card-to-access state)
                                 max-access (:max-access (:run @state))
                                 total-cards (or (when only-card [only-card])

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -22,12 +22,7 @@
                         (contains? t :value))
                  (:value t)
                  t))
-      context (let [t (first targets)]
-                (if (and (map? t)
-                         (contains? t :uuid)
-                         (contains? t :value))
-                  (:value t)
-                  t))
+      context (first targets)
       installed (#{:rig :servers} (first (game.core.card/get-zone card)))
       remotes (game.core.board/get-remote-names state)
       servers (game.core.servers/zones->sorted-names (game.core.board/get-zones state))


### PR DESCRIPTION
I migrated the `:candidates-determined` event. The `:hq` flag is wrapped `:breached-server` even though it is not needed. Future proofing I guess.

I also asked about how the event functions will change when this migration is done. I simplified the context form to make sure replacing `& targets` with `context` will work. Turns out nothing actually uses the transformation (and if something does need to use it, go through `target` instead. So we just get to strip out some unneeded code.