### PR TITLE
fix: don't drop :type from prompt card

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -251,7 +251,7 @@
   (when same-side?
     (-> prompt
         (update :eid #(when (:eid %) (select-keys % [:eid])))
-        (update :card #(not-empty (select-keys % [:cid :title :printed-title :code :side])))
+        (update :card #(not-empty (select-keys % [:cid :title :printed-title :code :side :type])))
         (update :choices (fn [choices]
                            (if (sequential? choices)
                              (->> choices


### PR DESCRIPTION
Its used in the prompt div to check it's not the basic action:
```
;; src/cljs/nr/gameboard/board.cljs:1802
     (when (and card (not= "Basic Action" (:type card)))
```

Fix #8784
