### PR TITLE
Tacticle features for cards in hand

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1598,6 +1598,10 @@ settings_card-backs-their-choice = Their Choice
 
 settings_card-backs-tip = You can earn more card backs by placing well in select online tournaments. If you're an artist with art that you think would make for a good card back, please feel free to contact us
 
+settings_card-unplayable-fade-out = Fade out unplayable cards
+
+settings_card-hover-movement = Responsive cards in hand
+
 settings_card-iamge = Card Image
 
 settings_card-images = Card images
@@ -1661,6 +1665,8 @@ settings_get-log-top = Get current log top
 settings_get-log-width = Get current log width
 
 settings_ghost-trojans = Display ghosts for hosted programs
+
+settings_tactile-cards = Tactile cards
 
 settings_high-res = Enable high-resolution card images
 

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -135,6 +135,16 @@
     :sync? true
     :validate-fn #(contains? valid-card-zoom-options %)
     :doc "How to display zoomed cards (image/text)"}
+   {:key :card-unplayable-fade-out
+    :default true
+    :sync? false  ; device-specific
+    :validate-fn boolean?
+    :doc "Whether to fade out unplayable cards in hand"}
+   {:key :card-hover-movement
+    :default true
+    :sync? false  ; device-specific
+    :validate-fn boolean?
+    :doc "Whether cards in hand should be responsive to mouse movement"}
    {:key :corp-card-sleeve
     :default "nsg-card-back"
     :sync? true

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -471,7 +471,22 @@
                               :value "none"
                               :checked (= "none" (:log-player-highlight @s))
                               :on-change #(swap! s assoc :log-player-highlight (.. % -target -value))}]
-              [tr-span [:settings_log-player-highlight-none "None"]]]]]]
+              [tr-span [:settings_log-player-highlight-none "None"]]]]]
+           [:br]
+           [tr-element :h4 [:settings_tactile-cards "Tactile cards"]]
+           [:div
+            [:div
+              [:label [:input {:type "checkbox"
+                               :value true
+                               :checked (:card-unplayable-fade-out @s)
+                               :on-change #(swap! s assoc :card-unplayable-fade-out (.. % -target -checked))}]
+              [tr-span [:settings_card-unplayable-fade-out "Fade out unplayable cards"]]]]
+            [:div
+              [:label [:input {:type "checkbox"
+                               :value true
+                               :checked (:card-hover-movement @s)
+                               :on-change #(swap! s assoc :card-hover-movement (.. % -target -checked))}]
+              [tr-span [:settings_card-hover-movement "Responsive cards in hand"]]]]]]
 
           (let [custom-bg-selected (= (:background @s) "custom-bg" )
                 custom-bg-url (r/cursor s [:custom-bg-url])]
@@ -735,6 +750,7 @@
         state (r/atom
                (-> (:options @app-state)
                    (select-keys [:pronouns :bespoke-sounds :language :card-language :sounds :default-format
+                                 :card-unplayable-fade-out :card-hover-movement
                                  :lobby-sounds :sounds-volume :background :custom-bg-url :card-zoom
                                  :pin-zoom :show-alt-art :card-resolution :pass-on-rez
                                  :player-stats-icons :stacked-cards :ghost-trojans

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -2295,7 +2295,6 @@
         custom-bg-url (r/cursor app-state [:options :custom-bg-url])
         labeled-unrezzed-cards (r/cursor app-state [:options :labeled-unrezzed-cards])
         labeled-cards (r/cursor app-state [:options :labeled-cards])
-        labeled-cards (r/cursor app-state [:options :labeled-cards])
         card-unplayable-fade-out (r/cursor app-state [:options :card-unplayable-fade-out])
         card-hover-movement (r/cursor app-state [:options :card-hover-movement])]
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -906,7 +906,7 @@
        (fn [i card]
          [:div {:key (or (:cid card) i)
                 :class (str wrapper-class)
-                :style {:left (when (< 1 size) (* (/ 320 (dec size)) i))}}
+                :style {:left (when (< 1 size) (* (/ 320 (dec size)) i)) :z-index i}}
           (cond
             (spectator-view-hidden?)
             [card-view (dissoc card :new :selected)]
@@ -1216,7 +1216,7 @@
     [label full-server-names (assoc opts
                                         :classes "server-label"
                                         :name (str "Servers " (join ", " numbers))
-                                        :tr-vec [:game_server "Server"] 
+                                        :tr-vec [:game_server "Server"]
                                         :tr-params {:num (join ", " numbers)}
                                         :hide-cursor true)]))
 
@@ -2294,7 +2294,10 @@
         background (r/cursor app-state [:options :background])
         custom-bg-url (r/cursor app-state [:options :custom-bg-url])
         labeled-unrezzed-cards (r/cursor app-state [:options :labeled-unrezzed-cards])
-        labeled-cards (r/cursor app-state [:options :labeled-cards])]
+        labeled-cards (r/cursor app-state [:options :labeled-cards])
+        labeled-cards (r/cursor app-state [:options :labeled-cards])
+        card-unplayable-fade-out (r/cursor app-state [:options :card-unplayable-fade-out])
+        card-hover-movement (r/cursor app-state [:options :card-hover-movement])]
 
     (go (while true
           (let [zoom (<! zoom-channel)]
@@ -2383,6 +2386,8 @@
                  sfx (r/cursor game-state [:sfx])]
              [:div.gameview
               [:div {:class [:gameboard
+                             (when (and (not= @side :spectator) @card-unplayable-fade-out) :card-unplayable-fade-out)
+                             (when (and (not= @side :spectator) @card-hover-movement) :card-hover-movement)
                              (when @labeled-unrezzed-cards :show-unrezzed-card-labels)
                              (when @labeled-cards :show-card-labels)]}
                (let [me-keep (r/cursor game-state [me-side :keep])

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1184,3 +1184,32 @@
                             li.command-match.highlight span
                                 color: gold-base
                                 cursor: pointer
+
+.gameboard.card-unplayable-fade-out
+
+    .hand-container .card
+        transition: all 0.15s
+
+    .hand-container .card:not(.playable, .selectable, .bg)
+        filter: contrast(0.8)
+
+    .hand-container .card:not(.playable, .selectable, .bg, :hover)
+        filter: contrast(0.7)
+
+.gameboard.card-hover-movement
+
+    .hand-container .card
+        transition: all 0.15s
+
+    .hand-container .card.selected
+        transform: translateY(-5px)
+
+    .hand-container .card.selected:hover
+        transform: translateY(-10px)
+
+    .hand-container .card.playable:hover:not(:has(+ .active-menu)),
+    .hand-container .card.selectable:hover:not(:has(+ .active-menu))
+        transform: translateY(-7.5px)
+
+    .hand-container .card:has(+ .active-menu)
+        transform: translateY(0) scale(1.05)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1202,14 +1202,23 @@
         transition: all 0.15s
 
     .hand-container .card.selected
-        transform: translateY(-5px)
+        transform: translateY(-5px) scale(1.02)
+
+    .hand-container .card-wrapper:has(.active-menu)
+        z-index: 99999 !important
 
     .hand-container .card.selected:hover
-        transform: translateY(-10px)
+        transform: translateY(-10px) scale(1.02)
 
     .hand-container .card.playable:hover:not(:has(+ .active-menu)),
     .hand-container .card.selectable:hover:not(:has(+ .active-menu))
-        transform: translateY(-7.5px)
+        transform: translateY(-7.5px) scale(1.02)
 
     .hand-container .card:has(+ .active-menu)
-        transform: translateY(0) scale(1.05)
+        transform: translateY(-5px) scale(1.1)
+
+    .hand-container .card:has(+ .active-menu):hover
+        transform: translateY(-5.2px) scale(1.11)
+
+    .hand-container .active-menu
+        transform: translateY(-10px)


### PR DESCRIPTION
Added two new settings to fade out unplayable cards and make playable cards feel more interactive. They are both on by default. Translations have not been provided. Implements part of #6731.

Tested on both sides, as the spectator, and with overlapping cards (due to excessive card draw).

### Settings
<img width="471" height="384" alt="image" src="https://github.com/user-attachments/assets/4c5a9a6d-fb13-4653-9c62-27d403882850" />

### Faded unplayable card (Biotic)
<img width="389" height="259" alt="image" src="https://github.com/user-attachments/assets/580174cc-2540-463c-aa3d-141db66b4372" />

### Hovered card
<img width="340" height="106" alt="image" src="https://github.com/user-attachments/assets/7d30459b-244a-44c9-bd89-f170710e8bf7" />

### Selected card
<img width="390" height="166" alt="image" src="https://github.com/user-attachments/assets/36db25c3-ee18-4cf4-9f16-cf29772f0e9f" />
