### PR TITLE
fix: discard-view-corp popup when runner spectator

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1076,7 +1076,7 @@
               {:faceup face-up
                :facedown (- total face-up)}])]]
          [:div.panel.blue-shade.popup {:ref #(swap! s assoc :popup %)
-                                       :class (if (= (:side @game-state) :runner) "opponent" "me")}
+                                       :class (if (= player-side :corp) "me" "opponent")}
           [:div
            [:a {:on-click #(close-popup % (:popup @s) nil false false)}
             [tr-span [:game_close "Close"]]]


### PR DESCRIPTION
This is the same as the rest of discard-view-corp and discard-view-runner.

Fix https://github.com/mtgred/netrunner/issues/8791
