### PR TITLE
Fix sometimes broken scrolling on firefox

### DIFF
--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -15,7 +15,8 @@
    [nr.news :refer [news]]
    [nr.translations :refer [tr tr-element tr-pronouns tr-span]]
    [nr.utils :refer [non-game-toast render-message format-date-time
-                     day-word-with-time-formatter tr-non-game-toast]]
+                     day-word-with-time-formatter tr-non-game-toast
+                     scroll-to-bottom!]]
    [nr.ws :as ws]
    [reagent.core :as r]))
 
@@ -119,8 +120,7 @@
                                    :msg       text
                                    :username  (:username user)
                                    :emailhash (:emailhash user)}])
-          (let [msg-list (:message-list @chat-state)]
-            (set! (.-scrollTop msg-list) (+ (.-scrollHeight msg-list) 500)))
+          (scroll-to-bottom! (:message-list @chat-state))
           (swap! s assoc :msg "")
           (.focus input))))))
 
@@ -248,8 +248,7 @@
                         :prev-page (:active-page @app-state)
                         :prev-channel channel
                         :prev-msg-count curr-count))
-             (when-let [msg-list (:message-list @chat-state)]
-               (set! (.-scrollTop msg-list) (.-scrollHeight msg-list))))))
+             (scroll-to-bottom! (:message-list @chat-state)))))
        :component-will-unmount
        (fn [_]
          (let [channel (:channel @s)]
@@ -286,7 +285,7 @@
                        (not= curr-channel prev-channel)
                        (and (not= curr-msg-count prev-msg-count)
                             (not is-scrolled)))
-               (set! (.-scrollTop msg-list) (.-scrollHeight msg-list))
+               (scroll-to-bottom! msg-list)
                ; use an atom instead of prev-props as r/current-component is only valid in component functions
                (swap! old assoc :prev-page curr-page)
                (swap! old assoc :prev-channel curr-channel)
@@ -333,8 +332,7 @@
          [message-panel s old]
          (when (pos? (:new-msg-count @s))
            [:button.new-messages-indicator
-            {:on-click #(do (when-let [msg-list (:message-list @chat-state)]
-                              (set! (.-scrollTop msg-list) (.-scrollHeight msg-list)))
+            {:on-click #(do (scroll-to-bottom! (:message-list @chat-state))
                             (swap! s assoc :new-msg-count 0))}
             (str "↓ " (:new-msg-count @s) " new message" (when (> (:new-msg-count @s) 1) "s"))])
          (when @user

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -29,16 +29,12 @@
   [el tolerance]
   (> tolerance (- (.-scrollHeight el) (.-scrollTop el) (.-clientHeight el))))
 
-(defn update-scroll-state!
-  [scrolled-away-from-end? el]
-  (reset! scrolled-away-from-end? (not (scrolled-to-end? el 15))))
-
-(def should-scroll (r/atom {:update true :send-msg false}))
+(def pinned-to-bottom? (r/atom true))
 
 (defn send-text [text]
   (when (and (not (:replay @game-state))
              (seq text))
-    (reset! should-scroll {:update false :send-msg true})
+    (reset! pinned-to-bottom? true)
     (ws/ws-send! [:game/say {:gameid (current-gameid app-state)
                              :msg text}])))
 
@@ -316,28 +312,23 @@
         corp (r/cursor game-state [:corp :user :username])
         runner (r/cursor game-state [:runner :user :username])
         !node-ref (r/atom nil)
