### PR TITLE
Ice swap vs beta build

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -307,17 +307,17 @@
                            :effect (effect (runner-install state side eid target {:ignore-all-cost :true :msg-keys {:display-origin true :source-card card}}))}
                           card nil)]
                        (continue-ability state side
-                         (run-any-server-ability
-                           {:events [{:event :run-ends
-                                      :unregister-once-resolved true
-                                      :duration :end-of-run
-                                      :interactive (effect true)
-                                      :automatic :last
-                                      :change-in-game-state {:silent true
-                                                             :req (req (get-card state installed-card))}
-                                      :msg (msg "add " (:title installed-card) " to the top of the stack")
-                                      :effect (effect (move state side installed-card :deck {:front true}))}]})
-                         card nil)))}})
+                                         (run-any-server-ability
+                                           {:events [{:event :run-ends
+                                                      :unregister-once-resolved true
+                                                      :duration :end-of-run
+                                                      :interactive (effect true)
+                                                      :automatic :last
+                                                      :change-in-game-state {:silent true
+                                                                             :req (req (get-card state installed-card))}
+                                                      :msg (msg "add " (:title installed-card) " to the top of the stack")
+                                                      :effect (effect (move state side (get-card state installed-card) :deck {:front true}))}]})
+                                         card nil)))}})
 
 (defcard "Black Hat"
   {:on-play

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -438,6 +438,13 @@
 
      (declare get-card-hosted)
 
+     (defn get-corp-installed-card
+       "returns the most recent copy of an installed card where the zone might not exactly match"
+       [state {:keys [cid zone side type] :as card}]
+       (when (and zone (#{:ices :content} (last zone)))
+         (let [relevant (mapcat (last zone) (-> @state :corp :servers vals))]
+           (some #(when (= (:cid %) cid) %) relevant))))
+
      (defn get-card
        "Returns the most recent copy of the card from the current state, as identified
        by the argument's :zone and :cid."
@@ -458,7 +465,13 @@
      (defn get-card-hosted
        "Finds the current version of the given card by finding its host."
        [state card]
-       (let [root-host (get-card state (get-nested-host card))
+       (let [root-host (get-nested-host card)
+             ;; Note: the reference passed to us might have a host with a now-obsolete zone
+             ;; if it has been swapped. Since get-card looks up by zones, get-card on the host would
+             ;; present us with nil, and get-card on the hosted card would return nil.
+             ;; The get-corp-installed lookup is expensive, but should only occur rarely.
+             root-host (or (get-card state root-host)
+                           (get-corp-installed-card state root-host))
              helper (fn search [card target]
                       (when-not (nil? card)
                         (if-let [c (some #(when (same-card? % target) %) (:hosted card))]

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -546,6 +546,22 @@
     (click-prompt state :runner "No action")
     (is-deck? state :runner ["Orca"])))
 
+(deftest beta-build-vs-ice-swap
+  (do-game
+    (new-game {:runner {:hand ["Beta Build" "Rising Tide" "Sipa"] :credits 10 :deck ["Kyuban"]}
+               :corp {:hand ["Vanilla" "Ice Wall"]}})
+    (play-cards state :corp ["Vanilla" "HQ" :rezzed] ["Ice Wall" "R&D"])
+    (take-credits state :corp)
+    (play-cards state :runner "Rising Tide" "Sipa" ["Beta Build" "Kyuban" "Vanilla" "HQ"])
+    (run-continue-until state :encounter-ice)
+    (card-ability state :runner (get-program state 0) 0)
+    (click-prompt state :runner "End the run")
+    (run-continue state)
+    (click-prompts state :runner "Kyuban" "Sipa" "Ice Wall")
+    (run-continue-until state :success)
+    (is (no-prompt? state :runner) "No lingering prompt")
+    (is-deck? state :runner ["Kyuban"])))
+
 #_(deftest ^:kaocha/pending beta-build-cannot-run
     ;; note that peace in our time needs to be updated currently, it forbids
     ;; run events when it should not


### PR DESCRIPTION
Closes #8737

We needed to call get-card on the card to bounce.

But then it turns out calling `get-card` on the old reference wouldn't return a result because it was looking up the host in the index of the old hosted reference and not the new one.

I kind of wonder why we don't have a better system for finding cards. Surely a map in state of zones like `{:corp {:cids {"aaaaaaaaa" [:servers :hq :ices] ...}}}` could take a lot of awkward code out of the code base (I get that it will add more too).