### PR TITLE
Avoid leaking selected ice to runner when trash-like-cards is enabled

### DIFF
--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2731,6 +2731,27 @@
       (is (no-prompt? state :corp) "No lingering prompts")
       (is (no-prompt? state :runner) "No lingering prompts"))))
 
+(deftest key-performance-indicators-issue-8729
+  ;; When choosing to install ice, the selected ice should not leak to the runner. Issue #8729
+  ;; The bug is reproduced when Corp has enabled the "trash like cards" setting.
+  (do-game
+   (new-game {:corp {:hand ["Key Performance Indicators" "Ice Wall" "Enigma" "NGO Front" "Hedge Fund"]
+                     :deck ["IPO"]}})
+   (play-from-hand state :corp "Ice Wall" "HQ") ; install an ice that we will be prompted to trash
+   (play-from-hand state :corp "Key Performance Indicators")
+   (click-prompt state :corp "Gain 2 [Credit]")
+
+   (swap! state assoc-in [:corp :properties :trash-like-cards] true)
+   (click-prompt state :corp "Install 1 piece of ice from HQ, ignoring all costs")
+   (click-card state :corp "Enigma")
+   (click-prompt state :corp "HQ")
+   (let [card-runner-sees (-> (prompt-map :runner) :card :title)]
+     (is (not= card-runner-sees "Enigma") "Runner should not see the selected ice"))
+
+   (click-prompt state :corp "Done")
+   (is (no-prompt? state :corp) "No lingering prompts")
+   (is (no-prompt? state :runner) "No lingering prompts")))
+
 (deftest kill-switch
   ;; Kill Switch
   (do-game


### PR DESCRIPTION
This PR is not ready for merging, it just makes progress on issue #8729 by reproducing it in a failing test.

One way to make the test pass is to set `:waiting-prompt false` instead of `true` in [game.core.installing/corp-install-pay](https://github.com/mtgred/netrunner/blob/0a80cb0856cd43da768159bc3c6db8bac2c0b60a/src/clj/game/core/installing.clj#L400), but I'm not sure it's the right fix, could be too heavy-handed. I didn't work out the consequences enough to assess that.

Also note that the added test is filed under the existing one for Key Performance Indicators, however the bug is not specific to that card. Don't know if the test would be better placed elsewhere.

Not sure I'll have time to continue working on this so feel free to pick it up.