### PR TITLE
feat: default decks and game options

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1558,6 +1558,8 @@ settings_api-keys-not-updated = Failed to update API keys
 
 settings_api-keys-updated = Updated API keys
 
+settings_auto-select-default-deck = Auto-select default deck in casual games
+
 settings_avatar = Avatar
 
 settings_background = Game board background
@@ -1687,6 +1689,8 @@ settings_language-tip = Some languages are not fully translated yet. If you woul
 settings_layout-device = Device Layout
 
 settings_layout-options = Layout options
+
+settings_game-settings = Game Settings
 
 settings_log-player-highlight = Log player highlight
 

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1640,6 +1640,10 @@ settings_deck-stats = Deck statistics
 
 settings_default-game-description = Default game description in casual games
 
+settings_default-password = Default game password
+
+settings_default-password-protect-casual = Password protect by default in casual games
+
 settings_default-save-replay = Save replays by default in casual games
 
 settings_delete-api-key = Delete

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -236,6 +236,8 @@ deck-builder_decklist = Decklist
 
 deck-builder_decklist-inst = (Type or paste a decklist, it will be parsed)
 
+deck-builder_default = Default deck
+
 deck-builder_delete = Delete
 
 deck-builder_delete-selected = Delete Selected
@@ -301,11 +303,15 @@ deck-builder_save = Save
 
 deck-builder_select-all = Select All
 
+deck-builder_set-default = Set Default
+
 deck-builder_show-credit-cost = Show Credit Cost
 
 deck-builder_show-memory-cost = Show Memory Cost
 
 deck-builder_unselect-all = Unselect All
+
+deck-builder_unset-default = Unset Default
 
 deck-builder_view-options = View Options
 
@@ -1064,6 +1070,8 @@ lobby_save-replay-details = This will save a replay file of this match with open
 lobby_save-replay-unshared = Only your latest 15 unshared games will be kept, so make sure to either download or share the match afterwards.
 
 lobby_select-deck = Select Deck
+
+lobby_select-default-deck = Select Default Deck
 
 lobby_select-error = Cannot select that deck
 

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1558,7 +1558,9 @@ settings_api-keys-not-updated = Failed to update API keys
 
 settings_api-keys-updated = Updated API keys
 
-settings_auto-select-default-deck = Auto-select default deck in casual games
+settings_auto-select-default-deck-casual = Auto-select default deck in casual games
+
+settings_auto-select-default-deck-tournament = Auto-select default deck in tournament games
 
 settings_avatar = Avatar
 

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1636,6 +1636,10 @@ settings_current-email = Current email
 
 settings_deck-stats = Deck statistics
 