-        scrolled-away-from-end? (r/atom false)]
+        !msg-count (atom 0)]
     (r/create-class
       {:display-name "log-messages"
 
        :component-did-mount
        (fn [_]
-         (when (:update @should-scroll)
-           (scroll-to-bottom! @!node-ref)))
-
-       :component-will-update
-       (fn [_]
-         (when-let [n @!node-ref]
-           (reset! should-scroll {:update (or (:send-msg @should-scroll)
-                                              (scrolled-to-end? n 15))
-                                  :send-msg false})))
+         (reset! pinned-to-bottom? true)
+         (reset! !msg-count (count @log))
+         (scroll-to-bottom! @!node-ref))
 
        :component-did-update
        (fn [_]
-         (when (:update @should-scroll)
-           (scroll-to-bottom! @!node-ref)
-           (when @scrolled-away-from-end?
-             (reset! scrolled-away-from-end? false))))
+         (let [msg-count (count @log)]
+           (when (and @pinned-to-bottom?
+                      (not= msg-count @!msg-count))
+             (scroll-to-bottom! @!node-ref))
+           (reset! !msg-count msg-count)))
 
        :reagent-render
        (fn []
@@ -346,7 +337,7 @@
                                           "panel-bottom")
                                         (player-highlight-option-class)]
                                 :ref #(reset! !node-ref %)
-                                :on-scroll #(update-scroll-state! scrolled-away-from-end? (.-currentTarget %))
+                                :on-scroll #(reset! pinned-to-bottom? (scrolled-to-end? (.-currentTarget %) 15))
                                 :on-mouse-over #(card-preview-mouse-over % zoom-channel)
                                 :on-mouse-out #(card-preview-mouse-out % zoom-channel)
                                 :aria-live "polite"}]
@@ -362,10 +353,10 @@
                          [format-user-timestamp timestamp user]
                          [:div (render-message text)]]]))
                   @log))
-          (when @scrolled-away-from-end?
+          (when-not @pinned-to-bottom?
             [:button.log-scroll-to-bottom
              {:on-click #(do (scroll-to-bottom! @!node-ref)
-                             (reset! scrolled-away-from-end? false))
+                             (reset! pinned-to-bottom? true))
               :title "Scroll to bottom"
               :aria-label "Scroll to bottom"}
              "↓"])])})))

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -11,8 +11,8 @@
                                       card-preview-mouse-over zoom-channel]]
    [nr.gameboard.state :refer [game-state not-spectator?]]
    [nr.translations :refer [tr tr-span]]
-   [nr.utils :refer [player-highlight-option-class
-                     render-message render-player-highlight]]
+   [nr.utils :refer [player-highlight-option-class render-message
+                     render-player-highlight scroll-to-bottom!]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [reagent.dom :as rdom]))
@@ -323,8 +323,7 @@
        :component-did-mount
        (fn [_]
          (when (:update @should-scroll)
-           (when-let [n @!node-ref]
-             (set! (.-scrollTop n) (.-scrollHeight n)))))
+           (scroll-to-bottom! @!node-ref)))
 
        :component-will-update
        (fn [_]
@@ -336,10 +335,9 @@
        :component-did-update
        (fn [_]
          (when (:update @should-scroll)
-           (when-let [n @!node-ref]
-             (set! (.-scrollTop n) (.-scrollHeight n))
-             (when @scrolled-away-from-end?
-               (reset! scrolled-away-from-end? false)))))
+           (scroll-to-bottom! @!node-ref)
+           (when @scrolled-away-from-end?
+             (reset! scrolled-away-from-end? false))))
 
        :reagent-render
        (fn []
@@ -366,9 +364,8 @@
                   @log))
           (when @scrolled-away-from-end?
             [:button.log-scroll-to-bottom
-             {:on-click #(when-let [n @!node-ref]
-                           (set! (.-scrollTop n) (.-scrollHeight n))
-                           (reset! scrolled-away-from-end? false))}
+             {:on-click #(do (scroll-to-bottom! @!node-ref)
+                             (reset! scrolled-away-from-end? false))}
              "↓ Scroll to bottom"])])})))
 
 (defn log-pane []

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -341,7 +341,7 @@
 
        :reagent-render
        (fn []
-         [:<>
+         [:div.log-scroll-to-bottom-wrapper
           (into [:div.messages {:class [(when (:replay @game-state)
                                           "panel-bottom")
                                         (player-highlight-option-class)]
@@ -365,8 +365,10 @@
           (when @scrolled-away-from-end?
             [:button.log-scroll-to-bottom
              {:on-click #(do (scroll-to-bottom! @!node-ref)
-                             (reset! scrolled-away-from-end? false))}
-             "↓ Scroll to bottom"])])})))
+                             (reset! scrolled-away-from-end? false))
+              :title "Scroll to bottom"
+              :aria-label "Scroll to bottom"}
+             "↓"])])})))
 
 (defn log-pane []
   (fn []

--- a/src/cljs/nr/lobby_chat.cljs
+++ b/src/cljs/nr/lobby_chat.cljs
@@ -2,6 +2,7 @@
   (:require
    [nr.avatar :refer [avatar]]
    [nr.translations :refer [tr tr-element]]
+   [nr.utils :refer [scroll-to-bottom!]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [reagent.dom :as rdom]))
@@ -29,15 +30,14 @@
       {:display-name "lobby-chat"
        :component-did-mount
        (fn []
-         (when-let [el @message-list]
-           (set! (.-scrollTop el) (.-scrollHeight el))))
+         (scroll-to-bottom! @message-list))
        :component-did-update
        (fn []
          (when-let [el @message-list]
            (when (or @should-scroll
                      (scrolled-to-end? el 15))
              (swap! state assoc :should-scroll false)
-             (set! (.-scrollTop el) (.-scrollHeight el)))))
+             (scroll-to-bottom! el))))
        :reagent-render
        (fn [current-game messages]
          [:div.chat-box

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -122,6 +122,12 @@
          msg (rdom-server/render-to-string (tr-span tr-vec tr-params))]
      (f msg))))
 
