### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -38,7 +38,7 @@
         ;;   minus the applicable discount. The number of power counters placed on Bug Out Bag
         ;;   is equal to the initial value chosen for X, not the discounted total paid.
         ;; This means that the X-cost needs to track it's modifiers,
-        ;; rather than have them as a seperate cost.
+        ;; rather than have them as a separate cost.
         (cond
           (some #(= :x-credits (:cost/type %)) special-cost)
           (mapv #(if (= :x-credits (:cost/type %))

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -35,7 +35,7 @@
    (count (filter pred (turn-events state side ev)))))
 
 (defn first-event?
-  "Returns true if the given event has only occured once this turn.
+  "Returns true if the given event has only occurred once this turn.
   Includes itself if this is checked in the requirement for an event ability.
   Filters on events satisfying (pred targets) if given pred."
   ([state side ev] (first-event? state side ev (constantly true)))
@@ -111,7 +111,7 @@
    (count (filter pred (run-events state side ev)))))
 
 (defn first-run-event?
-  "Returns true if the given run event has only occured once this run.
+  "Returns true if the given run event has only occurred once this run.
   Includes itself if this is checked in the requirement for a run event ability.
   Filters on run events satisfying (pred targets) if given pred."
   ([state side ev] (first-run-event? state side ev (constantly true)))


### PR DESCRIPTION
A few small typos in comments/docstrings:

- `src/clj/game/core/cost_fns.clj`: "as a seperate cost" -> "separate".
- `src/clj/game/core/events.clj`: two docstrings read "has only occured once this turn/run" -> "occurred".
