### PR TITLE
feat: stress test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ data/cards-zh-hant.edn
 .claude/
 .playwright-cli/
 .playwright/
+
+# Stress test output
+/stress-runs/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -185,3 +185,69 @@ already an index for `{ channel: 1 }`, you can replace it with `{ channel: 1,
 date: -1 }`, as the latter can also be used for all queries the former can
 support. See [Compound
 Indexes](https://docs.mongodb.com/manual/core/index-compound/) for details.
+
+
+## Stress Testing
+
+`bin/stress-test` reproduces server load from many simultaneous games so that
+resource usage can be measured and compared across runs. It connects headless
+bot players to a running server over real websockets (the same HTTP login,
+lobby events, game actions, and state diffs a browser goes through), plays
+full games using the built-in preconstructed Worlds decks, and samples the
+server's CPU and memory over time.
+
+Start the server stack first (`bin/up`), then:
+
+    $ bin/stress-test
+
+The defaults are sized for a local dev run (10 concurrent games for 3
+minutes at a 1s think time). To reproduce tournament-scale load:
+
+    $ bin/stress-test --concurrent-games 45 --duration-seconds 300
+
+Inputs: `-n`/`--concurrent-games`, `-d`/`--duration-seconds`, `--delay`
+per-bot think time in ms (lower = more load), `--matchups` to pick specific
+preconstructed matchups, `--spectators` per game, `--save-replays` to make
+games save replays at the end like tournament games do, `--chat-chance` to
+have bots chat in-game, and `--max-blocks` to give players block lists naming
+players of other games (exercising the lobby list filtering). See `--help`
+for all options.
+
+Outputs land in `stress-runs/<timestamp>/` (or `--out`): `samples.csv` with
+per-second server CPU/memory, action throughput, and action-to-diff latency
+percentiles; `summary.edn` with aggregates; `config.edn` with the run
+configuration.
+
+With `--profile`, the run also captures CPU profiles of the server JVM via
+its nREPL (port 44867 in the docker setup, `--nrepl-port` to change) using
+the clj-async-profiler already in the dev profile. Two phases are profiled
+separately, since their signatures differ completely: `profile-ramp.*`
+covers logins, lobby creation, and game starts, and `profile-steady.*`
+covers the loaded steady state once all games are up (profiling stops before
+teardown). Each phase produces three files in the output directory:
+
+- `<phase>.html`: interactive flamegraph, best for humans (self-contained,
+  regenerate any time from the collapsed file).
+- `<phase>-collapsed.txt`: raw collapsed stacks, one `frame;frame;... count`
+  line per unique stack. Greppable, diffable, loads into
+  [speedscope](https://www.speedscope.app), and the best input for agents.
+- `<phase>-summary.txt`: top frames by self and total time, for a quick look.
+
+If the run ends before all games came up (short duration, or the server
+buckling under the load), only the ramp profile exists and it covers the run
+up to that point.
+
+Inside docker, perf events are unavailable and the profiler falls back to
+itimer sampling automatically; the event used is printed and recorded in the
+summary file. To evaluate a change, run the same configuration on both
+versions of the server and compare the summaries; bot decisions are seeded
+per game slot, but engine randomness (shuffles, accesses) still varies, so
+prefer several runs or longer durations over single short runs.
+
+The bots decide from the same client-visible state a browser sees and follow
+the same action locking, so they exercise the full production path per action:
+engine execution, per-perspective state projections and diffs, JSON encoding,
+and websocket sends, plus lobby churn as games finish and restart. Games write
+normal rows to `game-logs`, so stress runs against a database you care about
+will leave records.
+

--- a/bin/stress-test
+++ b/bin/stress-test
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# not via the lein alias: lein would swallow -h/--help instead of passing it through
+cd "$(dirname "$0")/.." && exec lein run -m tasks.stress.run/command "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   server:
     entrypoint: lein repl :headless :host 0.0.0.0 :port 44867
+    # let the profiler use perf events (bin/stress-test --profile)
+    security_opt:
+      - seccomp=unconfined
+    cap_add:
+      - PERFMON
     ports:
       - 127.0.0.1:1042:1042
       - 127.0.0.1:44867:44867

--- a/project.clj
+++ b/project.clj
@@ -71,8 +71,11 @@
   :test-selectors {:default (fn [m] (not (:kaocha/pending m)))}
 
   :profiles {:dev {:dependencies [[binaryage/devtools "1.0.7"]
+                                  ;; JVM websocket client for the stress harness
+                                  ;; (optional dep of sente since 1.20)
+                                  [org.java-websocket/Java-WebSocket "1.5.3"]
                                   [cider/piggieback "0.5.3"]
-                                  [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
+                                  [com.clojure-goes-fast/clj-async-profiler "1.6.2"]
                                   [rewrite-clj "1.1.45"]
                                   [criterium "0.4.6"]
                                   [instaparse "1.5.0"]
@@ -99,6 +102,7 @@
             "kaocha" ^{:doc "Run tests with kaocha"} ["run" "-m" "kaocha.runner"]
             "dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]
             "load-generator" ^{:doc "Performance test lobbies"} ["run" "-m" "tasks.load-generator/command"]
+            "stress-test" ^{:doc "Run concurrent bot games against a running server and sample resource usage"} ["run" "-m" "tasks.stress.run/command"]
             "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]
             "update-all-decks" ["run" "-m" "tasks.db/update-all-decks"]
             "update-prizes" ^{:doc "Update prize information (card-backs, etc)"} ["run" "-m" "tasks.update-prizes/command"]

--- a/src/clj/tasks/stress/bot.clj
+++ b/src/clj/tasks/stress/bot.clj
@@ -1,0 +1,206 @@
+(ns tasks.stress.bot
+  "Decision engine for stress-test players. Decides one command at a time from
+  the client-visible game state, leaning on the :playable flags, prompt choice
+  uuids and :selectable lists the server computes for real clients. It plays
+  legally and keeps games progressing; it does not try to play well."
+  (:require
+    [clojure.string :as str]))
+
+(defn- rand-nth* [^java.util.Random rng coll]
+  (when (seq coll)
+    (nth (vec coll) (.nextInt rng (count coll)))))
+
+(defn- chance? [^java.util.Random rng p]
+  (< (.nextDouble rng) p))
+
+(defn card-ref [card]
+  (select-keys card [:cid :zone :side :host :type]))
+
+(defn find-card
+  "Finds a full card map by cid anywhere in either player's visible state.
+  The :zone guard skips the zoneless card stubs echoed in prompts."
+  [state cid]
+  (->> [(:corp state) (:runner state)]
+       (tree-seq coll? seq)
+       (filter #(and (map? %) (= cid (:cid %)) (:zone %)))
+       first))
+
+;; prompts
+
+(defn- answer-buttons [prompt rng]
+  (when-let [choice (rand-nth* rng (:choices prompt))]
+    ["choice" {:eid (:eid prompt) :choice {:uuid (:uuid choice)}}]))
+
+(defn- answer-select [state prompt rng]
+  (if-let [card (some->> (:selectable prompt) (rand-nth* rng) (find-card state))]
+    ["select" {:card (card-ref card) :eid (:eid prompt)}]
+    (answer-buttons prompt rng)))
+
+(defn- answer-prompt [state _side prompt rng]
+  (let [choices (:choices prompt)]
+    (cond
+      (= "mulligan" (:prompt-type prompt))
+      (when-let [keep (first (filter #(= "Keep" (:value %)) choices))]
+        ["choice" {:eid (:eid prompt) :choice {:uuid (:uuid keep)}}])
+
+      (= "select" (:prompt-type prompt))
+      (answer-select state prompt rng)
+
+      (sequential? choices)
+      (answer-buttons prompt rng)
+
+      (:card-title choices)
+      ["choice" {:eid (:eid prompt) :choice "Hedge Fund"}]
+
+      (:number choices)
+      ["choice" {:eid (:eid prompt) :choice (.nextInt rng (inc (:number choices)))}]
+
+      (or (int? choices) (= "credit" choices) (= "trace" (:prompt-type prompt)) (:base choices))
+      ["choice" {:eid (:eid prompt) :choice 0}]
+
+      :else nil)))
+
+;; runs
+
+(defn- run-server-key [state]
+  (some-> (get-in state [:run :server]) first keyword))
+
+(defn- approached-ice [state]
+  (let [pos (get-in state [:run :position])
+        ices (get-in state [:corp :servers (run-server-key state) :ices])]
+    (when (and pos (seq ices) (<= 1 pos (count ices)))
+      (nth ices (dec pos)))))
+
+(defn- icebreakers [state]
+  (->> (get-in state [:runner :rig :program])
+       (filter (fn [c] (some #(str/includes? % "breaker") (map str/lower-case (:subtypes c [])))))))
+
+(def ^:private continue-phases
+  #{"initiation" "approach-ice" "encounter-ice" "movement"})
+
+(defn- continue* [state side]
+  (when (and (continue-phases (get-in state [:run :phase]))
+             (not= (name side) (get-in state [:run :no-action])))
+    ["continue" nil]))
+
+(defn- corp-run-action [state rng]
+  (let [ice (approached-ice state)
+        phase (get-in state [:run :phase])]
+    (cond
+      (and ice (= "approach-ice" phase) (not (:rezzed ice)) (chance? rng 0.4))
+      ["rez" {:card (card-ref ice)}]
+
+      (and ice (= "encounter-ice" phase) (:rezzed ice) (chance? rng 0.5))
+      ["unbroken-subroutines" {:card (card-ref ice)}]
+
+      :else (continue* state :corp))))
+
+(defn- runner-run-action [state rng]
+  (let [ice (approached-ice state)]
+    (cond
+      (and ice (= "encounter-ice" (get-in state [:run :phase])) (:rezzed ice) (chance? rng 0.5))
+      (if-let [breaker (rand-nth* rng (icebreakers state))]
+        ["dynamic-ability" {:dynamic "auto-pump-and-break" :card (card-ref breaker)}]
+        (continue* state :runner))
+
+      (chance? rng 0.05) ["jack-out" nil]
+      :else (continue* state :runner))))
+
+;; turns
+
+(defn- playable-from-hand [me]
+  (filter :playable (:hand me)))
+
+(defn- corp-install-server [card rng]
+  (case (:type card)
+    ("ICE" "Upgrade") (rand-nth* rng ["HQ" "R&D" "Archives" "New remote"])
+    "New remote"))
+
+(defn- play-card [side me rng]
+  (when-let [card (rand-nth* rng (playable-from-hand me))]
+    (if (and (= :corp side) (not= "Operation" (:type card)))
+      ["play" {:card (card-ref card) :server (corp-install-server card rng)}]
+      ["play" {:card (card-ref card)}])))
+
+(defn- installed-cards [state side]
+  (if (= :corp side)
+    (mapcat (fn [[_ server]] (concat (:content server) (:ices server)))
+            (get-in state [:corp :servers]))
+    (mapcat #(get-in state [:runner :rig %]) [:program :hardware :resource])))
+
+(defn- use-ability [state side rng]
+  (let [cards (for [card (installed-cards state side)
+                    [idx ab] (map-indexed vector (:abilities card))
+                    :when (:playable ab)]
+                [card idx])]
+    (when-let [[card idx] (rand-nth* rng cards)]
+      ["ability" {:card (card-ref card) :ability idx}])))
+
+(defn- advanceable [state]
+  (->> (installed-cards state :corp)
+       (remove #(= "ICE" (:type %)))
+       (filter #(or (:advanceable %) (= "Agenda" (:type %))))))
+
+(defn- scoreable [state]
+  (->> (installed-cards state :corp)
+       (filter #(and (= "Agenda" (:type %))
+                     (>= (:advance-counter % 0) (:advancementcost % 99))))))
+
+(defn- corp-turn-action [state me rng]
+  (or (when-let [agenda (first (scoreable state))]
+        ["score" {:card (card-ref agenda)}])
+      (let [roll (.nextDouble rng)]
+        (cond
+          (< roll 0.35) (or (play-card :corp me rng) ["credit" nil])
+          (< roll 0.50) (or (when-let [card (rand-nth* rng (advanceable state))]
+                              (when (pos? (:credit me 0))
+                                ["advance" {:card (card-ref card)}]))
+                            ["credit" nil])
+          (< roll 0.60) (or (use-ability state :corp rng) ["credit" nil])
+          (< roll 0.75) ["draw" nil]
+          :else ["credit" nil]))))
+
+(defn- runner-turn-action [state me rng]
+  (let [roll (.nextDouble rng)]
+    (cond
+      (< roll 0.35) (or (play-card :runner me rng) ["credit" nil])
+      (< roll 0.55) (if-let [server (rand-nth* rng (:runnable-list me))]
+                      ["run" {:server server}]
+                      ["credit" nil])
+      (< roll 0.65) (or (use-ability state :runner rng) ["credit" nil])
+      (< roll 0.80) ["draw" nil]
+      :else ["credit" nil])))
+
+(defn- no-prompt-action [state side me rng]
+  (let [my-turn? (= (name side) (:active-player state))]
+    (cond
+      (:run state)
+      (if (= :corp side) (corp-run-action state rng) (runner-run-action state rng))
+
+      (get state (if (= :corp side) :corp-phase-12 :runner-phase-12))
+      (when my-turn? ["end-phase-12" nil])
+
+      (and (:end-turn state) (not my-turn?))
+      ["start-turn" nil]
+
+      (and my-turn? (not (:end-turn state)))
+      (if (pos? (:click me 0))
+        (if (= :corp side)
+          (corp-turn-action state me rng)
+          (runner-turn-action state me rng))
+        ["end-turn" nil])
+
+      :else nil)))
+
+(defn decide
+  "Returns [command args] for `side` given its visible state, or nil when
+  there is nothing sensible to do (e.g. waiting on the opponent)."
+  [state side ^java.util.Random rng]
+  (when (and state (not (:winner state)))
+    (let [me (get state side)
+          prompt (:prompt-state me)]
+      (cond
+        (nil? prompt) (no-prompt-action state side me rng)
+        (= "waiting" (:prompt-type prompt)) nil
+        (= "run" (:prompt-type prompt)) (no-prompt-action state side me rng)
+        :else (answer-prompt state side prompt rng)))))

--- a/src/clj/tasks/stress/client.clj
+++ b/src/clj/tasks/stress/client.clj
@@ -1,0 +1,185 @@
+(ns tasks.stress.client
+  "Headless jinteki client for stress testing. Talks to a running server the
+  same way the browser does: HTTP register/login, then a real websocket over
+  which it receives the state diffs and tracks game state with differ/patch."
+  (:require
+    [cheshire.core :as json]
+    [clojure.core.async :as async]
+    [clojure.string :as str]
+    [differ.core :as differ]
+    [org.httpkit.client :as http]
+    [taoensso.sente :as sente]))
+
+(defn- cookie-pair [set-cookie]
+  (first (str/split (or set-cookie "") #";")))
+
+(defn- scrape-csrf [body]
+  (second (re-find #"data-csrf-token=\"(.*?)\"" (str body))))
+
+(defn login!
+  "Registers the user if needed and logs in.
+  Returns {:cookie ... :csrf ...} for the websocket connection."
+  [base-url username password]
+  (let [home @(http/get base-url {:as :text})
+        ring-cookie (cookie-pair (get-in home [:headers :set-cookie]))
+        csrf (scrape-csrf (:body home))
+        _ @(http/post (str base-url "/register")
+                      {:headers {"Cookie" ring-cookie "x-csrf-token" csrf}
+                       :form-params {:username username :password password
+                                     :confirm-password password
+                                     :email (str username "@stress.invalid")}})
+        login @(http/post (str base-url "/login")
+                          {:headers {"Cookie" ring-cookie "x-csrf-token" csrf}
+                           :form-params {:username username :password password}})]
+    (when (not= 200 (:status login))
+      (throw (ex-info (str "login failed for " username
+                           " (status " (:status login)
+                           (when-let [err (:error login)] (str ", " err))
+                           ")")
+                      {:status (:status login) :body (:body login)})))
+    {:cookie (str ring-cookie "; " (cookie-pair (get-in login [:headers :set-cookie])))
+     :csrf csrf}))
+
+(defn set-blocked-users!
+  "Replaces the user's block list, like saving it in account settings."
+  [base-url {:keys [cookie csrf]} usernames]
+  (let [resp @(http/put (str base-url "/profile")
+                        {:headers {"Cookie" cookie
+                                   "x-csrf-token" csrf
+                                   "Content-Type" "application/json"}
+                         :body (json/generate-string {:blocked-users usernames})})]
+    (when (not= 200 (:status resp))
+      (throw (ex-info "failed to set blocked users" {:status (:status resp) :body (:body resp)})))))
+
+(defn- clear-processed-action!
+  "Like the browser client, an action counts as processed once our side's
+  :aid changes (game.main/set-action-id bumps it per handled command)."
+  [{:keys [game-state counters pending-action]}]
+  (when-let [{:keys [side aid sent-at]} @pending-action]
+    (when (not= aid (get-in @game-state [side :aid]))
+      (reset! pending-action nil)
+      (swap! counters update :latencies conj (/ (- (System/nanoTime) sent-at) 1e6)))))
+
+(defn- resync! [{:keys [game-state lobby-state counters pending-action send-fn]}]
+  (swap! counters update :errors inc)
+  (reset! pending-action nil)
+  (when-let [gameid (or (:gameid @lobby-state)
+                        (some-> (:gameid @game-state) parse-uuid))]
+    (send-fn [:game/resync {:gameid gameid}])))
+
+(defn- apply-diff! [{:keys [game-state] :as client} data]
+  (when @game-state
+    (let [{:keys [gameid diff]} (json/parse-string data true)
+          old-seq (:sequence @game-state 0)]
+      (when (= gameid (:gameid @game-state))
+        (try
+          (swap! game-state differ/patch diff)
+          ;; websockets guarantee order but not delivery; log-only diffs leave
+          ;; :sequence untouched, so only a jump past old+1 means we missed one
+          (when (> (:sequence @game-state 0) (inc old-seq))
+            (resync! client))
+          (catch Exception _
+            (resync! client)))))))
+
+(defn- handle-event [{:keys [game-state lobby-state counters] :as client} [id data]]
+  (case id
+    :lobby/list (swap! counters update :lobby-lists inc)
+    :lobby/state (reset! lobby-state (or data {:not-in-a-lobby true}))
+    :game/start (do (reset! game-state (json/parse-string data true))
+                    (swap! counters update :diffs inc))
+    :game/resync (reset! game-state (json/parse-string data true))
+    :game/diff (do (apply-diff! client data)
+                   (swap! counters update :diffs inc)
+                   (clear-processed-action! client))
+    :game/error (resync! client)
+    nil)
+  ;; only game progress counts as activity, or keepalive pings defeat the wedge watchdog
+  (when (#{:game/start :game/diff :game/resync} id)
+    (reset! (:last-event-at client) (System/currentTimeMillis))))
+
+(def ^:private msgpack-connect-opts
+  "Extra client opts when the classpath has the msgpack wire (sente 1.20+):
+  the msgpack packer plus a binary-capable ws client. Nil against an older
+  edn-wire server, whose sente client connects by itself and packs edn."
+  (when (try (requiring-resolve 'taoensso.sente.packers.msgpack/get-packer)
+             (catch java.io.FileNotFoundException _ nil))
+    ((requiring-resolve 'tasks.stress.msgpack/connect-opts))))
+
+(defn connect!
+  "Opens a websocket as `username` and starts the receive loop.
+  Returns a client map; deref :game-state / :lobby-state to observe."
+  [base-url {:keys [cookie csrf]} username counters]
+  (let [uri (java.net.URI. base-url)
+        port (.getPort uri)
+        chsk (sente/make-channel-socket-client!
+              "/chsk" csrf
+              (merge {:type :ws
+                      :protocol (keyword (.getScheme uri))
+                      :host (.getHost uri)
+                      :port (when (pos? port) port)
+                      :headers {"Cookie" cookie "Origin" base-url}}
+                     msgpack-connect-opts))
+        client {:username username
+                :chsk chsk
+                :game-state (atom nil)
+                :lobby-state (atom nil)
+                :pending-action (atom nil)
+                :reconnected? (atom false)
+                :last-event-at (atom (System/currentTimeMillis))
+                :counters counters
+                :send-fn (:send-fn chsk)}]
+    ;; a reconnect means the server evicted us from our game; the slot must reset
+    (add-watch (:state chsk) ::reconnect
+               (fn [_ _ old new]
+                 (when (and (:open? new) (not (:open? old)) (:ever-opened? old))
+                   (reset! (:reconnected? client) true))))
+    (async/go-loop []
+      (when-let [msg (async/<! (:ch-recv chsk))]
+        (try
+          (handle-event client (:event msg))
+          (catch Exception e
+            (swap! counters update :errors inc)
+            (println "client" username "event error:" (.getMessage e))))
+        (recur)))
+    ;; sente connects asynchronously and drops sends on a closed chsk, so
+    ;; wait for the handshake before anyone gets to send
+    (loop [waited 0]
+      (when (and (not (:open? @(:state chsk))) (< waited 15000))
+        (Thread/sleep 100)
+        (recur (+ waited 100))))
+    (when-not (:open? @(:state chsk))
+      (sente/chsk-disconnect! (:chsk chsk))
+      (throw (ex-info (str "websocket never opened for " username) {})))
+    client))
+
+(defn disconnect! [client]
+  (sente/chsk-disconnect! (:chsk (:chsk client))))
+
+(defn send-event! [client event]
+  ((:send-fn client) event))
+
+(defn send-chat!
+  "Sends an in-game chat message; the server logs it and diffs it to everyone."
+  [client gameid text]
+  (swap! (:counters client) update :chats inc)
+  (send-event! client [:game/say {:gameid gameid :msg text}]))
+
+(defn send-action!
+  "Sends a game action and locks the client until the server reflects it."
+  [client side gameid command args]
+  (reset! (:pending-action client) {:side side
+                                    :aid (get-in @(:game-state client) [side :aid])
+                                    :sent-at (System/nanoTime)})
+  (swap! (:counters client) update :actions inc)
+  (send-event! client [:game/action {:gameid gameid :command command :args args}]))
+
+(defn wait-for
+  "Polls f every 100ms until it returns truthy or timeout-ms passes.
+  Returns the value or nil."
+  [f timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (or (f)
+          (when (< (System/currentTimeMillis) deadline)
+            (Thread/sleep 100)
+            (recur))))))

--- a/src/clj/tasks/stress/msgpack.clj
+++ b/src/clj/tasks/stress/msgpack.clj
@@ -1,0 +1,48 @@
+(ns tasks.stress.msgpack
+  "The msgpack half of the stress client, kept apart so the harness also
+  compiles against a server on the older edn wire: sente pre-1.20 has neither
+  the msgpack packer nor the pluggable ws client used here. Only loaded (via
+  requiring-resolve in tasks.stress.client) when the packer namespace exists."
+  (:require
+    [jinteki.msgpack-ext]
+    [taoensso.sente.interfaces :as sente-interfaces]
+    [taoensso.sente.packers.msgpack :as msgpack])
+  (:import
+    (java.nio ByteBuffer)
+    (org.java_websocket.client WebSocketClient)))
+
+(defn- make-binary-ws
+  "Like taoensso.sente.java-ws-client/make-client-ws, but also accepts the
+  binary frames a binary packer (msgpack) produces; sente's own Java client
+  only handles text frames."
+  [{:keys [uri-str headers on-error on-message on-close]}]
+  (when-let [^WebSocketClient ws-client
+             (try
+               (proxy [WebSocketClient] [(java.net.URI. ^String uri-str) ^java.util.Map headers]
+                 (onOpen [_] nil)
+                 (onError [ex] (on-error ex))
+                 (onMessage [msg]
+                   (on-message
+                    (if (instance? ByteBuffer msg)
+                      (let [^ByteBuffer bb msg
+                            arr (byte-array (.remaining bb))]
+                        (.get bb arr)
+                        arr)
+                      msg)))
+                 (onClose [code reason remote] (on-close code reason remote)))
+               (catch Throwable t
+                 (println "websocket client creation failed:" (.getMessage t))
+                 nil))]
+    (delay
+      (.connect ws-client)
+      (reify
+        sente-interfaces/IClientWebSocket
+        (cws-raw [_] ws-client)
+        (cws-send [_ data] (.send ws-client data))
+        (cws-close [_ code reason _clean?] (.close ws-client code reason))))))
+
+(defn connect-opts
+  "Extra make-channel-socket-client! opts for the msgpack wire."
+  []
+  {:packer (msgpack/get-packer)
+   :ws-constructor make-binary-ws})

--- a/src/clj/tasks/stress/profiler.clj
+++ b/src/clj/tasks/stress/profiler.clj
@@ -1,0 +1,113 @@
+(ns tasks.stress.profiler
+  "Drives clj-async-profiler inside the server JVM over nREPL and collects the
+  results into the stress run's output directory: collapsed stacks (text, one
+  'frame;frame;... count' line per unique stack), a flamegraph SVG, and a
+  top-frames text summary."
+  (:require
+    [clojure.java.io :as io]
+    [clojure.java.shell :as shell]
+    [clojure.string :as str]
+    [nrepl.core :as nrepl]))
+
+(defn- eval-remote
+  "Evaluates code in the server JVM. Returns the printed value; throws on error."
+  [{:keys [host port]} code]
+  (with-open [conn (nrepl/connect :host host :port port)]
+    (let [responses (doall (nrepl/message (nrepl/client conn 120000) {:op "eval" :code code}))
+          err (some :err responses)
+          value (first (keep :value responses))]
+      (when err
+        (throw (ex-info (str/trim err) {:code code})))
+      value)))
+
+(defn start!
+  "Starts profiling in the server JVM. For cpu, falls back to itimer where
+  perf events are unavailable (typical inside docker). Returns the event used."
+  [nrepl-opts preferred-event]
+  (eval-remote nrepl-opts "(require 'clj-async-profiler.core)")
+  (let [candidates (if (= preferred-event "cpu")
+                     [":cpu" ":itimer"]
+                     [(str ":" preferred-event)])]
+    (or (some (fn [event]
+                (try
+                  ;; big framebuf: deep clojure stacks overflow the 1MB default
+                  (eval-remote nrepl-opts (format "(clj-async-profiler.core/start {:event %s :framebuf 10000000})" event))
+                  event
+                  (catch Exception _ nil)))
+              candidates)
+        (throw (ex-info (str "profiler failed to start with " (str/join ", " candidates)) {})))))
+
+(defn- collect-collapsed!
+  "Stops the profiler and brings the collapsed stacks file into out-dir."
+  [nrepl-opts container out-file]
+  (let [remote-path (read-string
+                     (eval-remote nrepl-opts
+                                  "(.getAbsolutePath (clj-async-profiler.core/stop {:generate-flamegraph? false}))"))]
+    (if container
+      ;; absolute destination: docker cp reads a relative path with a colon
+      ;; (like our timestamped run folders) as container:path
+      (let [{:keys [exit err]} (shell/sh "docker" "cp" (str container ":" remote-path)
+                                         (.getAbsolutePath (io/file out-file)))]
+        (when-not (zero? exit)
+          (throw (ex-info (str "docker cp failed: " err) {}))))
+      (io/copy (io/file remote-path) out-file))))
+
+(defn- parse-collapsed [collapsed-file]
+  (with-open [rdr (io/reader collapsed-file)]
+    (doall
+     (keep (fn [line]
+             (let [sep (str/last-index-of line " ")]
+               (when sep
+                 [(str/split (subs line 0 sep) #";")
+                  (parse-long (subs line (inc sep)))])))
+           (line-seq rdr)))))
+
+(defn- top-frames
+  "Sample counts per frame: :self for leaf time, :total for time anywhere on
+  the stack (each frame counted once per stack to keep recursion honest)."
+  [stacks]
+  (let [totals (reduce (fn [acc [frames n]]
+                         (reduce #(update %1 %2 (fnil + 0) n) acc (distinct frames)))
+                       {} stacks)
+        selfs (reduce (fn [acc [frames n]]
+                        (update acc (peek frames) (fnil + 0) n))
+                      {} stacks)]
+    {:total-samples (reduce + 0 (map second stacks))
+     :by-total (sort-by val > totals)
+     :by-self (sort-by val > selfs)}))
+
+(defn- write-summary! [collapsed-file summary-file event]
+  (let [{:keys [total-samples by-total by-self]} (top-frames (parse-collapsed collapsed-file))
+        pct #(format "%5.1f%%" (double (* 100 (/ % total-samples))))
+        section (fn [title entries]
+                  (into [title]
+                        (map (fn [[frame n]] (str (pct n) " " n " " frame))
+                             (take 40 entries))))]
+    (->> (concat
+          [(str "Server profile, event " event ", " total-samples " samples")
+           "Full stacks in the sibling -collapsed.txt (frame;frame;... count), flamegraph in the sibling .html"
+           ""]
+          (section "== Top frames by self time (time spent in the frame itself) ==" by-self)
+          [""]
+          (section "== Top frames by total time (frame plus everything it calls) ==" by-total))
+         (str/join "\n")
+         (spit summary-file))))
+
+(defn- write-flamegraph! [collapsed-file html-file]
+  (let [generate (requiring-resolve 'clj-async-profiler.core/generate-flamegraph)
+        rendered (generate (str collapsed-file) {:title "netrunner stress run"})]
+    (io/copy rendered (io/file html-file))))
+
+(defn stop-and-collect!
+  "Stops profiling and writes <prefix>-collapsed.txt, <prefix>-summary.txt and
+  <prefix>.html into out-dir. Returns nil; failures print a warning and keep
+  whatever was collected so far."
+  [nrepl-opts container out-dir event prefix]
+  (let [collapsed (io/file out-dir (str prefix "-collapsed.txt"))]
+    (collect-collapsed! nrepl-opts container collapsed)
+    (write-summary! collapsed (io/file out-dir (str prefix "-summary.txt")) event)
+    (try
+      (write-flamegraph! collapsed (io/file out-dir (str prefix ".html")))
+      (catch Exception e
+        (println "warning: flamegraph generation failed:" (.getMessage e))
+        (println (str "         " prefix "-collapsed.txt still works with https://www.speedscope.app"))))))

--- a/src/clj/tasks/stress/run.clj
+++ b/src/clj/tasks/stress/run.clj
@@ -1,0 +1,574 @@
+(ns tasks.stress.run
+  "Stress test: runs N concurrent bot-vs-bot games against a running server
+  over real websockets and samples the server's resource usage over time.
+
+  See `bin/stress-test --help` for usage."
+  (:require
+    [cheshire.core :as json]
+    [clojure.java.io :as io]
+    [clojure.java.shell :as shell]
+    [clojure.string :as str]
+    [clojure.tools.cli :refer [parse-opts]]
+    [jinteki.preconstructed :refer [all-matchups]]
+    [tasks.stress.bot :as bot]
+    [tasks.stress.client :as client]
+    [tasks.stress.profiler :as profiler])
+  (:import
+    (java.time Instant)
+    (java.time.temporal ChronoUnit)))
+
+(defn- now-ms [] (System/currentTimeMillis))
+
+;; game lifecycle
+
+(defn- locked? [c]
+  (when-let [{:keys [sent-at]} @(:pending-action c)]
+    (< (- (System/nanoTime) sent-at) 5e9)))
+
+(def ^:private chat-phrases
+  ["thinking..." "gl hf" "one sec" "nice" "oops" "well played" "hm"])
+
+(defn- act! [c side gameid ^java.util.Random rng {:keys [chat-chance]}]
+  (if (and (pos? chat-chance) (< (.nextDouble rng) chat-chance))
+    (client/send-chat! c gameid (nth chat-phrases (.nextInt rng (count chat-phrases))))
+    (when-not (locked? c)
+      (when-let [[command args] (bot/decide @(:game-state c) side rng)]
+        (client/send-action! c side gameid command args)))))
+
+(defn- last-diff-at [slot]
+  (max @(:last-event-at (:corp slot)) @(:last-event-at (:runner slot))))
+
+(defn- winner [slot]
+  (some :winner [@(:game-state (:corp slot)) @(:game-state (:runner slot))]))
+
+(defn- jitter [^java.util.Random rng delay-ms]
+  (long (* delay-ms (+ 0.7 (* 0.6 (.nextDouble rng))))))
+
+(defn- clear-states! [slot]
+  (doseq [c (list* (:corp slot) (:runner slot) (:spectators slot))]
+    (reset! (:game-state c) nil)
+    (reset! (:lobby-state c) nil)
+    (reset! (:pending-action c) nil)))
+
+(defn- leave-game! [slot gameid]
+  (doseq [c (list* (:corp slot) (:runner slot) (:spectators slot))]
+    (client/send-event! c [:game/leave {:gameid gameid}])
+    ;; back on the lobby page between games, like the browser
+    (client/send-event! c [:lobby/continue-updates]))
+  (clear-states! slot))
+
+(defn- abandon-stale-lobby!
+  "After an unclean shutdown the server may still have this user in a lobby,
+  which makes it silently refuse to create a new one. Ask where we are and leave."
+  [c]
+  (reset! (:lobby-state c) nil)
+  (client/send-event! c [:lobby/list])
+  (when-let [gameid (:gameid (client/wait-for #(deref (:lobby-state c)) 3000))]
+    (client/send-event! c [:game/leave {:gameid gameid}])
+    (client/send-event! c [:lobby/leave {:gameid gameid}])
+    (client/wait-for #(nil? (:gameid @(:lobby-state c))) 5000)
+    (println (:username c) "left a stale lobby")))
+
+(defn- start-game!
+  "Creates a lobby, joins, starts the game and connects spectators.
+  Returns the gameid. Throws on timeout."
+  [{:keys [corp runner spectators id] :as slot} matchup save-replays?]
+  (doseq [c (list* corp runner spectators)]
+    (abandon-stale-lobby! c))
+  (clear-states! slot)
+  (client/send-event! corp [:lobby/create {:title (str "stress-" id)
+                                           :format "preconstructed"
+                                           :precon (name matchup)
+                                           :room "casual"
+                                           :side "Corp"
+                                           :allow-spectator true
+                                           :spectatorhands false
+                                           :save-replay save-replays?
+                                           :password ""
+                                           :options {}}])
+  (let [gameid (client/wait-for #(:gameid @(:lobby-state corp)) 30000)]
+    (when-not gameid
+      (throw (ex-info "lobby create timed out" {:slot id})))
+    (try
+      (client/send-event! runner [:lobby/join {:gameid gameid :password ""}])
+      (when-not (client/wait-for #(= gameid (:gameid @(:lobby-state runner))) 30000)
+        (throw (ex-info "lobby join timed out" {:slot id})))
+      (client/send-event! corp [:game/start {:gameid gameid}])
+      (when-not (client/wait-for #(and @(:game-state corp) @(:game-state runner)) 60000)
+        (throw (ex-info "game start timed out" {:slot id})))
+      (doseq [spec spectators]
+        (client/send-event! spec [:game/watch {:gameid gameid :password ""}]))
+      ;; the browser pauses lobby updates once you're in a game; mirror it so
+      ;; the broadcast audience is watchers plus whoever is between games
+      (doseq [c (list* corp runner spectators)]
+        (client/send-event! c [:lobby/pause-updates]))
+      gameid
+      (catch Exception e
+        ;; leave the half-made lobby or the server will refuse our next create
+        (client/send-event! corp [:lobby/leave {:gameid gameid}])
+        (throw e)))))
+
+(defn- play-game!
+  "Runs the bot loop until the game has a winner, wedges, or the run stops."
+  [{:keys [corp runner rng] :as slot} gameid {:keys [delay-ms wedge-timeout-ms stop? counters] :as ctx}]
+  (let [game-deadline (+ (now-ms) (* 20 60 1000))
+        concede! (fn []
+                   (swap! counters update :wedges inc)
+                   (client/send-action! corp :corp gameid "concede" nil)
+                   (client/wait-for #(winner slot) 10000))]
+    (loop []
+      (Thread/sleep (jitter rng delay-ms))
+      (cond
+        @stop?
+        (client/send-action! corp :corp gameid "concede" nil)
+
+        (winner slot)
+        (swap! counters update :games-completed inc)
+
+        (or @(:reconnected? corp) @(:reconnected? runner))
+        (throw (ex-info "websocket reconnected, game lost" {:slot (:id slot)}))
+
+        (or (> (- (now-ms) (last-diff-at slot)) wedge-timeout-ms)
+            (> (now-ms) game-deadline))
+        (concede!)
+
+        :else
+        (do (act! corp :corp gameid rng ctx)
+            (act! runner :runner gameid rng ctx)
+            (recur))))))
+
+(defn- blocked-usernames
+  "0..max-blocks players from other games, never the own opponent, so the
+  pairings this slot plays are unaffected while playing players still block
+  each other across games."
+  [games max-blocks id role]
+  (let [n (mod (+ id (case role :corp 0 :runner 1)) (inc max-blocks))]
+    (vec (distinct
+          (for [k (range 1 (inc n))
+                :let [target (mod (+ id k) games)]
+                :when (not= target id)]
+            (str (case role :corp "stress-runner-" :runner "stress-corp-") target))))))
+
+(defn- watcher-blocked-usernames
+  "Watchers block 0..max-blocks playing players, exercising the lobby list
+  filter's slow path for part of the crowd."
+  [games max-blocks id]
+  (let [n (mod id (inc max-blocks))]
+    (vec (distinct
+          (for [k (range 1 (inc n))]
+            (str (if (even? k) "stress-corp-" "stress-runner-")
+                 (mod (+ id k) (max games 1))))))))
+
+(defn- pre-authenticate!
+  "Registers/logs in every user of the run and writes their block lists.
+  Logging in again is rare in production (sessions persist), so this
+  bcrypt-heavy stage runs before profiling starts. Returns username->auth."
+  [{:keys [base-url games max-blocks spectators-per-game]} lobby-watchers]
+  (let [users (concat
+               (mapcat (fn [id]
+                         [[(str "stress-corp-" id) (blocked-usernames games max-blocks id :corp)]
+                          [(str "stress-runner-" id) (blocked-usernames games max-blocks id :runner)]])
+                       (range games))
+               (for [id (range games)
+                     s (range spectators-per-game)]
+                 [(str "stress-spec-" id "-" s) []])
+               (for [i (range lobby-watchers)]
+                 [(str "stress-watch-" i) (watcher-blocked-usernames games max-blocks i)]))]
+    (println (format "Authenticating %d users..." (count users)))
+    (let [auths (->> users
+                     (pmap (fn [[username blocked]]
+                             (let [auth (try
+                                          (client/login! base-url username "stress-password")
+                                          (catch Exception _
+                                            (Thread/sleep 1000)
+                                            (client/login! base-url username "stress-password")))]
+                               (client/set-blocked-users! base-url auth blocked)
+                               [username auth])))
+                     (into {}))]
+      (println "Authentication done")
+      auths)))
+
+(defn- connect-watchers!
+  "Connects idle users subscribed to lobby updates: the tournament crowd that
+  receives every lobby-list broadcast without playing or spectating."
+  [{:keys [base-url counters auths stop?]} n]
+  (println (format "Connecting %d lobby watchers..." n))
+  (let [watchers (->> (range n)
+                      (pmap (fn [i]
+                              (try
+                                (let [username (str "stress-watch-" i)
+                                      c (client/connect! base-url (get auths username) username counters)]
+                                  ;; subscribe explicitly; this also delivers a first list
+                                  (client/send-event! c [:lobby/continue-updates])
+                                  c)
+                                (catch Exception e
+                                  (println "watcher" i "failed:" (.getMessage e))
+                                  nil))))
+                      (filterv some?))]
+    ;; subscriptions lapse after an hour; refresh like a browser on the lobby page
+    (doto (Thread.
+           (fn []
+             (loop []
+               (Thread/sleep 600000)
+               (when-not @stop?
+                 (doseq [c watchers]
+                   (try (client/send-event! c [:lobby/continue-updates]) (catch Exception _)))
+                 (recur))))
+           "stress-watchers-keepalive")
+      (.setDaemon true)
+      (.start))
+    (println (format "%d lobby watchers connected" (count watchers)))
+    watchers))
+
+(defn- connect-slot!
+  "(Re)connects all clients of a slot; on failure disconnects any partial ones.
+  Auth and block lists come from the pre-authentication stage; a fresh login
+  only happens as a fallback (e.g. an expired session on a very long run)."
+  [{:keys [base-url counters auths]} id spectators-per-game]
+  (let [connected (atom [])
+        conn (fn [username]
+               (let [auth (or (get auths username)
+                              (client/login! base-url username "stress-password"))
+                     c (client/connect! base-url auth username counters)]
+                 ;; a browser lands on the lobby page and subscribes itself;
+                 ;; the server no longer subscribes anyone by default
+                 (client/send-event! c [:lobby/continue-updates])
+                 (swap! connected conj c)
+                 c))]
+    (try
+      {:id id
+       :rng (java.util.Random. (+ 42 id))
+       :corp (conn (str "stress-corp-" id))
+       :runner (conn (str "stress-runner-" id))
+       :spectators (mapv #(conn (str "stress-spec-" id "-" %)) (range spectators-per-game))}
+      (catch Exception e
+        (doseq [c @connected]
+          (try (client/disconnect! c) (catch Exception _)))
+        (throw e)))))
+
+(defn- disconnect-slot! [slot]
+  (doseq [c (list* (:corp slot) (:runner slot) (:spectators slot))]
+    (try (client/disconnect! c) (catch Exception _))))
+
+(defn- slot-loop
+  "One thread per slot: play games back to back until stopped."
+  [{:keys [stop? counters active-games matchups spectators-per-game save-replays?] :as ctx} id]
+  (Thread/sleep (* 200 id))
+  (loop [slot nil
+         [matchup & more] (drop id (cycle matchups))]
+    (let [slot' (try
+                  (let [slot (or slot (connect-slot! ctx id spectators-per-game))
+                        gameid (start-game! slot matchup save-replays?)]
+                    (swap! active-games inc)
+                    (try
+                      (play-game! slot gameid ctx)
+                      (finally
+                        (swap! active-games dec)
+                        (leave-game! slot gameid)))
+                    slot)
+                  (catch InterruptedException _ nil)
+                  (catch Exception e
+                    (swap! counters update :slot-resets inc)
+                    (println (str "slot " id " reset: " (.getMessage e)))
+                    (when slot (disconnect-slot! slot))
+                    (when-not @stop?
+                      (Thread/sleep 3000))
+                    nil))]
+      (if @stop?
+        (when slot' (disconnect-slot! slot'))
+        (recur slot' more)))))
+
+;; resource sampling
+
+(defn- parse-mem [s]
+  (when-let [[_ n unit] (re-find #"([\d.]+)\s*([KMGT]?i?B)" (str s))]
+    (long (* (Double/parseDouble n)
+             (case (first unit)
+               \K 1024 \M (* 1024 1024) \G (* 1024 1024 1024) \T (* 1024 1024 1024 1024)
+               1)))))
+
+(defn- docker-sampler!
+  "Streams `docker stats` into the latest-sample atom until stopped."
+  [container latest stop?]
+  (let [proc (.start (ProcessBuilder. ["docker" "stats" "--format" "{{json .}}" container]))]
+    (doto (Thread.
+           (fn []
+             (with-open [rdr (io/reader (.getInputStream proc))]
+               ;; the first streamed frame reports stale values, skip it
+               (doseq [[i line] (map-indexed vector (line-seq rdr))
+                       :while (not @stop?)
+                       :when (pos? i)]
+                 (when-let [start (str/index-of line "{")]
+                   (try
+                     (let [sample (json/parse-string (subs line start) true)]
+                       (reset! latest {:cpu-pct (some-> (:CPUPerc sample) (str/replace "%" "") Double/parseDouble)
+                                       :mem-bytes (parse-mem (:MemUsage sample))}))
+                     (catch Exception _))))))
+           "docker-sampler")
+      (.setDaemon true)
+      (.start))
+    proc))
+
+(defn- ps-sample [pid]
+  (let [out (:out (shell/sh "ps" "-o" "%cpu=,rss=" "-p" (str pid)))
+        [cpu rss] (some-> out str/trim (str/split #"\s+"))]
+    (when (and cpu rss)
+      {:cpu-pct (Double/parseDouble cpu)
+       :mem-bytes (* 1024 (Long/parseLong rss))})))
+
+(defn- percentile [sorted p]
+  (when (seq sorted)
+    (nth sorted (min (dec (count sorted)) (int (* p (count sorted)))))))
+
+(defn- sample-row [t0 latest-resources counters-snapshot prev-snapshot active-games lats]
+  (let [{:keys [cpu-pct mem-bytes]} @latest-resources
+        sorted (vec (sort lats))]
+    {:elapsed-s (quot (- (now-ms) t0) 1000)
+     :cpu-pct cpu-pct
+     :mem-mb (some-> mem-bytes (quot (* 1024 1024)))
+     :actions (- (:actions counters-snapshot 0) (:actions prev-snapshot 0))
+     :diffs (- (:diffs counters-snapshot 0) (:diffs prev-snapshot 0))
+     :errors (:errors counters-snapshot 0)
+     :active-games @active-games
+     :games-completed (:games-completed counters-snapshot 0)
+     :wedges (:wedges counters-snapshot 0)
+     :slot-resets (:slot-resets counters-snapshot 0)
+     :chats (:chats counters-snapshot 0)
+     :lobby-lists (:lobby-lists counters-snapshot 0)
+     :lat-p50-ms (percentile sorted 0.50)
+     :lat-p95-ms (percentile sorted 0.95)
+     :lat-p99-ms (percentile sorted 0.99)}))
+
+(def ^:private csv-columns
+  [:elapsed-s :cpu-pct :mem-mb :actions :diffs :errors :active-games
+   :games-completed :wedges :slot-resets :chats :lobby-lists
+   :lat-p50-ms :lat-p95-ms :lat-p99-ms])
+
+(defn- fmt [x]
+  (cond
+    (nil? x) ""
+    (double? x) (format "%.2f" x)
+    :else (str x)))
+
+(defn- status-line [{:keys [elapsed-s cpu-pct mem-mb actions active-games errors lat-p95-ms]}]
+  (format "[%4ds] cpu %s%% mem %sMB | games %d | %s act/s | p95 %sms | errors %s"
+          elapsed-s (fmt cpu-pct) (fmt mem-mb) active-games (fmt actions) (fmt lat-p95-ms) (fmt errors)))
+
+(defn- summarize [rows all-latencies config]
+  (let [cpus (keep :cpu-pct rows)
+        mems (keep :mem-mb rows)
+        sorted (vec (sort all-latencies))
+        total-actions (reduce + 0 (keep :actions rows))
+        duration (max 1 (- (:elapsed-s (last rows) 1) (:elapsed-s (first rows) 0)))]
+    {:config config
+     :run-at (str (Instant/now))
+     :duration-s duration
+     :cpu-pct {:mean (when (seq cpus) (/ (reduce + cpus) (count cpus)))
+               :max (when (seq cpus) (apply max cpus))}
+     :mem-mb {:mean (when (seq mems) (quot (reduce + mems) (count mems)))
+              :max (when (seq mems) (apply max mems))}
+     :actions {:total total-actions :per-s (double (/ total-actions duration))}
+     :chats (:chats (last rows) 0)
+     :lobby-lists (:lobby-lists (last rows) 0)
+     :action-latency-ms {:p50 (percentile sorted 0.50)
+                         :p95 (percentile sorted 0.95)
+                         :p99 (percentile sorted 0.99)
+                         :max (last sorted)}
+     :games-completed (:games-completed (last rows) 0)
+     :wedges (:wedges (last rows) 0)
+     :slot-resets (:slot-resets (last rows) 0)
+     :errors (:errors (last rows) 0)}))
+
+;; entry point
+
+;; defaults are sized for a local dev run: enough concurrent games for
+;; meaningful contention, long enough for several games to complete
+(def ^:private cli-options
+  [["-n" "--concurrent-games N" "Number of games running at the same time"
+    :default 10 :parse-fn #(Integer/parseInt %) :validate [pos? "must be positive"]]
+   ["-d" "--duration-seconds SEC" "How long to keep the load going"
+    :default 180 :parse-fn #(Integer/parseInt %) :validate [pos? "must be positive"]]
+   [nil "--delay MS" "Think time per bot between actions (lower = more load)"
+    :default 1000 :parse-fn #(Integer/parseInt %) :validate [#(>= % 50) "must be >= 50"]]
+   [nil "--matchups LIST" "Comma-separated preconstructed matchup keys (see jinteki.preconstructed), or 'all'"
+    :default "all"]
+   [nil "--spectators N" "Spectators per game"
+    :default 0 :parse-fn #(Integer/parseInt %)]
+   [nil "--save-replays" "Save replays at game end, like tournament games do"
+    :default false]
+   [nil "--chat-chance P" "Probability (0-1) a bot chats in-game instead of acting on a tick"
+    :default 0.0 :parse-fn #(Double/parseDouble %)
+    :validate [#(<= 0.0 % 1.0) "must be between 0 and 1"]]
+   [nil "--max-blocks N" "Players block 0..N players from other games (0 disables)"
+    :default 0 :parse-fn #(Integer/parseInt %)
+    :validate [#(<= 0 % 10) "must be between 0 and 10"]]
+   [nil "--lobby-watchers N" "Idle connected users subscribed to lobby updates (the tournament crowd)"
+    :default 0 :parse-fn #(Integer/parseInt %)]
+   [nil "--profile" "Capture a profile of the server into the output directory"
+    :default false]
+   [nil "--profile-event EVENT" "What to profile: cpu, alloc (allocation pressure), wall, or itimer"
+    :default "cpu" :validate [#{"cpu" "alloc" "wall" "itimer"} "must be cpu, alloc, wall or itimer"]]
+   [nil "--nrepl-port PORT" "Server nREPL port, used by --profile"
+    :default 44867 :parse-fn #(Integer/parseInt %)]
+   [nil "--url URL" "Server base url" :default "http://localhost:1042"]
+   [nil "--container NAME" "Docker container to sample resources from"
+    :default "netrunner-server-1"]
+   [nil "--pid PID" "Sample this OS pid with ps instead of docker stats"
+    :parse-fn #(Long/parseLong %)]
+   [nil "--out DIR" "Output directory (default stress-runs/<timestamp>)"]
+   ["-h" "--help"]])
+
+(defn- resolve-matchups [s]
+  (if (= "all" s)
+    (vec (sort all-matchups))
+    (let [ks (mapv keyword (str/split s #","))
+          bad (remove all-matchups ks)]
+      (when (seq bad)
+        (throw (ex-info (str "unknown matchups: " (str/join ", " (map name bad))
+                             "\navailable: " (str/join ", " (sort (map name all-matchups))))
+                        {})))
+      ks)))
+
+(defn- quiet-sente-logging!
+  "Sente 1.20+ logs :info per connection event via trove; with hundreds of
+  clients that buries the status lines. Our own teardown disconnects arrive
+  as warns, so drop exactly those too. Older sente has no trove and logs
+  via timbre, quiet enough as-is."
+  []
+  (when-let [log-fn-var (try (requiring-resolve 'taoensso.trove/*log-fn*)
+                             (catch java.io.FileNotFoundException _ nil))]
+    (let [get-log-fn (requiring-resolve 'taoensso.trove.console/get-log-fn)
+          console-log (get-log-fn {:min-level :warn})]
+      ;; trove/set-log-fn! is a macro, so set its var like it would
+      (alter-var-root log-fn-var
+                      (constantly
+                       (fn [ns coords level id lazy_]
+                         (when-not (and (= id :sente.client/chsk-closed)
+                                        (= :requested-disconnect (:reason (:data (force lazy_)))))
+                           (console-log ns coords level id lazy_))))))))
+
+(defn command
+  "Entry point for `lein stress-test` / `bin/stress-test`."
+  [& args]
+  (let [{:keys [options errors summary]} (parse-opts args cli-options)]
+    (cond
+      (:help options) (do (println "Run concurrent bot games against a running server and sample its resource usage.")
+                          (println)
+                          (println summary))
+      errors (do (doseq [e errors] (println e)) (System/exit 1))
+      :else
+      (let [_ (quiet-sente-logging!)
+            {:keys [concurrent-games duration-seconds delay spectators url container pid out
+                    save-replays profile nrepl-port chat-chance max-blocks lobby-watchers]} options
+            matchups (try (resolve-matchups (:matchups options))
+                          (catch Exception e
+                            (println (.getMessage e))
+                            (System/exit 1)))
+            out-dir (io/file (or out (str "stress-runs/" (.truncatedTo (Instant/now) ChronoUnit/SECONDS))))
+            counters (atom {:actions 0 :diffs 0 :errors 0 :latencies [] :chats 0
+                            :lobby-lists 0 :games-completed 0 :wedges 0 :slot-resets 0})
+            active-games (atom 0)
+            stop? (atom false)
+            latest-resources (atom nil)
+            config (-> options (assoc :matchups (mapv name matchups)) (dissoc :help))
+            ctx {:base-url url :counters counters :active-games active-games
+                 :stop? stop? :delay-ms delay :spectators-per-game spectators
+                 :save-replays? save-replays :chat-chance chat-chance
+                 :games concurrent-games :max-blocks max-blocks
+                 :wedge-timeout-ms (max 30000 (* 30 delay)) :matchups matchups}
+            nrepl-opts {:host (.getHost (java.net.URI. url)) :port nrepl-port}
+            profile-event (atom nil)
+            ;; :ramp while logins/creates assemble, :steady once games are up,
+            ;; nil once collected; guarded by profile-lock
+            profile-phase (atom nil)
+            profile-lock (Object.)
+            docker-proc (when-not pid
+                          (try
+                            (docker-sampler! container latest-resources stop?)
+                            (catch Exception e
+                              (println "warning: resource sampling disabled:" (.getMessage e))
+                              nil)))
+            _ (println (format "Starting %d games (%d matchups, delay %dms, %d spectators/game) against %s for %ds"
+                               concurrent-games (count matchups) delay spectators url duration-seconds))
+            ctx (assoc ctx :auths (pre-authenticate! ctx lobby-watchers))
+            _ (when profile
+                (try
+                  (reset! profile-event (profiler/start! nrepl-opts (:profile-event options)))
+                  (reset! profile-phase :ramp)
+                  (println "profiling server ramp-up with event" @profile-event)
+                  (catch Exception e
+                    (println "warning: profiling disabled:" (.getMessage e)))))
+            watchers (if (pos? lobby-watchers)
+                       (connect-watchers! ctx lobby-watchers)
+                       [])
+            threads (mapv (fn [id]
+                            (doto (Thread. #(slot-loop ctx id) (str "stress-slot-" id))
+                              (.start)))
+                          (range concurrent-games))
+            t0 (now-ms)
+            deadline (+ t0 (* 1000 duration-seconds))
+            collect! (fn [prefix]
+                       (try
+                         (profiler/stop-and-collect! nrepl-opts (when-not pid container)
+                                                     out-dir @profile-event prefix)
+                         (catch Exception e
+                           (println "warning: profile collection failed:" (.getMessage e)))))]
+        (when @profile-phase
+          ;; the ramp and the loaded steady state have very different profiles;
+          ;; collect them separately, switching once all games are up
+          (doto (Thread.
+                 (fn []
+                   (client/wait-for #(or @stop? (>= @active-games concurrent-games))
+                                    (max 90000 (* 1500 concurrent-games)))
+                   (locking profile-lock
+                     (when (and (= :ramp @profile-phase) (not @stop?))
+                       (collect! "profile-ramp")
+                       (try
+                         (profiler/start! nrepl-opts (:profile-event options))
+                         (reset! profile-phase :steady)
+                         (println "ramp-up profile collected; profiling steady state")
+                         (catch Exception e
+                           (reset! profile-phase nil)
+                           (println "warning: steady profiling failed to start:" (.getMessage e)))))))
+                 "stress-profiler")
+            (.setDaemon true)
+            (.start)))
+        (.mkdirs out-dir)
+        (spit (io/file out-dir "config.edn") (pr-str config))
+        (with-open [csv (io/writer (io/file out-dir "samples.csv"))]
+          (.write csv (str (str/join "," (map name csv-columns)) "\n"))
+          (loop [prev @counters
+                 rows []
+                 all-lats []]
+            (Thread/sleep 1000)
+            (when pid (reset! latest-resources (ps-sample pid)))
+            (let [[snapshot _] (swap-vals! counters assoc :latencies [])
+                  lats (:latencies snapshot)
+                  row (sample-row t0 latest-resources snapshot prev active-games lats)]
+              (.write csv (str (str/join "," (map #(fmt (row %)) csv-columns)) "\n"))
+              (.flush csv)
+              (when (and (= 5 (count rows)) (nil? @latest-resources))
+                (println "warning: no resource samples yet; check --container or --pid"))
+              (when (zero? (mod (count rows) 10))
+                (println (status-line row)))
+              (if (< (now-ms) deadline)
+                (recur snapshot (conj rows row) (into all-lats lats))
+                (do
+                  (locking profile-lock
+                    (when-let [phase @profile-phase]
+                      (collect! (if (= :steady phase) "profile-steady" "profile-ramp"))
+                      (reset! profile-phase nil)))
+                  (println "Stopping...")
+                  (reset! stop? true)
+                  (doseq [t threads] (.join t 15000))
+                  (doseq [w watchers]
+                    (try (client/disconnect! w) (catch Exception _)))
+                  (when docker-proc (.destroy docker-proc))
+                  (let [summary (summarize (conj rows row) (into all-lats lats) config)]
+                    (spit (io/file out-dir "summary.edn") (pr-str summary))
+                    (println)
+                    (println "Summary:")
+                    (println (json/generate-string summary {:pretty true}))
+                    (println)
+                    (println "Results in" (str out-dir))))))))
+        (System/exit 0)))))


### PR DESCRIPTION
This PR is not meant to be reviewed yet, it's a bunch of agent-generated code that I haven't gone through. I want to make it into a real PR eventually, but not right now.

I'm just putting it up so other people can reproduce the load I used to find the fixes in https://github.com/mtgred/netrunner/pull/8798.

## How to get a profile

Check out this branch, run `bin/up` to start the docker setup, then run this command:
```
bin/stress-test -n 30 --spectators 2 --chat-chance 0.1 --max-blocks 3 --lobby-watchers 30 --save-replays
```

This means: make 30 concurrent games, with 2 spectators each, and up to 3 blocked users for each player, 30 players watching the lobby, save replays on the game. Defaults to 1 action on each game per second, and output goes to `stress-runs/<timestamp>`.

## Results before https://github.com/mtgred/netrunner/pull/8798

I ran the command above but with `-n 90` (90 concurrent games) and a custom output directory, and got this output:
```
filipesilva@m4 ~/r/p/netrunner (stress-test-master)> bin/stress-test -n 90 --spectators 2 --chat-chance 0.1 --max-blocks 3 --lobby-watchers 30 --save-replays --profile --out stress-runs/before
WARNING: random-uuid already refers to: #'clojure.core/random-uuid in namespace: monger.util, being replaced by: #'monger.util/random-uuid
Starting 90 games (28 matchups, delay 1000ms, 2 spectators/game) against http://localhost:1042 for 180s
Authenticating 390 users...
Authentication done
profiling server ramp-up with event :cpu
Connecting 30 lobby watchers...
30 lobby watchers connected
[   1s] cpu 183.57% mem 1370MB | games 0 | 0 act/s | p95 ms | errors 0
[  11s] cpu 399.95% mem 2633MB | games 49 | 39 act/s | p95 119.56ms | errors 0
[  21s] cpu 756.63% mem 3378MB | games 84 | 78 act/s | p95 365.29ms | errors 0
ramp-up profile collected; profiling steady state
[  31s] cpu 52.70% mem 3358MB | games 90 | 93 act/s | p95 45.71ms | errors 0
[  41s] cpu 50.58% mem 3373MB | games 90 | 98 act/s | p95 45.76ms | errors 0
[  51s] cpu 41.06% mem 3377MB | games 90 | 81 act/s | p95 46.90ms | errors 1
[  61s] cpu 48.50% mem 3380MB | games 90 | 95 act/s | p95 45.64ms | errors 1
[  71s] cpu 41.67% mem 3390MB | games 90 | 96 act/s | p95 45.00ms | errors 1
[  81s] cpu 47.24% mem 3392MB | games 90 | 92 act/s | p95 44.38ms | errors 1
stress-corp-1 left a stale lobby
[  91s] cpu 51.25% mem 3401MB | games 90 | 93 act/s | p95 45.81ms | errors 2
[ 101s] cpu 49.75% mem 3424MB | games 90 | 85 act/s | p95 46.02ms | errors 2
[ 111s] cpu 47.11% mem 1998MB | games 90 | 88 act/s | p95 45.40ms | errors 2
[ 121s] cpu 51.62% mem 1999MB | games 90 | 86 act/s | p95 45.32ms | errors 3
[ 131s] cpu 49.90% mem 2004MB | games 90 | 85 act/s | p95 45.64ms | errors 4
stress-corp-9 left a stale lobby
[ 141s] cpu 235.95% mem 2572MB | games 90 | 85 act/s | p95 64.98ms | errors 4
[ 151s] cpu 51.31% mem 3536MB | games 90 | 80 act/s | p95 46.38ms | errors 4
stress-corp-81 left a stale lobby
[ 161s] cpu 45.02% mem 3575MB | games 90 | 93 act/s | p95 46.96ms | errors 4
[ 171s] cpu 191.97% mem 3595MB | games 90 | 97 act/s | p95 47.77ms | errors 4
Stopping...

Summary:
{
  "errors" : 5,
  "config" : {
    "concurrent-games" : 90,
    "duration-seconds" : 180,
    "lobby-watchers" : 30,
    "chat-chance" : 0.1,
    "matchups" : [ "worlds-2012-a", "worlds-2012-b", "worlds-2013-a", "worlds-2013-b", "worlds-2014-a", "worlds-2014-b", "worlds-2015-a", "worlds-2015-b", "worlds-2016-a", "worlds-2016-b", "worlds-2017-a", "worlds-2017-b", "worlds-2018-a", "worlds-2018-b", "worlds-2019-a", "worlds-2019-b", "worlds-2020-a", "worlds-2020-b", "worlds-2021-a", "worlds-2021-b", "worlds-2022-a", "worlds-2022-b", "worlds-2023-a", "worlds-2023-b", "worlds-2024-a", "worlds-2024-b", "worlds-2025-a", "worlds-2025-b" ],
    "max-blocks" : 3,
    "nrepl-port" : 44867,
    "profile-event" : "cpu",
    "out" : "stress-runs/before",
    "save-replays" : true,
    "container" : "netrunner-server-1",
    "url" : "http://localhost:1042",
    "spectators" : 2,
    "delay" : 1000,
    "profile" : true
  },
  "games-completed" : 10,
  "action-latency-ms" : {
    "p50" : 38.427791,
    "p95" : 64.143292,
    "p99" : 233.475917,
    "max" : 577.670291
  },
  "chats" : 2983,
  "actions" : {
    "total" : 15184,
    "per-s" : 84.8268156424581
  },
  "cpu-pct" : {
    "mean" : 114.33722222222218,
    "max" : 830.43
  },
  "mem-mb" : {
    "mean" : 3032,
    "max" : 3599
  },
  "slot-resets" : 0,
  "wedges" : 0,
  "duration-s" : 179,
  "lobby-lists" : 30629,
  "run-at" : "2026-07-19T15:54:01.982644Z"
}
```

Then in `stress-runs/before/profile-ramp.html` there's a cpu profile for the game creation stage, and in `stress-runs/before/profile-steady.html` there's a profile for the game playing stage.

The important part of the data above is the latency for actions, and the cpu/memory use:
```
  "action-latency-ms" : {
    "p50" : 38.427791,
    "p95" : 64.143292,
    "p99" : 233.475917,
    "max" : 577.670291
  },
  "cpu-pct" : {
    "mean" : 114.33722222222218,
    "max" : 830.43
  },
  "mem-mb" : {
    "mean" : 3032,
    "max" : 3599
  },
```

## Results after https://github.com/mtgred/netrunner/pull/8798

I cherry picked this PRs commit on top of the changes in the fixes PR, restarted `bin/up, then ran the same command but different output dir:
```
filipesilva@m4 ~/r/p/netrunner (stress-test)> bin/stress-test -n 90 --spectators 2 --chat-chance 0.1 --max-blocks 3 --lobby-watchers 30 --save-replays --profile --out stress-runs/after
WARNING: random-uuid already refers to: #'clojure.core/random-uuid in namespace: monger.util, being replaced by: #'monger.util/random-uuid
Starting 90 games (28 matchups, delay 1000ms, 2 spectators/game) against http://localhost:1042 for 180s
Authenticating 390 users...
Authentication done
profiling server ramp-up with event :cpu
Connecting 30 lobby watchers...
30 lobby watchers connected
[   1s] cpu 229.44% mem 1269MB | games 0 | 0 act/s | p95 ms | errors 0
[  11s] cpu 154.18% mem 1547MB | games 50 | 42 act/s | p95 64.28ms | errors 0
ramp-up profile collected; profiling steady state
[  21s] cpu 85.85% mem 1832MB | games 90 | 88 act/s | p95 36.87ms | errors 0
[  31s] cpu 48.28% mem 1838MB | games 90 | 90 act/s | p95 36.43ms | errors 1
[  41s] cpu 41.78% mem 1846MB | games 90 | 76 act/s | p95 43.47ms | errors 2
[  51s] cpu 51.01% mem 1849MB | games 90 | 88 act/s | p95 39.62ms | errors 2
[  61s] cpu 50.46% mem 1853MB | games 90 | 90 act/s | p95 38.01ms | errors 2
stress-corp-81 left a stale lobby
[  71s] cpu 54.25% mem 1872MB | games 90 | 88 act/s | p95 37.73ms | errors 2
[  81s] cpu 43.70% mem 1875MB | games 90 | 86 act/s | p95 38.27ms | errors 3
[  91s] cpu 34.92% mem 1885MB | games 90 | 97 act/s | p95 39.80ms | errors 7
[ 101s] cpu 46.24% mem 1764MB | games 90 | 86 act/s | p95 158.12ms | errors 7
[ 111s] cpu 47.61% mem 1765MB | games 90 | 105 act/s | p95 37.81ms | errors 7
[ 121s] cpu 74.52% mem 1770MB | games 88 | 96 act/s | p95 166.37ms | errors 7
[ 131s] cpu 53.54% mem 1774MB | games 90 | 85 act/s | p95 38.84ms | errors 7
stress-corp-24 left a stale lobby
[ 141s] cpu 42.87% mem 1781MB | games 90 | 87 act/s | p95 38.57ms | errors 7
stress-corp-77 left a stale lobby
[ 151s] cpu 43.38% mem 1783MB | games 90 | 93 act/s | p95 40.03ms | errors 7
[ 161s] cpu 64.16% mem 1783MB | games 90 | 88 act/s | p95 64.95ms | errors 7
[ 171s] cpu 47.08% mem 1790MB | games 90 | 94 act/s | p95 40.07ms | errors 8
Stopping...

Summary:
{
  "errors" : 9,
  "config" : {
    "concurrent-games" : 90,
    "duration-seconds" : 180,
    "lobby-watchers" : 30,
    "chat-chance" : 0.1,
    "matchups" : [ "worlds-2012-a", "worlds-2012-b", "worlds-2013-a", "worlds-2013-b", "worlds-2014-a", "worlds-2014-b", "worlds-2015-a", "worlds-2015-b", "worlds-2016-a", "worlds-2016-b", "worlds-2017-a", "worlds-2017-b", "worlds-2018-a", "worlds-2018-b", "worlds-2019-a", "worlds-2019-b", "worlds-2020-a", "worlds-2020-b", "worlds-2021-a", "worlds-2021-b", "worlds-2022-a", "worlds-2022-b", "worlds-2023-a", "worlds-2023-b", "worlds-2024-a", "worlds-2024-b", "worlds-2025-a", "worlds-2025-b" ],
    "max-blocks" : 3,
    "nrepl-port" : 44867,
    "profile-event" : "cpu",
    "out" : "stress-runs/after",
    "save-replays" : true,
    "container" : "netrunner-server-1",
    "url" : "http://localhost:1042",
    "spectators" : 2,
    "delay" : 1000,
    "profile" : true
  },
  "games-completed" : 20,
  "action-latency-ms" : {
    "p50" : 35.15525,
    "p95" : 46.111166,
    "p99" : 132.282291,
    "max" : 279.235458
  },
  "chats" : 3070,
  "actions" : {
    "total" : 15376,
    "per-s" : 85.89944134078212
  },
  "cpu-pct" : {
    "mean" : 59.57122222222222,
    "max" : 229.44
  },
  "mem-mb" : {
    "mean" : 1779,
    "max" : 1886
  },
  "slot-resets" : 0,
  "wedges" : 0,
  "duration-s" : 179,
  "lobby-lists" : 29827,
  "run-at" : "2026-07-19T15:59:22.971068Z"
}
```

Profiles now at `stress-runs/after/profile-ramp.html` and `stress-runs/after/profile-steady.html`.

Important bits again:
```
  "action-latency-ms" : {
    "p50" : 35.15525,
    "p95" : 46.111166,
    "p99" : 132.282291,
    "max" : 279.235458
  },
  "cpu-pct" : {
    "mean" : 59.57122222222222,
    "max" : 229.44
  },
  "mem-mb" : {
    "mean" : 1779,
    "max" : 1886
  },
```

So the end result is roughly half of the cpu, memory and top-end latency.