### PR TITLE
Clean-up in game.macro

### DIFF
--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -60,10 +60,7 @@
 
 (defn- emit-only
   [needed-locals]
-  (mapcat identity
-          (for [x needed-locals
-                :when (contains? forms x)]
-            [x (get forms x)])))
+  (mapcat #(when-let [form (get forms %)] [% form]) needed-locals))
 
 (defmacro effect
   "Returns a function taking `state`, `side`, `eid`, `card`, and `targets`, binding
@@ -123,9 +120,8 @@
   [action & body]
   (when (vector? action)
     (assert (= 2 (count action)) "Both bind and call must be in binding vec"))
-  (let [[binds action] (if (vector? action)
-                         [[{(first action) :result}] (second action)]
-                         [[{'async-result :result}] action])
+  (let [[binds action] (if (vector? action) action ['async-result action])
+        binds [{binds :result}]
         abnormal? (#{'handler 'payable?} (first action))
         to-take (if abnormal? 4 3)
         fn-name (gensym (name (first action)))
@@ -136,7 +132,7 @@
            new-eid# (if use-eid# eid?# (game.core.eid/make-eid ~state existing-eid#))]
        (game.core.eid/register-effect-completed
          ~state new-eid#
-         (fn ~fn-name ~(if (vector? binds) binds [binds])
+         (fn ~fn-name ~binds
            (let [ret# (do ~@body)]
              ret#)))
        (if use-eid#


### PR DESCRIPTION
Three pieces of clean-up, in response to the recent reworks:

The new handling of binds means that it is always a vector. There was still a check if it was not and handling for that case, that has been removed.

I broke the definition of binds into two steps. Checking if we need to supply a default and spitting it it off from action are now done in the first step and the nesting of the provided bind into the deeper binding. This removed some repeated code and I believe it is clearer to read.

There was a bunch of extra code in emit-only. Did a few passes over it taking advantage of the function in mapcat, that nil is the same as an empty sequence and concatenates to nothing and that missing bindings are false to get it down to a single line. (That last one is a change of behaviour if a false value is ever in the map, but I don't see that ever happening.