+settings_default-game-description = Default game description in casual games
+
+settings_default-save-replay = Save replays by default in casual games
+
 settings_delete-api-key = Delete
 
 settings_desired-email = Desired email

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -249,7 +249,7 @@
 
 (defmethod ws/-msg-handler :game/rejoin
   game--rejoin
-  [{{user :user} :ring-req
+  [{{db :system/db user :user} :ring-req
     uid :uid
     ?data :?data
     id :id
@@ -261,7 +261,7 @@
                 original-player
                 (< (count (remove #(= uid (:uid %)) players)) 2))
        (let [?data (assoc ?data :request-side "Any Side")
-             lobby? (lobby/join-lobby! user uid ?data nil lobby)]
+             lobby? (lobby/join-lobby! db user uid ?data nil lobby)]
          (when lobby?
            (send-state-to-uid! uid :game/start lobby? (diffs/public-states (:state lobby?)))
            (update-and-send-diffs! main/handle-rejoin lobby? user)))))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -10,7 +10,7 @@
     [crypto.password.bcrypt :as bcrypt]
     [game.core :as core]
     [game.utils :refer [server-card]]
-    [jinteki.utils :refer [select-non-nil-keys side-from-str superuser? to?]]
+    [jinteki.utils :refer [constructed-game? select-non-nil-keys side-from-str superuser? to?]]
     [jinteki.preconstructed :refer [all-matchups]]
     [jinteki.validator :as validator]
     [medley.core :refer [find-first]]
@@ -545,7 +545,7 @@
 
 (defn auto-select-decks
   [db lobby]
-  (if (or (:started lobby) (not= "casual" (:room lobby)))
+  (if (or (:started lobby) (not= "casual" (:room lobby)) (not (constructed-game? lobby)))
     lobby
     (update lobby :players
             (partial mapv #(if (:deck %) % (maybe-auto-select-deck db lobby %))))))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -25,6 +25,8 @@
 
 (read-write/print-time-literals-clj!)
 
+(declare auto-select-decks)
+
 (defonce telemetry-buckets (agent {}))
 (defn log-delay!
   [timestamp id]
@@ -345,8 +347,9 @@
   (update lobby :messages conj message))
 
 (defn try-create-lobby
-  [uid user ?data]
+  [db uid user ?data]
   (let [lobby (-> (create-new-lobby {:uid uid :user user :options ?data})
+                  (->> (auto-select-decks db))
                   (send-message
                     (core/make-system-message (str (:username user) " has created the game."))))
         new-app-state (swap! app-state/app-state update :lobbies
@@ -359,7 +362,7 @@
 
 (defmethod ws/-msg-handler :lobby/create
   lobby--create
-  [{{user :user} :ring-req
+  [{{db :system/db user :user} :ring-req
     uid :uid
     ?data :?data
     id :id
@@ -368,7 +371,7 @@
     (if (:block-game-creation @app-state/app-state)
       (ws/chsk-send! uid [:lobby/toast {:message :lobby_creation-paused
                                         :type "error"}])
-      (try-create-lobby uid user ?data))
+      (try-create-lobby db uid user ?data))
     (log-delay! timestamp id)))
 
 (defn clear-lobby-state [uid]
@@ -526,6 +529,27 @@
                   p))
         players))
 
+(defn auto-select-deck-id
+  [{:keys [auto-select-default-deck default-decks]} format side]
+  (when (and auto-select-default-deck side (not= "Any Side" side))
+    (get-in default-decks [(keyword side) (keyword format)])))
+
+(defn maybe-auto-select-deck
+  [db lobby player]
+  (let [options (:options (app-state/get-user (:uid player)))
+        deck (when-let [deck-id (auto-select-deck-id options (:format lobby) (:side player))]
+               (process-deck (find-deck-for-user db deck-id (:user player))))]
+    (if (and deck (valid-deck-for-lobby? lobby deck))
+      (assoc player :deck deck)
+      player)))
+
+(defn auto-select-decks
+  [db lobby]
+  (if (or (:started lobby) (not= "casual" (:room lobby)))
+    lobby
+    (update lobby :players
+            (partial mapv #(if (:deck %) % (maybe-auto-select-deck db lobby %))))))
+
 (defn handle-select-deck [lobbies uid deck]
   (let [lobby (app-state/uid-player->lobby lobbies uid)
         gameid (:gameid lobby)]
@@ -625,21 +649,22 @@
                           :side user-side}]
       (assoc lobby :players [existing-player user-as-player]))))
 
-(defn handle-join-lobby [lobbies ?data uid user correct-password? join-message]
+(defn handle-join-lobby [db lobbies ?data uid user correct-password? join-message]
   (let [{:keys [gameid request-side]} ?data
         lobby (get lobbies gameid)]
     (if (and user lobby (allowed-in-lobby user lobby) correct-password?)
       (-> lobby
           (insert-user-as-player uid user request-side)
+          (->> (auto-select-decks db))
           (send-message join-message)
           (->> (assoc lobbies gameid)))
       lobbies)))
 
-(defn join-lobby! [user uid ?data ?reply-fn lobby]
+(defn join-lobby! [db user uid ?data ?reply-fn lobby]
   (let [correct-password? (check-password lobby user (:password ?data))
         join-message (core/make-system-message (str (:username user) " joined the game."))
         new-app-state (swap! app-state/app-state update :lobbies
-                             #(handle-join-lobby % ?data uid user correct-password? join-message))
+                             #(handle-join-lobby db % ?data uid user correct-password? join-message))
         lobby? (get-in new-app-state [:lobbies (:gameid ?data)])]
     (cond
       (and lobby? correct-password?)
@@ -659,7 +684,7 @@
 
 (defmethod ws/-msg-handler :lobby/join
   lobby--join
-  [{{user :user} :ring-req
+  [{{db :system/db user :user} :ring-req
     uid :uid
     {gameid :gameid :as ?data} :?data
     ?reply-fn :?reply-fn
@@ -667,7 +692,7 @@
     timestamp :timestamp}]
   (lobby-thread
     (when-let [lobby (app-state/get-lobby gameid)]
-      (join-lobby! user uid ?data ?reply-fn lobby))
+      (join-lobby! db user uid ?data ?reply-fn lobby))
     (log-delay! timestamp id)))
 
 (defn swap-side
@@ -691,10 +716,11 @@
       (some? side) (update lobby :players (fn [x] (mapv #(change-side % side) x)))
       :else (update lobby :players #(mapv swap-side %)))))
 
-(defn handle-swap-sides [lobbies gameid uid side swap-message]
+(defn handle-swap-sides [db lobbies gameid uid side swap-message]
   (if-let [lobby (get lobbies gameid)]
     (-> lobby
         (update-sides uid side)
+        (->> (auto-select-decks db))
         (send-message swap-message)
         (->> (assoc lobbies gameid)))
     lobbies))
@@ -717,7 +743,7 @@
 
 (defmethod ws/-msg-handler :lobby/swap
   lobby--swap
-  [{{user :user} :ring-req
+  [{{db :system/db user :user} :ring-req
     uid :uid
     {:keys [gameid side]} :?data
     id :id
@@ -729,8 +755,7 @@
                                                :text (swap-text (:players lobby) side)})
               new-app-state (swap! app-state/app-state
                                    update :lobbies
-                                   #(-> %
-                                        (handle-swap-sides gameid uid side swap-message)
+                                   #(-> (handle-swap-sides db % gameid uid side swap-message)
                                         (handle-set-last-update gameid uid)))
               lobby? (get-in new-app-state [:lobbies gameid])]
           (send-lobby-state lobby?)

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -529,15 +529,22 @@
                   p))
         players))
 
+(defn auto-select-enabled?
+  [{:keys [auto-select-default-deck-casual auto-select-default-deck-tournament]} room]
+  (case room
+    "casual" auto-select-default-deck-casual
+    "competitive" auto-select-default-deck-tournament
+    false))
+
 (defn auto-select-deck-id
-  [{:keys [auto-select-default-deck default-decks]} format side]
-  (when (and auto-select-default-deck side (not= "Any Side" side))
-    (get-in default-decks [(keyword side) (keyword format)])))
+  [options room format side]
+  (when (and (auto-select-enabled? options room) side (not= "Any Side" side))
+    (get-in options [:default-decks (keyword side) (keyword format)])))
 
 (defn maybe-auto-select-deck
   [db lobby player]
   (let [options (:options (app-state/get-user (:uid player)))
-        deck (when-let [deck-id (auto-select-deck-id options (:format lobby) (:side player))]
+        deck (when-let [deck-id (auto-select-deck-id options (:room lobby) (:format lobby) (:side player))]
                (process-deck (find-deck-for-user db deck-id (:user player))))]
     (if (and deck (valid-deck-for-lobby? lobby deck))
       (assoc player :deck deck)
@@ -545,7 +552,7 @@
 
 (defn auto-select-decks
   [db lobby]
-  (if (or (:started lobby) (not= "casual" (:room lobby)) (not (constructed-game? lobby)))
+  (if (or (:started lobby) (not (constructed-game? lobby)))
     lobby
     (update lobby :players
             (partial mapv #(if (:deck %) % (maybe-auto-select-deck db lobby %))))))

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -99,6 +99,11 @@
     :sync? true
     :validate-fn validate-alt-arts
     :doc "User's selected alternate art set when :show-alt-art is true"}
+   {:key :auto-select-default-deck
+    :default false
+    :sync? true
+    :validate-fn boolean?
+    :doc "Auto-select your default deck on casual lobbies"}
    {:key :archives-sorted
     :default false
     :sync? true

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -82,6 +82,10 @@
   "Validates visible-formats is a set of valid format strings"
   (validate-coll-of #(contains? valid-formats %) set?))
 
+(def validate-default-decks
+  "Validates default-decks is a map of side -> {format -> deck-id-string}"
+  (validate-map-of keyword? (validate-map-of keyword? string?)))
+
 (def all-settings
   "Vector of all application settings with their metadata.
    Each setting has:
@@ -150,6 +154,11 @@
     :sync? true
     :validate-fn #(contains? valid-stats-options %)
     :doc "When to show deck statistics (always/competitive/none)"}
+   {:key :default-decks
+    :default {}
+    :sync? true
+    :validate-fn validate-default-decks
+    :doc "Default deck _id per side+format, auto-selected in the lobby"}
    {:key :default-format
     :default "standard"
     :sync? true

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -102,11 +102,16 @@
     :sync? true
     :validate-fn validate-alt-arts
     :doc "User's selected alternate art set when :show-alt-art is true"}
-   {:key :auto-select-default-deck
+   {:key :auto-select-default-deck-casual
     :default false
     :sync? true
     :validate-fn boolean?
-    :doc "Auto-select your default deck on casual lobbies"}
+    :doc "Auto-select default deck in casual games"}
+   {:key :auto-select-default-deck-tournament
+    :default false
+    :sync? true
+    :validate-fn boolean?
+    :doc "Auto-select default deck in tournament games"}
    {:key :archives-sorted
     :default false
     :sync? true

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -8,7 +8,9 @@
 
    All settings are validated before being stored in app state. Invalid values are
    filtered out at each source level, ensuring app state always contains valid settings."
-  (:require [clojure.string :as str]))
+  (:require
+   [clojure.string :as str]
+   [jinteki.utils :as utils]))
 
 ;; Validation constants
 (def valid-background-slugs
@@ -33,6 +35,7 @@
 (def valid-card-sleeves #{"ffg-card-back" "nsg-card-back" "ffg" "nsg"})
 (def valid-formats #{"standard" "throwback" "startup" "system-gateway"
                      "core" "preconstructed" "eternal" "casual"})
+(def valid-game-descriptions (set (map name (keys utils/descriptions))))
 
 ;; Validation combinators
 (defn- validate-coll-of
@@ -169,6 +172,16 @@
     :sync? true
     :validate-fn #(contains? valid-formats %)
     :doc "Default game format when creating new games"}
+   {:key :default-game-description
+    :default "new-game_default"
+    :sync? true
+    :validate-fn #(contains? valid-game-descriptions %)
+    :doc "Default game description in casual games"}
+   {:key :default-save-replay
+    :default false
+    :sync? true
+    :validate-fn boolean?
+    :doc "Save replays by default in casual games"}
    {:key :disable-websockets
     :default false
     :sync? false  ; device-specific

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -182,6 +182,16 @@
     :sync? true
     :validate-fn #(contains? valid-game-descriptions %)
     :doc "Default game description in casual games"}
+   {:key :default-password
+    :default ""
+    :sync? true
+    :validate-fn string?
+    :doc "Default game password"}
+   {:key :default-password-protect-casual
+    :default false
+    :sync? true
+    :validate-fn boolean?
+    :doc "Password protect by default in casual games"}
    {:key :default-save-replay
     :default false
     :sync? true

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -50,6 +50,14 @@
   (or (get-in @state [:runner :tag :is-tagged])
       (pos? (count-tags state))))
 
+(defn constructed-format?
+  [format]
+  (not (#{"quick-draft" "chimera"} format)))
+
+(defn constructed-game?
+  [{:keys [precon format]}]
+  (and (not precon) (constructed-format? format)))
+
 (defn slugify
   "As defined here: https://you.tools/slugify/"
   ([string] (slugify string "-"))

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -119,6 +119,14 @@
           (next keyseq)))
       (with-meta (persistent! ret) (meta m)))))
 
+(def descriptions
+  "Game description options when creating a lobby."
+  {:new-game_default "No special conditions"
+   :new-game_meta-deck "Play against meta decks"
+   :new-game_casual "Casual play"
+   :new-game_competitive "Play competitive games"
+   :new-game_new-player "Learning the game"})
+
 (def command-info
   [{:name "/adv-counter"
     :has-args :required

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -378,14 +378,22 @@
                  [tr-span [:settings_bespoke-sounds group-name] {:sound group-name}]]]))]
 
           [:section
-           [tr-element :h3 [:lobby_default-game-format "Default game format"]]
-           [:select.format
-            {:value (or (:default-format @s) "standard")
-             :on-change #(swap! s assoc :default-format (.. % -target -value))}
-            (doall
-             (for [[k v] slug->format]
-               ^{:key k}
-               [:option {:value k :data-i18n-key k} (tr-format v)]))]]
+           [tr-element :h3 [:settings_game-settings "Game Settings"]]
+           [:div
+            [tr-element :h4 [:lobby_default-game-format "Default game format"]]
+            [:select.format
+             {:value (or (:default-format @s) "standard")
+              :on-change #(swap! s assoc :default-format (.. % -target -value))}
+             (doall
+              (for [[k v] slug->format]
+                ^{:key k}
+                [:option {:value k :data-i18n-key k} (tr-format v)]))]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:auto-select-default-deck @s)
+                             :on-change #(swap! s assoc :auto-select-default-deck (.. % -target -checked))}]
+             [tr-span [:settings_auto-select-default-deck "Auto-select default deck in casual games"]]]]]
 
           [:section
            [tr-element :h3 [:settings_gameplay-settings "Gameplay Settings"]]
@@ -737,6 +745,7 @@
                    (select-keys [:pronouns :bespoke-sounds :language :card-language :sounds :default-format
                                  :lobby-sounds :sounds-volume :background :custom-bg-url :card-zoom
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
+                                 :auto-select-default-deck
                                  :player-stats-icons :stacked-cards :ghost-trojans
                                  :corp-card-sleeve :runner-card-sleeve :prizes
                                  :display-encounter-info :sides-overlap :log-timestamps

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -401,6 +401,18 @@
            [:div
             [:label [:input {:type "checkbox"
                              :value true
+                             :checked (:default-password-protect-casual @s)
+                             :on-change #(swap! s assoc :default-password-protect-casual (.. % -target -checked))}]
+             [tr-span [:settings_default-password-protect-casual "Password protect by default in casual games"]]]]
+           [:div
+            [tr-element :h4 [:settings_default-password "Default game password"]]
+            [:input {:type "text"
+                     :maxLength "30"
+                     :on-change #(swap! s assoc :default-password (.. % -target -value))
+                     :value (:default-password @s "")}]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
                              :checked (:default-save-replay @s)
                              :on-change #(swap! s assoc :default-save-replay (.. % -target -checked))}]
              [tr-span [:settings_default-save-replay "Save replays by default in casual games"]]]]
@@ -769,6 +781,7 @@
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
                                  :auto-select-default-deck-casual :auto-select-default-deck-tournament
                                  :default-game-description :default-save-replay
+                                 :default-password :default-password-protect-casual
                                  :player-stats-icons :stacked-cards :ghost-trojans
                                  :corp-card-sleeve :runner-card-sleeve :prizes
                                  :display-encounter-info :sides-overlap :log-timestamps

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -407,9 +407,15 @@
            [:div
             [:label [:input {:type "checkbox"
                              :value true
-                             :checked (:auto-select-default-deck @s)
-                             :on-change #(swap! s assoc :auto-select-default-deck (.. % -target -checked))}]
-             [tr-span [:settings_auto-select-default-deck "Auto-select default deck in casual games"]]]]]
+                             :checked (:auto-select-default-deck-casual @s)
+                             :on-change #(swap! s assoc :auto-select-default-deck-casual (.. % -target -checked))}]
+             [tr-span [:settings_auto-select-default-deck-casual "Auto-select default deck in casual games"]]]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:auto-select-default-deck-tournament @s)
+                             :on-change #(swap! s assoc :auto-select-default-deck-tournament (.. % -target -checked))}]
+             [tr-span [:settings_auto-select-default-deck-tournament "Auto-select default deck in tournament games"]]]]]
 
           [:section
            [tr-element :h3 [:settings_gameplay-settings "Gameplay Settings"]]
@@ -761,7 +767,8 @@
                    (select-keys [:pronouns :bespoke-sounds :language :card-language :sounds :default-format
                                  :lobby-sounds :sounds-volume :background :custom-bg-url :card-zoom
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
-                                 :auto-select-default-deck :default-game-description :default-save-replay
+                                 :auto-select-default-deck-casual :auto-select-default-deck-tournament
+                                 :default-game-description :default-save-replay
                                  :player-stats-icons :stacked-cards :ghost-trojans
                                  :corp-card-sleeve :runner-card-sleeve :prizes
                                  :display-encounter-info :sides-overlap :log-timestamps

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -6,6 +6,7 @@
    [goog.dom :as gdom]
    [jinteki.cards :refer [all-cards]]
    [jinteki.settings :as settings]
+   [jinteki.utils :refer [descriptions]]
    [medley.core :as m]
    [nr.ajax :refer [DELETE GET POST PUT]]
    [nr.appstate :refer [app-state]]
@@ -389,6 +390,21 @@
                 ^{:key k}
                 [:option {:value k :data-i18n-key k} (tr-format v)]))]]
            [:div
+            [tr-element :h4 [:settings_default-game-description "Default game description in casual games"]]
+            [:select.description
+             {:value (or (:default-game-description @s) "new-game_default")
+              :on-change #(swap! s assoc :default-game-description (.. % -target -value))}
+             (doall
+              (for [[k v] descriptions]
+                ^{:key k}
+                [:option {:value k :data-i18n-key k} (tr [k v])]))]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:default-save-replay @s)
+                             :on-change #(swap! s assoc :default-save-replay (.. % -target -checked))}]
+             [tr-span [:settings_default-save-replay "Save replays by default in casual games"]]]]
+           [:div
             [:label [:input {:type "checkbox"
                              :value true
                              :checked (:auto-select-default-deck @s)
@@ -745,7 +761,7 @@
                    (select-keys [:pronouns :bespoke-sounds :language :card-language :sounds :default-format
                                  :lobby-sounds :sounds-volume :background :custom-bg-url :card-zoom
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
-                                 :auto-select-default-deck
+                                 :auto-select-default-deck :default-game-description :default-save-replay
                                  :player-stats-icons :stacked-cards :ghost-trojans
                                  :corp-card-sleeve :runner-card-sleeve :prizes
                                  :display-encounter-info :sides-overlap :log-timestamps

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -724,6 +724,23 @@
          " - " [tr-span [:deck-builder_won "Won"] {:won wins :percent (safe-divide wins (+ wins losses))}]
          " - " [tr-span [:deck-builder_lost "Lost"] {:lost losses}]]))))
 
+(defn default-deck?
+  [deck]
+  (let [side (keyword (get-in deck [:identity :side]))
+        fmt (keyword (:format deck))]
+    (= (:_id deck) (get-in @app-state [:options :default-decks side fmt]))))
+
+(defn toggle-default-deck
+  [deck]
+  (authenticated
+    (fn [_]
+      (let [side (keyword (get-in deck [:identity :side]))
+            fmt (keyword (:format deck))]
+        (if (default-deck? deck)
+          (swap! app-state update-in [:options :default-decks side] dissoc fmt)
+          (swap! app-state assoc-in [:options :default-decks side fmt] (:_id deck)))
+        (go (<! (PUT "/profile" (:options @app-state) :json)))))))
+
 (defn deck-entry [s deck]
   (r/with-let [state-deck (r/cursor s [:deck])
                cleanup-mode (r/cursor s [:cleanup-mode])
@@ -744,7 +761,9 @@
        [:span.float-right
         [deck-status-span deck]
         [:p (deck-date deck)]]
-       [:h4 (deck-name deck)]
+       [:h4 (when (default-deck? deck)
+              [:span.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
+        (deck-name deck)]
        [:span (tr-data :title (:identity deck))]
        [deck-stats-line deck]])))
 
@@ -1037,6 +1056,12 @@
               (not= "none" (get-in @app-state [:options :deckstats])))
      [:button {:on-click #(clear-deck-stats s)}
       [tr-span [:deck-builder_clear-stats "Clear Stats"]]])
+   [cond-button
+    (if (default-deck? deck)
+      [tr-span [:deck-builder_unset-default "Unset Default"]]
+      [tr-span [:deck-builder_set-default "Set Default"]])
+    (boolean (:_id deck))
+    #(toggle-default-deck deck)]
    ;; (let [disabled (or (:editing-game @app-state false)
    ;;                    (:gameid @app-state false)
    ;;                    (and (not= (:format deck) "casual")

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -4,7 +4,7 @@
     [cljs.core.async :refer [<! >! chan put! timeout go-loop] :as async]
     [clojure.string :refer [join lower-case split split-lines] :as str]
     [jinteki.cards :refer [all-cards] :as cards]
-    [jinteki.utils :refer [INFINITY str->int] :as utils]
+    [jinteki.utils :refer [INFINITY constructed-format? str->int] :as utils]
     [jinteki.validator :as validator]
     [nr.ajax :refer [DELETE GET POST PUT]]
     [nr.appstate :refer [app-state]]
@@ -1056,12 +1056,13 @@
               (not= "none" (get-in @app-state [:options :deckstats])))
      [:button {:on-click #(clear-deck-stats s)}
       [tr-span [:deck-builder_clear-stats "Clear Stats"]]])
-   [cond-button
-    (if (default-deck? deck)
-      [tr-span [:deck-builder_unset-default "Unset Default"]]
-      [tr-span [:deck-builder_set-default "Set Default"]])
-    (boolean (:_id deck))
-    #(toggle-default-deck deck)]
+   (when (constructed-format? (:format deck))
+     [cond-button
+      (if (default-deck? deck)
+        [tr-span [:deck-builder_unset-default "Unset Default"]]
+        [tr-span [:deck-builder_set-default "Set Default"]])
+      (boolean (:_id deck))
+      #(toggle-default-deck deck)])
    ;; (let [disabled (or (:editing-game @app-state false)
    ;;                    (:gameid @app-state false)
    ;;                    (and (not= (:format deck) "casual")

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -761,9 +761,9 @@
        [:span.float-right
         [deck-status-span deck]
         [:p (deck-date deck)]]
-       [:h4 (when (default-deck? deck)
-              [:span.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
-        (deck-name deck)]
+       (when (default-deck? deck)
+         [:span.float-right.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
+       [:h4 (deck-name deck)]
        [:span (tr-data :title (:identity deck))]
        [deck-stats-line deck]])))
 

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -214,7 +214,7 @@
    :pending-game_new-player "Looking To: Learn the game"})
 
 (defn description-span [description]
-  (when (and description (not= description :new-game_default))
+  (when (and description (not= description "new-game_default"))
     (let [k (keyword (str "pending-game_" (last (s/split (name description) #"_"))))]
       [:span.format-precon-deck-names {:class "game-description"}
        [tr-span [k (k descriptions)]]])))

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -5,7 +5,7 @@
     [nr.appstate :refer [app-state]]
     [nr.auth :refer [authenticated] :as auth]
     [nr.translations :refer [tr tr-format tr-side tr-element tr-span]]
-    [nr.utils :refer [cond-button slug->format]]
+    [nr.utils :refer [cond-button focus-on-mount slug->format]]
     [nr.ws :as ws]
     [reagent.core :as r]))
 
@@ -186,6 +186,7 @@
    (when (:protected @options)
      [:p
       [:input.game-title {:on-change #(swap! options assoc :password (.. % -target -value))
+                          :ref focus-on-mount
                           :value (:password @options)
                           :data-i18n-key :lobby_password
                           :placeholder (tr [:lobby_password "Password"])

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -177,11 +177,11 @@
   [:<>
    [:p
     [:label
-     [:input {:type "checkbox" :checked (:private @options)
+     [:input {:type "checkbox" :checked (:protected @options)
               :on-change #(let [checked (.. % -target -checked)]
                             (swap! options assoc :protected checked)
                             (when (not checked)
-                              (swap! options assoc :password "")))}]
+                              (swap! options assoc :password (:password @options))))}]
      [tr-span [:lobby_password-protected "Password protected"]]]]
    (when (:protected @options)
      [:p
@@ -259,6 +259,8 @@
 
 (defn create-new-game [lobby-state user]
   (r/with-let [casual? (= "casual" (:room @lobby-state))
+               default-password (get-in @app-state [:options :default-password] "")
+               protected? (and casual? (get-in @app-state [:options :default-password-protect-casual]))
                state (r/atom {:flash-message ""
                               :format (or (get-in @app-state [:options :default-format]) "standard")
                               :room (:room @lobby-state)
@@ -270,8 +272,8 @@
                               :title (str (:username @user) "'s game")})
                options (r/atom {:allow-spectator true
                                 :api-access false
-                                :password ""
-                                :protected false
+                                :password default-password
+                                :protected protected?
                                 :save-replay (if casual?
                                                (get-in @app-state [:options :default-save-replay])
                                                true)

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -1,6 +1,6 @@
 (ns nr.new-game
   (:require
-    [jinteki.utils :refer [str->int]]
+    [jinteki.utils :refer [str->int descriptions]]
     [jinteki.preconstructed :refer [all-matchups matchup-by-key]]
     [nr.appstate :refer [app-state]]
     [nr.auth :refer [authenticated] :as auth]
@@ -27,13 +27,6 @@
    :replay-timestamp
    :timer
    :title])
-
-(def descriptions
-  {:new-game_default "No special conditions"
-   :new-game_meta-deck "Play against meta decks"
-   :new-game_casual "Casual play"
-   :new-game_competitive "Play competitive games"
-   :new-game_new-player "Learning the game"})
 
 (defn create-game [state lobby-state options]
   (authenticated
@@ -264,18 +257,23 @@
    [api-access options user]])
 
 (defn create-new-game [lobby-state user]
-  (r/with-let [state (r/atom {:flash-message ""
+  (r/with-let [casual? (= "casual" (:room @lobby-state))
+               state (r/atom {:flash-message ""
                               :format (or (get-in @app-state [:options :default-format]) "standard")
                               :room (:room @lobby-state)
                               :side "Any Side"
                               :gateway-type "Beginner"
                               :precon "worlds-2012-a"
+                              :description (when casual?
+                                             (get-in @app-state [:options :default-game-description]))
                               :title (str (:username @user) "'s game")})
                options (r/atom {:allow-spectator true
                                 :api-access false
                                 :password ""
                                 :protected false
-                                :save-replay (not= "casual" (:room @lobby-state))
+                                :save-replay (if casual?
+                                               (get-in @app-state [:options :default-save-replay])
+                                               true)
                                 :singleton false
                                 :spectatorhands false
                                 :open-decklists false

--- a/src/cljs/nr/password_game.cljs
+++ b/src/cljs/nr/password_game.cljs
@@ -2,6 +2,7 @@
   (:require
    [nr.auth :refer [authenticated]]
    [nr.translations :refer [tr tr-span tr-element tr-room-type]]
+   [nr.utils :refer [focus-on-mount]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [taoensso.sente :as sente]))
@@ -37,6 +38,7 @@
                  " " (:title @game))]
        [:p
         [:input.game-title {:on-change #(swap! state assoc :password (.. % -target -value))
+                            :ref focus-on-mount
                             :value (:password @state)
                             :placeholder (tr [:lobby_password "Password"])
                             :data-i18n-key :lobby_password

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -172,8 +172,7 @@
         {:on-click #(reagent-modals/modal! [select-deck-modal user current-game])}
         [tr-span [:lobby_select-deck "Select Deck"]]])
      (when (and can-select?
-                (not (:deck player))
-                (= "casual" (:room @current-game)))
+                (not (:deck player)))
        (when-let [default (default-deck-for-lobby current-game side)]
          [:span.fake-link.deck-load
           {:on-click #(select-deck default)}

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -172,7 +172,9 @@
        [:span.fake-link.deck-load
         {:on-click #(reagent-modals/modal! [select-deck-modal user current-game])}
         [tr-span [:lobby_select-deck "Select Deck"]]])
-     (when (and can-select? (not (:deck player)))
+     (when (and can-select?
+                (not (:deck player))
+                (= "casual" (:room @current-game)))
        (when-let [default (default-deck-for-lobby current-game side)]
          [:span.fake-link.deck-load
           {:on-click #(select-deck default)}

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -5,7 +5,7 @@
     [nr.appstate :refer [app-state current-gameid]]
     [nr.cardbrowser :refer [image-url] :as cb]
     [nr.deck-status :refer [deck-format-status-span]]
-    [nr.deckbuilder :refer [deck-name]]
+    [nr.deckbuilder :refer [deck-name default-deck?]]
     [nr.lobby-chat :refer [lobby-chat]]
     [nr.player-view :refer [player-view]]
     [nr.translations :refer [tr tr-element tr-element-with-embedded-content tr-span tr-side]]
@@ -35,26 +35,25 @@
                   (tr-non-game-toast [:lobby_select-error "Cannot select that deck"] "error")))
   (reagent-modals/close-modal!))
 
+(defn deck-valid-for-lobby?
+  [deck {:keys [format singleton]} side]
+  (and (= side (get-in deck [:identity :side]))
+       (or (not singleton) (singleton-deck? deck))
+       (or (= "casual" format)
+           (get-in deck [:status (keyword format) :legal]
+                   (get-in (trusted-deck-status (assoc deck :format format))
+                           [(keyword format) :legal]
+                           false)))))
+
 (defn select-deck-modal [user current-game]
   (r/with-let [decks (r/cursor app-state [:decks])]
-    (let [fmt (:format @current-game)
-          players (:players @current-game)
-          singleton? (:singleton @current-game)
-          singleton-fn? (fn [deck] (or (not singleton?) (singleton-deck? deck)))
-          ;;(or (not singleton?) (singleton-id? (get-in deck [:identity])))) -- this one restricts to the ids only
+    (let [game @current-game
+          fmt (:format game)
+          players (:players game)
           side (:side (some #(when (= (-> % :user :_id) (:_id @user)) %) players))
-          same-side? (fn [deck] (= side (get-in deck [:identity :side])))
-          legal? (fn [deck fmt] (or (= "casual" fmt)
-                                    (get-in deck [:status (keyword fmt) :legal]
-                                            (get-in (trusted-deck-status (assoc deck :format fmt))
-                                                    [(keyword fmt) :legal]
-                                                    false))))
           matches-format? (fn [deck] (= (:format deck) fmt))
           by-date-desc (fn [decks] (reverse (sort-by :date decks)))
-          legal-decks (->> @decks
-                           (filter same-side?)
-                           (filter singleton-fn?)
-                           (filter #(legal? % fmt)))
+          legal-decks (filter #(deck-valid-for-lobby? % game side) @decks)
           appropriate-decks (concat (by-date-desc (filter matches-format? legal-decks))
                                      (by-date-desc (remove matches-format? legal-decks)))]
       (if (seq appropriate-decks)
@@ -68,7 +67,9 @@
                [:img {:src (image-url (:identity deck))
                       :alt (get-in deck [:identity :title] "")}]
                [:div.float-right [deck-format-status-span deck fmt true]]
-               [:h4 (:name deck)]
+               [:h4 (when (default-deck? deck)
+                      [:span.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
+                (:name deck)]
                [:div.float-right
                 (format-date-time mdy-formatter (:date deck))]
                [:p (get-in deck [:identity :title])]]))]]
@@ -143,9 +144,20 @@
    [leave-button gameid]
    [swap-sides-button user gameid players]])
 
+(defn default-deck-for-lobby
+  [current-game side]
+  (let [deck-id (get-in @app-state [:options :default-decks (keyword side) (keyword (:format @current-game))])
+        deck (some #(when (= (:_id %) deck-id) %) (:decks @app-state))]
+    (when (and deck (deck-valid-for-lobby? deck @current-game side))
+      deck)))
+
 (defn player-item [user current-game player]
   (let [player-id (get-in player [:user :_id])
-        this-player (= player-id (:_id @user))]
+        this-player (= player-id (:_id @user))
+        side (:side player)
+        can-select? (and (is-constructed? current-game)
+                         this-player
+                         (not (= side (tr-side "Any Side"))))]
     [:div {:key player-id}
      [player-view player (dissoc @current-game :password)]
      (when-let [{:keys [status]} (:deck player)]
@@ -156,12 +168,15 @@
            [tr-span [:lobby_deck-selected "Deck selected"]])]])
      (when-let [deck (:deck player)]
        [:div.float-right [deck-format-status-span deck (:format @current-game "standard") true]])
-     (when (and (is-constructed? current-game)
-                this-player
-                (not (= (:side player) (tr-side "Any Side"))))
+     (when can-select?
        [:span.fake-link.deck-load
         {:on-click #(reagent-modals/modal! [select-deck-modal user current-game])}
-        [tr-span [:lobby_select-deck "Select Deck"]]])]))
+        [tr-span [:lobby_select-deck "Select Deck"]]])
+     (when (and can-select? (not (:deck player)))
+       (when-let [default (default-deck-for-lobby current-game side)]
+         [:span.fake-link.deck-load
+          {:on-click #(select-deck default)}
+          [tr-span [:lobby_select-default-deck "Select Default Deck"]]]))]))
 
 (defn player-list [user current-game players]
   [:<>

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -2,6 +2,7 @@
   (:require
     [jinteki.validator :refer [singleton-deck? trusted-deck-status]]
     [jinteki.preconstructed :refer [matchup-by-key]]
+    [jinteki.utils :refer [constructed-game?]]
     [nr.appstate :refer [app-state current-gameid]]
     [nr.cardbrowser :refer [image-url] :as cb]
     [nr.deck-status :refer [deck-format-status-span]]
@@ -19,9 +20,7 @@
 (defn is-constructed?
   "Games using the starter decks are not constructed"
   [current-game]
-  (and (not (:precon @current-game))
-       (not= "quick-draft" (:format @current-game))
-       (not= "chimera" (:format @current-game))))
+  (constructed-game? @current-game))
 
 (defn is-preconstructed?
   [current-game]

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -66,9 +66,9 @@
                [:img {:src (image-url (:identity deck))
                       :alt (get-in deck [:identity :title] "")}]
                [:div.float-right [deck-format-status-span deck fmt true]]
-               [:h4 (when (default-deck? deck)
-                      [:span.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
-                (:name deck)]
+(when (default-deck? deck)
+                 [:span.float-right.deck-default-star {:title (tr [:deck-builder_default "Default deck"])} "★ "])
+               [:h4 (:name deck)]
                [:div.float-right
                 (format-date-time mdy-formatter (:date deck))]
                [:p (get-in deck [:identity :title])]]))]]

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -39,10 +39,9 @@
   (and (= side (get-in deck [:identity :side]))
        (or (not singleton) (singleton-deck? deck))
        (or (= "casual" format)
-           (get-in deck [:status (keyword format) :legal]
-                   (get-in (trusted-deck-status (assoc deck :format format))
-                           [(keyword format) :legal]
-                           false)))))
+           (get-in deck [:status (keyword format) :legal])
+           (get-in (trusted-deck-status (assoc deck :format format)) [(keyword format) :legal])
+           false)))
 
 (defn select-deck-modal [user current-game]
   (r/with-let [decks (r/cursor app-state [:decks])]

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -404,6 +404,12 @@
     [:button.on {:on-click f :key on-text} on-text]
     [:button.off {:on-click f :key off-text} off-text]))
 
+(defn focus-on-mount
+  "Reagent :ref callback that focuses the element once it mounts. Pass it as a stable
+   var, never as an inline fn, so React only invokes it once on mount instead of every render."
+  [el]
+  (when el (.focus el)))
+
 (defn tristate-button [on-text off-text on-cond disable-cond f]
   (let [text (if on-cond on-text off-text)]
     (if disable-cond

--- a/test/clj/web/lobby_test.clj
+++ b/test/clj/web/lobby_test.clj
@@ -81,3 +81,26 @@
                    :players [(player "Corp")]}
             result (lobby/auto-select-decks nil lobby)]
         (is (nil? (get-in result [:players 0 :deck])))))))
+
+(deftest auto-select-decks-skips-non-constructed-test
+  (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] {:_id deck-id})
+                lobby/process-deck (fn [raw] (assoc raw :identity {:title "id"}))
+                lobby/valid-deck-for-lobby? (fn [_lobby _deck] true)
+                app-state/get-user (fn [_uid]
+                                     {:options {:auto-select-default-deck true
+                                                :default-decks {:Corp {:system-gateway "sg-deck"
+                                                                       :quick-draft "qd-deck"
+                                                                       :chimera "ch-deck"}}}})]
+    (testing "preconstructed games (precon set) are not auto-selected"
+      (let [lobby {:room "casual" :format "system-gateway" :precon :beginner
+                   :players [(player "Corp")]}]
+        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
+    (testing "quick-draft games are not auto-selected"
+      (let [lobby {:room "casual" :format "quick-draft" :players [(player "Corp")]}]
+        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
+    (testing "chimera games are not auto-selected"
+      (let [lobby {:room "casual" :format "chimera" :players [(player "Corp")]}]
+        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
+    (testing "a normal constructed casual game still auto-selects"
+      (let [lobby {:room "casual" :format "system-gateway" :players [(player "Corp")]}]
+        (is (= "sg-deck" (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck :_id])))))))

--- a/test/clj/web/lobby_test.clj
+++ b/test/clj/web/lobby_test.clj
@@ -4,103 +4,90 @@
    [web.app-state :as app-state]
    [web.lobby :as lobby]))
 
+(def auto-opts
+  {:auto-select-default-deck-casual true
+   :default-decks {:Corp {:standard "corp-standard"
+                          :eternal "corp-eternal"}
+                   :Runner {:standard "runner-standard"}}})
+
+(deftest auto-select-deck-id-test
+  (testing "returns the default deck id for the given side and format in casual"
+    (is (= "corp-standard" (lobby/auto-select-deck-id auto-opts "casual" "standard" "Corp")))
+    (is (= "corp-eternal" (lobby/auto-select-deck-id auto-opts "casual" "eternal" "Corp")))
+    (is (= "runner-standard" (lobby/auto-select-deck-id auto-opts "casual" "standard" "Runner"))))
+
+  (testing "nil when casual auto-select is disabled"
+    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :auto-select-default-deck-casual false)
+                                         "casual" "standard" "Corp"))))
+
+  (testing "tournament uses its own setting, not the casual one"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "competitive" "standard" "Corp")))
+    (is (= "corp-standard"
+           (lobby/auto-select-deck-id (assoc auto-opts :auto-select-default-deck-tournament true)
+                                      "competitive" "standard" "Corp"))))
+
+  (testing "nil in rooms that never auto-select"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "angel-arena" "standard" "Corp"))))
+
+  (testing "nil for Any Side"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "casual" "standard" "Any Side"))))
+
+  (testing "nil when no default deck for that side+format"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "casual" "eternal" "Runner")))
+    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :default-decks {})
+                                         "casual" "standard" "Corp")))))
+
 (defn- player
   ([side] (player side nil))
   ([side deck]
    (cond-> {:uid side :side side :user {:username side}}
      deck (assoc :deck deck))))
 
-(def auto-opts
-  {:auto-select-default-deck true
-   :default-decks {:Corp {:standard "corp-standard"
-                          :eternal "corp-eternal"}
-                   :Runner {:standard "runner-standard"}}})
-
-(deftest auto-select-deck-id-test
-  (testing "returns the default deck id for the given side and format"
-    (is (= "corp-standard" (lobby/auto-select-deck-id auto-opts "standard" "Corp")))
-    (is (= "corp-eternal" (lobby/auto-select-deck-id auto-opts "eternal" "Corp")))
-    (is (= "runner-standard" (lobby/auto-select-deck-id auto-opts "standard" "Runner"))))
-
-  (testing "nil when auto-select is disabled"
-    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :auto-select-default-deck false)
-                                         "standard" "Corp"))))
-
-  (testing "nil for Any Side"
-    (is (nil? (lobby/auto-select-deck-id auto-opts "standard" "Any Side"))))
-
-  (testing "nil when no default deck for that side+format"
-    (is (nil? (lobby/auto-select-deck-id auto-opts "eternal" "Runner")))
-    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :default-decks {})
-                                         "standard" "Corp")))))
+(defn- auto-select
+  [lobby & {:keys [options deck-found?] :or {options auto-opts deck-found? true}}]
+  (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] (when deck-found? {:_id deck-id}))
+                lobby/process-deck (fn [deck] (when deck (assoc deck :identity {:title "id"})))
+                lobby/valid-deck-for-lobby? (fn [_lobby _deck] true)
+                app-state/get-user (fn [_uid] {:options options})]
+    (lobby/auto-select-decks nil lobby)))
 
 (deftest auto-select-decks-test
-  (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] {:_id deck-id})
-                lobby/process-deck (fn [raw] (assoc raw :identity {:title "id"}))
-                lobby/valid-deck-for-lobby? (fn [_lobby _deck] true)
-                app-state/get-user (fn [_uid] {:options auto-opts})]
-    (testing "selects each player's default deck for the lobby format"
-      (let [lobby {:room "casual" :format "standard"
-                   :players [(player "Corp") (player "Runner")]}
-            result (lobby/auto-select-decks nil lobby)]
-        (is (= "corp-standard" (get-in result [:players 0 :deck :_id])))
-        (is (= "runner-standard" (get-in result [:players 1 :deck :_id])))))
+  (testing "selects each deckless player's default deck for the lobby format"
+    (let [result (auto-select {:room "casual" :format "standard"
+                               :players [(player "Corp") (player "Runner")]})]
+      (is (= "corp-standard" (get-in result [:players 0 :deck :_id])))
+      (is (= "runner-standard" (get-in result [:players 1 :deck :_id])))))
 
-    (testing "uses the side+format default"
-      (let [lobby {:room "casual" :format "eternal"
-                   :players [(player "Corp")]}
-            result (lobby/auto-select-decks nil lobby)]
-        (is (= "corp-eternal" (get-in result [:players 0 :deck :_id])))))
+  (testing "leaves a player that already chose a deck untouched"
+    (let [chosen {:_id "manual"}
+          result (auto-select {:room "casual" :format "standard"
+                               :players [(player "Corp" chosen)]})]
+      (is (= chosen (get-in result [:players 0 :deck])))))
 
-    (testing "leaves a player that already chose a deck untouched"
-      (let [chosen {:_id "manual"}
-            lobby {:room "casual" :format "standard"
-                   :players [(player "Corp" chosen)]}
-            result (lobby/auto-select-decks nil lobby)]
-        (is (= chosen (get-in result [:players 0 :deck])))))
+  (testing "no-op once the game has started"
+    (let [result (auto-select {:room "casual" :format "standard" :started true
+                               :players [(player "Corp")]})]
+      (is (nil? (get-in result [:players 0 :deck])))))
 
-    (testing "no-op once the game has started"
-      (let [lobby {:room "casual" :format "standard" :started true
-                   :players [(player "Corp")]}
-            result (lobby/auto-select-decks nil lobby)]
-        (is (nil? (get-in result [:players 0 :deck])))))
+  (testing "no-op when the configured default deck no longer exists"
+    (let [result (auto-select {:room "casual" :format "standard"
+                               :players [(player "Corp")]}
+                              :deck-found? false)]
+      (is (nil? (get-in result [:players 0 :deck])))))
 
-    (testing "no-op outside the casual room"
-      (doseq [room ["competitive" "angel-arena"]]
-        (let [lobby {:room room :format "standard"
-                     :players [(player "Corp")]}
-              result (lobby/auto-select-decks nil lobby)]
-          (is (nil? (get-in result [:players 0 :deck]))
-              (str "should not auto-select in " room " room")))))))
+  (testing "no-op for non-constructed games"
+    (let [opts {:auto-select-default-deck-casual true
+                :default-decks {:Corp {:quick-draft "qd-deck"
+                                       :chimera "ch-deck"}}}
+          deck (fn [lobby] (get-in (auto-select (assoc lobby :players [(player "Corp")]) :options opts)
+                                   [:players 0 :deck :_id]))]
+      (is (nil? (deck {:room "casual" :format "quick-draft"})))
+      (is (nil? (deck {:room "casual" :format "chimera"})))))
 
-(deftest auto-select-decks-skips-missing-deck-test
-  (with-redefs [lobby/find-deck-for-user (fn [_db _deck-id _user] nil)
-                app-state/get-user (fn [_uid] {:options auto-opts})]
-    (testing "deleted default deck leaves the player without a selection"
-      (let [lobby {:room "casual" :format "standard"
-                   :players [(player "Corp")]}
-            result (lobby/auto-select-decks nil lobby)]
-        (is (nil? (get-in result [:players 0 :deck])))))))
-
-(deftest auto-select-decks-skips-non-constructed-test
-  (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] {:_id deck-id})
-                lobby/process-deck (fn [raw] (assoc raw :identity {:title "id"}))
-                lobby/valid-deck-for-lobby? (fn [_lobby _deck] true)
-                app-state/get-user (fn [_uid]
-                                     {:options {:auto-select-default-deck true
-                                                :default-decks {:Corp {:system-gateway "sg-deck"
-                                                                       :quick-draft "qd-deck"
-                                                                       :chimera "ch-deck"}}}})]
-    (testing "preconstructed games (precon set) are not auto-selected"
-      (let [lobby {:room "casual" :format "system-gateway" :precon :beginner
-                   :players [(player "Corp")]}]
-        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
-    (testing "quick-draft games are not auto-selected"
-      (let [lobby {:room "casual" :format "quick-draft" :players [(player "Corp")]}]
-        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
-    (testing "chimera games are not auto-selected"
-      (let [lobby {:room "casual" :format "chimera" :players [(player "Corp")]}]
-        (is (nil? (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck])))))
-    (testing "a normal constructed casual game still auto-selects"
-      (let [lobby {:room "casual" :format "system-gateway" :players [(player "Corp")]}]
-        (is (= "sg-deck" (get-in (lobby/auto-select-decks nil lobby) [:players 0 :deck :_id])))))))
+  (testing "no-op for precon gateway, but works for non-precon gateway"
+    (let [opts {:auto-select-default-deck-casual true
+                :default-decks {:Corp {:system-gateway "sg-deck"}}}
+          deck (fn [lobby] (get-in (auto-select (assoc lobby :players [(player "Corp")]) :options opts)
+                                   [:players 0 :deck :_id]))]
+      (is (nil? (deck {:room "casual" :format "system-gateway" :precon :beginner})))
+      (is (= "sg-deck" (deck {:room "casual" :format "system-gateway"}))))))

--- a/test/clj/web/lobby_test.clj
+++ b/test/clj/web/lobby_test.clj
@@ -1,0 +1,83 @@
+(ns web.lobby-test
+  (:require
+   [clojure.test :refer :all]
+   [web.app-state :as app-state]
+   [web.lobby :as lobby]))
+
+(defn- player
+  ([side] (player side nil))
+  ([side deck]
+   (cond-> {:uid side :side side :user {:username side}}
+     deck (assoc :deck deck))))
+
+(def auto-opts
+  {:auto-select-default-deck true
+   :default-decks {:Corp {:standard "corp-standard"
+                          :eternal "corp-eternal"}
+                   :Runner {:standard "runner-standard"}}})
+
+(deftest auto-select-deck-id-test
+  (testing "returns the default deck id for the given side and format"
+    (is (= "corp-standard" (lobby/auto-select-deck-id auto-opts "standard" "Corp")))
+    (is (= "corp-eternal" (lobby/auto-select-deck-id auto-opts "eternal" "Corp")))
+    (is (= "runner-standard" (lobby/auto-select-deck-id auto-opts "standard" "Runner"))))
+
+  (testing "nil when auto-select is disabled"
+    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :auto-select-default-deck false)
+                                         "standard" "Corp"))))
+
+  (testing "nil for Any Side"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "standard" "Any Side"))))
+
+  (testing "nil when no default deck for that side+format"
+    (is (nil? (lobby/auto-select-deck-id auto-opts "eternal" "Runner")))
+    (is (nil? (lobby/auto-select-deck-id (assoc auto-opts :default-decks {})
+                                         "standard" "Corp")))))
+
+(deftest auto-select-decks-test
+  (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] {:_id deck-id})
+                lobby/process-deck (fn [raw] (assoc raw :identity {:title "id"}))
+                lobby/valid-deck-for-lobby? (fn [_lobby _deck] true)
+                app-state/get-user (fn [_uid] {:options auto-opts})]
+    (testing "selects each player's default deck for the lobby format"
+      (let [lobby {:room "casual" :format "standard"
+                   :players [(player "Corp") (player "Runner")]}
+            result (lobby/auto-select-decks nil lobby)]
+        (is (= "corp-standard" (get-in result [:players 0 :deck :_id])))
+        (is (= "runner-standard" (get-in result [:players 1 :deck :_id])))))
+
+    (testing "uses the side+format default"
+      (let [lobby {:room "casual" :format "eternal"
+                   :players [(player "Corp")]}
+            result (lobby/auto-select-decks nil lobby)]
+        (is (= "corp-eternal" (get-in result [:players 0 :deck :_id])))))
+
+    (testing "leaves a player that already chose a deck untouched"
+      (let [chosen {:_id "manual"}
+            lobby {:room "casual" :format "standard"
+                   :players [(player "Corp" chosen)]}
+            result (lobby/auto-select-decks nil lobby)]
+        (is (= chosen (get-in result [:players 0 :deck])))))
+
+    (testing "no-op once the game has started"
+      (let [lobby {:room "casual" :format "standard" :started true
+                   :players [(player "Corp")]}
+            result (lobby/auto-select-decks nil lobby)]
+        (is (nil? (get-in result [:players 0 :deck])))))
+
+    (testing "no-op outside the casual room"
+      (doseq [room ["competitive" "angel-arena"]]
+        (let [lobby {:room room :format "standard"
+                     :players [(player "Corp")]}
+              result (lobby/auto-select-decks nil lobby)]
+          (is (nil? (get-in result [:players 0 :deck]))
+              (str "should not auto-select in " room " room")))))))
+
+(deftest auto-select-decks-skips-missing-deck-test
+  (with-redefs [lobby/find-deck-for-user (fn [_db _deck-id _user] nil)
+                app-state/get-user (fn [_uid] {:options auto-opts})]
+    (testing "deleted default deck leaves the player without a selection"
+      (let [lobby {:room "casual" :format "standard"
+                   :players [(player "Corp")]}
+            result (lobby/auto-select-decks nil lobby)]
+        (is (nil? (get-in result [:players 0 :deck])))))))


### PR DESCRIPTION
Adds a `Select Default Deck` button to casual game deck selection when you have a default deck for that side+format. 

<img width="832" height="250" alt="CleanShot 2026-06-27 at 18 34 07@2x" src="https://github.com/user-attachments/assets/06486fbe-1754-4e82-ad58-42494aa1c0ec" />

Defaults decks show a `★` before their name. You can have one default deck for each side+format, and are set in the deck details screen with the `Set Default` button for constructed formats.

<img width="2528" height="1692" alt="CleanShot 2026-06-27 at 18 35 29@2x" src="https://github.com/user-attachments/assets/c70a202c-6cf0-429b-9d44-8878890f9b6d" />

You can auto-select the default decks on game create/join/swap sides with a new setting in the new `Game Settings` section, along with the the existing game format, and new game description, password, and replay defaults.

<img width="822" height="792" alt="CleanShot 2026-06-29 at 22 42 17@2x" src="https://github.com/user-attachments/assets/377ca40d-a0b8-4111-b125-bf4537e86594" />

One last tweak is that the password field will be focused when it shows up. This will make it a bit faster to add or edit the password on game creation and on join.

Fix https://github.com/mtgred/netrunner/issues/8614