### PR TITLE
Migrated Various Dataless Events

### DIFF
--- a/src/clj/game/core/gaining.clj
+++ b/src/clj/game/core/gaining.clj
@@ -110,7 +110,7 @@
          (when (and (= side :runner)
                     (= :all amount))
            (lose state :runner :run-credit :all))
-         (trigger-event-sync state side eid (if (= :corp side) :corp-credit-loss :runner-credit-loss) amount args))
+         (trigger-event-sync state side eid (if (= :corp side) :corp-credit-loss :runner-credit-loss) nil))
      (effect-completed state side eid))))
 
 (defn gain-clicks

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -400,7 +400,7 @@
                           (map-indexed (fn [idx sub] (assoc sub :index idx)))
                           (into []))]
         (update! state side (assoc ice :subroutines new-subs))
-        (trigger-event state side :subroutines-changed (get-card state ice))
+        (trigger-event state side :subroutines-changed nil)
         true)))))
 
 (defn update-ice-in-server

--- a/src/clj/game/core/prevention.clj
+++ b/src/clj/game/core/prevention.clj
@@ -590,7 +590,7 @@
                     {:count n :remaining n :prevented 0 :source-player side :source-card card :uses {}})
   (if (or unpreventable (not (pos? n)))
     (complete-with-result state side eid (fetch-and-clear! state :tag))
-    (wait-for (trigger-event-simult state side :tag-interrupt nil card)
+    (wait-for (trigger-event-simult state side :tag-interrupt nil nil)
               (let [active-side (:active-player @state)
                     responding-side (other-side active-side)]
                 (wait-for

--- a/src/clj/game/core/trace.clj
+++ b/src/clj/game/core/trace.clj
@@ -142,7 +142,7 @@
   ([state side card trace] (init-trace state side (make-eid state {:source-type :trace}) card trace))
   ([state side eid card {:keys [base] :as trace}]
    (reset-trace-modifications state)
-   (wait-for (trigger-event-sync state :corp :initialize-trace card eid)
+   (wait-for (trigger-event-sync state :corp :initialize-trace nil)
              (let [force-base (get-in @state [:trace :force-base])
                    force-link (first (get-effects state :corp :trace-force-link card [eid]))
                    base (cond force-base force-base


### PR DESCRIPTION
Mass migration of some/all of the remaining events. These never actually use the data in the targets list so I passed nil instead of a context map.

These may be all the remaining events to migrate. The checks I have been using to search for unmigrated events (checking for at most 1 target, nil or a map, to the event functions) now seem to pass for all tests.