### PR TITLE
inner leftpane fixes

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1798,7 +1798,7 @@
 (defn prompt-div
   [me {:keys [card msg prompt-type choices offer-bad-pub?] :as prompt-state}]
   (let [id (atom 0)]
-    [:div.panel.blue-shade
+    [:div.panel.blue-shade.prompt
      (when (and card (not= "Basic Action" (:type card)))
        [:<>
         (let [get-nested-host (fn [card] (if (:host card)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -675,10 +675,12 @@ glow-spin(prop, pct)
         display-flex()
         flex-direction(column)
         justify-content(space-between)
+        max-height: 100%
 
         .inner-leftpane
             flex(1)
             display-flex()
+            min-height: 0
 
             .left-inner-leftpane
                 width: 201px
@@ -737,25 +739,33 @@ glow-spin(prop, pct)
                             color: orange-dark
 
                 .button-pane
+                    min-height: 0
+
                     .panel
                         padding: 8px
                         z-index: 20
+
+                        // scroll oversized prompts (e.g. long install choice lists)
+                        &.prompt
+                            overflow-y: auto
 
                         .prompt-card-preview
                             text-align: center
 
                             div.card
                                 width: 168px
-                                height: 234.833px
+                                max-width: 100%
+                                height: auto
+                                aspect-ratio: unquote("168 / 234.833")
 
                                 >div:first-child
                                     display:inline
-                                    width: 168px !important
-                                    height: 234.833px
+                                    width: 100% !important
+                                    height: 100%
 
                                     >img.card
-                                        width: 168px
-                                        height: 234.833px
+                                        width: 100%
+                                        height: 100%
 
                     .run-button
                         position: relative

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -705,11 +705,13 @@ glow-spin(prop, pct)
                 justify-content(space-between)
                 display-flex()
                 flex-direction(column)
+                row-gap: 5px
 
                 > div
                     width: 100%
                     display-flex()
                     flex-direction(column)
+                    row-gap: 5px
 
                 .panel
                     margin: 0

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -762,7 +762,7 @@ glow-spin(prop, pct)
 
                                 >div:first-child
                                     display:inline
-                                    width: 100% !important
+                                    width: 100%
                                     height: 100%
 
                                     >img.card


### PR DESCRIPTION
This PR adds fixes for 2 things. First is how some button panels, like self-modifying code and malapert data vault, could break the board layout vertically by pushing it down. Now they will get scroll bars instead:

<img width="1766" height="1904" alt="CleanShot 2026-07-10 at 00 09 35@2x" src="https://github.com/user-attachments/assets/ad36dc53-5301-49ae-9ebb-cd39bad0ac8b" />

<img width="1766" height="1904" alt="CleanShot 2026-07-10 at 00 09 58@2x" src="https://github.com/user-attachments/assets/7825a138-5e02-4d1a-9bfd-bcab4938c651" />

The second fix is for the spacing between the boxes in that button panel column. You can see in the first image that there was no spacing between game start, last revealed, and the prompt. In the second image there is a bit of spacing, like in the left-most column.
