### PR TITLE
Fix card-def Error

### DIFF
--- a/src/clj/game/core/card_defs.clj
+++ b/src/clj/game/core/card_defs.clj
@@ -9,6 +9,5 @@
   (cond
     title (or (defcard-impl title) {})
     printed-title (or (defcard-impl printed-title) {})
-    :else (throw (ex-info "Tried to select card def for non-existent card"
-                          {:msg "Tried to select card-def for non existent card"
-                           :card card}))))
+    :else (let [msg "Tried to select card-def for non-existent card."]
+            (throw (ex-info msg {:msg msg :card card})))))


### PR DESCRIPTION
The two versions of the error message in `card-def` were not consistent. So I changed it so they had to be.

I was going to do this with a larger fix that didn't work out, so here is this tiny change on its own.