+(defn scroll-to-bottom!
+  "Scrolls an element to the bottom of its content. Does nothing when el is nil."
+  [el]
+  (when el
+    (set! (.-scrollTop el) (.-scrollHeight el))))
+
 (defn map-longest
   [f default & colls]
   (lazy-seq

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1182,13 +1182,18 @@ glow-spin(prop, pct)
                         div
                             animation: fadein 0.5s
 
+                    .log-scroll-to-bottom-wrapper
+                        flex(1)
+                        display-flex()
+                        flex-direction(column)
+                        position: relative
+                        min-height: 0
+
                     .log-scroll-to-bottom
-                        flex: none
-                        width: 100%
-                        height: auto
+                        position: absolute
+                        bottom: 8px
+                        right: 16px
                         margin: 0
-                        border-radius: 0
-                        padding: 2px
 
                     .log-input form input, .indicate-action, .show-decklists
                         width: 100%


### PR DESCRIPTION
Best reviewed commit by commit.

This was a weird one. I was able to reproduce the flickering effect on firefox with about 300 messages only when scrolling by click hold on the scroll bar and dragging. It seemed to be due to how the button appears under the message log, and thus moves it up, messing with the logic to show it.

I wasn't able to reproduce being unable to scroll up at all, but I was able to trigger a snapping behavior where the scroll bar snaps to the bottom when scrolling down. It's due to the interaction between the new statekeeping for the scroll button and the existing behavior where you should scroll to the bottom when getting a new message via the `:component-did-update` hook. Before the button was added, this only trigger when getting new messages. But then it also started triggering when scrolling because `scrolled-away-from-end?` changed. So scrolling itself could trigger a scroll to bottom.

With these changes the button is now just a floating down arrow (so it doesn't get added in a way that changes the message log size), auto-scroll being based on message counts (so scrolling can't trigger auto-scroll), and I simplified the logic around auto-scrolling down with the notion of being pinned to the bottom or not.

This is how it looks:

<img width="620" height="276" alt="CleanShot 2026-08-14 at 21 01 41@2x" src="https://github.com/user-attachments/assets/86c71b2d-daca-46b9-bf27-1a3fe729be5f" />

<img width="620" height="276" alt="CleanShot 2026-08-14 at 21 01 36@2x" src="https://github.com/user-attachments/assets/165abd32-c6fb-4566-aa30-69dac20047b4" />

Fix https://github.com/mtgred/netrunner/issues/8824