### PR TITLE
dev: fix safari login

### DIFF
--- a/resources/dev.edn
+++ b/resources/dev.edn
@@ -11,7 +11,6 @@
             :secret "Dev salt"
             :cookie {:http-only true
                      :same-site :lax
-                     :secure true
                      ; 60 days
                      :max-age 5184000}}
  :web/lobby {:interval 1000


### PR DESCRIPTION
Login on safari dev won't work with the secure cookie.
