### PR TITLE
Resync on dropped states

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -489,6 +489,7 @@
    :runner
    :runner-phase-12
    :runner-post-discard
+   :sequence
    :sfx
    :sfx-current-id
    :start-date
@@ -579,6 +580,7 @@
       base-diff)))
 
 (defn public-diffs [old-state new-state spectators? corp-spectators? runner-spectators?]
+  (swap! new-state update :sequence inc)
   (let [{old-corp :corp-state old-runner :runner-state
          old-spect :spect-state old-hist :hist-state
          old-corp-spect :corp-spect-state

--- a/src/clj/game/core/state.clj
+++ b/src/clj/game/core/state.clj
@@ -75,5 +75,6 @@
      :start-date now
      :options options
      :encounters []
+     :sequence 0
      :corp corp
      :runner runner}))

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -1,6 +1,7 @@
 (ns nr.gameboard.actions
   (:require
    [differ.core :as differ]
+   [goog.functions :as gfn]
    [nr.angel-arena.lobby :as angel-arena]
    [nr.appstate :refer [app-state current-gameid]]
    [nr.gameboard.replay :refer [init-replay]]
@@ -42,13 +43,23 @@
   (-> "#gameboard" js/$ .fadeOut)
   (-> "#gamelobby" js/$ .fadeIn))
 
+(defn- sequence-resync []
+  (prn "resynchronising game state due to out of order data")
+  (ws/resync))
+
 (defn handle-diff! [{:keys [gameid diff]}]
   (when (= gameid (str (current-gameid app-state)))
-    (let [patch (differ/patch @last-state diff)]
-      (reset! game-state patch))
-    (check-lock?)
-    (let [gs @game-state]
-      (reset! last-state gs))))
+    (let [old-sequence (:sequence @game-state)
+          patch (differ/patch @last-state diff)]
+      (reset! game-state patch)
+      (check-lock?)
+      (let [gs @game-state]
+        (reset! last-state gs))
+      ;; Note: Although websockets gaurantee in-order delivery, they do not gaurantee
+      ;; delivery of every message. If we miss a message, we need to trigger a re-sync.
+      (let [new-sequence (:sequence @game-state)]
+        (when (not= new-sequence (inc old-sequence))
+          (gfn/throttle sequence-resync 1500))))))
 
 (declare toast)
 (defn handle-timeout [gameid]


### PR DESCRIPTION
This makes it so that when states are dropped (ie there was enough packet loss than an entire message didn't make it), we can trigger a resync.

I throttled it so it's not possible to resync this way more than once every 1.5 seconds.

This required adding a tiny bit of extra info (just a sequence number) into the state. This is incremented whenever we crunch diffs to send to clients, but not when resyncing.

This covers us for dropped packets, and I think it should cover us for duplicate packages too in *most* circumstances. If those happen within 1.5 seconds of a resync, then :shrug:.

Closes #8727 (and maybe a few more, I'll scan later)