### PR TITLE
feat: custom messages

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1656,6 +1656,10 @@ settings_create-api-key = Create API Key
 
 settings_current-email = Current email
 
+settings_custom-messages = Custom chat messages
+
+settings_custom-messages-note = These messages are sent in-game with the buttons above the chat input.
+
 settings_deck-stats = Deck statistics
 
 settings_default-game-description = Default game description in casual games

--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -43,6 +43,9 @@
 (def card-color-states (-> default-card-custom-colors keys set))
 (def valid-game-descriptions (set (map name (keys utils/descriptions))))
 
+(def default-custom-messages
+  ["Good luck & have fun!" "Thinking..." "Good game!" "Thank you for the game!"])
+
 ;; Validation combinators
 (defn- validate-coll-of
   "Returns a validator that checks if value is a collection of items matching pred"
@@ -103,6 +106,13 @@
 (def validate-default-decks
   "Validates default-decks is a map of side -> {format -> deck-id-string}"
   (validate-map-of keyword? (validate-map-of keyword? string?)))
+
+(defn- validate-custom-messages
+  "Validates custom-messages is a vector of 4 strings"
+  [value]
+  (and (vector? value)
+       (= (count default-custom-messages) (count value))
+       (every? string? value)))
 
 (def all-settings
   "Vector of all application settings with their metadata.
@@ -187,6 +197,11 @@
     :sync? true
     :validate-fn string?
     :doc "URL for custom game board background image"}
+   {:key :custom-messages
+    :default default-custom-messages
+    :sync? true
+    :validate-fn validate-custom-messages
+    :doc "Preset chat messages sent from buttons in the game log"}
    {:key :deckstats
     :default "always"
     :sync? true

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -445,6 +445,18 @@
              [tr-span [:settings_pass-on-rez "Pass priority when rezzing ice"]]]]]
 
           [:section
+           [tr-element :h3 [:settings_custom-messages "Custom chat messages"]]
+           [tr-element :p [:settings_custom-messages-note "These messages are sent in-game with the buttons above the chat input."]]
+           (doall
+             (for [i (range (count settings/default-custom-messages))]
+               ^{:key i}
+               [:div
+                [:input {:type "text"
+                         :maxLength "100"
+                         :value (get-in @s [:custom-messages i] "")
+                         :on-change #(swap! s assoc-in [:custom-messages i] (.. % -target -value))}]]))]
+
+          [:section
            [tr-element :h3 [:settings_layout-options "Layout options"]]
            [:div
             [:label [:input {:type "checkbox"
@@ -832,7 +844,8 @@
                                  :blocked-users :alt-arts :gamestats :deckstats :disable-websockets
                                  :archives-sorted :heap-sorted :card-back-display
                                  :card-colors :card-custom-colors
-                                 :labeled-cards :labeled-unrezzed-cards])
+                                 :labeled-cards :labeled-unrezzed-cards
+                                 :custom-messages])
                    (assoc :flash-message ""
                           :all-art-select "wc2015")))]
 

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -37,13 +37,18 @@
                  ^{:key i}
                  [:span " " influence-dot " "]))]])))
 
+(defn send-text [text]
+  (when (and (not (:replay @game-state))
+             (seq text))
+    (reset! should-scroll {:update false :send-msg true})
+    (ws/ws-send! [:game/say {:gameid (current-gameid app-state)
+                             :msg text}])))
+
 (defn send-msg [s]
   (let [text (:msg @s)]
     (when (and (not (:replay @game-state))
                (seq text))
-      (reset! should-scroll {:update false :send-msg true})
-      (ws/ws-send! [:game/say {:gameid (current-gameid app-state)
-                               :msg text}])
+      (send-text text)
       (swap! s assoc :msg ""))))
 
 (defn send-typing
@@ -58,6 +63,20 @@
                  (not-spectator?))
         (ws/ws-send! [:game/typing {:gameid (current-gameid app-state)
                                     :typing typing?}])))))
+
+(defn custom-messages []
+  (when (not-spectator?)
+    [:div.custom-messages
+     (doall
+       (map-indexed
+         (fn [i msg]
+           (when-not (string/blank? msg)
+             [:button.custom-message {:on-click #(do (.preventDefault %)
+                                                     (send-text msg))
+                                      :title msg
+                                      :key i}
+              msg]))
+         (get-in @app-state [:options :custom-messages])))]))
 
 (defn indicate-action []
   (when (not-spectator?)
@@ -242,6 +261,7 @@
              ;;:on-blur #(send-typing (atom nil))
              :on-key-down #(completions-key-down-handler state %)
              :on-change #(log-input-change-handler state %)}]]]
+         [custom-messages]
          [indicate-action]
          [show-decklists]
          [completions !input-ref state]]))))

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1185,6 +1185,21 @@ glow-spin(prop, pct)
                     .log-input form input, .indicate-action, .show-decklists
                         width: 100%
 
+                    .custom-messages
+                        display-flex()
+
+                        .custom-message
+                            flex(1)
+                            min-width: 0
+                            overflow: hidden
+                            text-overflow: ellipsis
+                            white-space: nowrap
+                            padding: 4px 6px
+                            margin: 0 4px 0 0
+
+                            &:last-child
+                                margin-right: 0
+
                     .command-matches-container
                         position: absolute !important
                         bottom: 24px


### PR DESCRIPTION
Adds buttons for customizable messages in the chat log.

This is what they look like:
<img width="381" height="439" alt="Screenshot 2026-07-12 at 22 51 53" src="https://github.com/user-attachments/assets/c11a9115-1f91-4fca-b08a-50c916bca543" />

You can't see the full message in the button, but the tooltip will show it:
<img width="222" height="70" alt="Screenshot 2026-07-12 at 22 52 37" src="https://github.com/user-attachments/assets/0ffc0847-a396-456c-8f27-6bb04f01e47f" />

You can customize these messages in the account settings:
<img width="488" height="231" alt="Screenshot 2026-07-12 at 22 54 53" src="https://github.com/user-attachments/assets/b3d6b1d1-4c72-434e-bb9c-9d27489affc6" />

<img width="381" height="294" alt="Screenshot 2026-07-12 at 22 55 26" src="https://github.com/user-attachments/assets/0e2da2b6-0a9c-4120-8857-cfd6e9e52c58" />


Fix #6521
Fix #7750
