### PR TITLE
Remove uses of jquery-ui

### DIFF
--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -844,6 +844,8 @@ ingame-settings_runner-classic = Classic
 
 ingame-settings_runner-reverse = Reversed
 
+ingame-settings_reset-log-size = Reset log size
+
 ingame-settings_save = Save
 
 ingame-settings_show-alt = Show alternate card arts

--- a/resources/public/i18n/en.ftl
+++ b/resources/public/i18n/en.ftl
@@ -1716,10 +1716,6 @@ settings_game-stats = Game Win/Lose statistics
 
 settings_gameplay-settings = Gameplay Settings
 
-settings_get-log-top = Get current log top
-
-settings_get-log-width = Get current log width
-
 settings_ghost-trojans = Display ghosts for hosted programs
 
 settings_tactile-cards = Tactile cards
@@ -1749,8 +1745,6 @@ settings_log-player-highlight = Log player highlight
 settings_log-player-highlight-none = None
 
 settings_log-player-highlight-red-blue = Corp: Blue / Runner: Red
-
-settings_log-size = Log size
 
 settings_log-timestamps = Log timestamps
 

--- a/resources/public/i18n/fr.ftl
+++ b/resources/public/i18n/fr.ftl
@@ -681,10 +681,6 @@ settings_ffg = FFG
 
 settings_game-stats = Statistiques des parties gagnées/perdues
 
-settings_get-log-top = Obtenir le top du journal actuel
-
-settings_get-log-width = Obtenir la largeur actuelle du journal
-
 settings_high-res = Activer les images des cartes en haute résolution
 
 settings_invalid-email = Aucun compte avec cette adresse e-mail

--- a/resources/public/i18n/it.ftl
+++ b/resources/public/i18n/it.ftl
@@ -1620,10 +1620,6 @@ settings_game-stats = Statistiche vittorie/sconfitte
 
 settings_gameplay-settings = Impostazioni di gioco
 
-settings_get-log-top = Ottieni la parte superiore del log corrente
-
-settings_get-log-width = Ottieni la larghezza del log corrente
-
 settings_ghost-trojans = Mostra i trojan ospitati nel rig
 
 settings_high-res = Abilita immagini delle carte ad alta risoluzione
@@ -1649,8 +1645,6 @@ settings_log-player-highlight = Evidenziazione giocatore nel log
 settings_log-player-highlight-none = Nessuna
 
 settings_log-player-highlight-red-blue = Corp: Blu / Runner: Rosso
-
-settings_log-size = Dimensione log
 
 settings_log-timestamps = Timestamp log
 

--- a/resources/public/i18n/ja.ftl
+++ b/resources/public/i18n/ja.ftl
@@ -799,8 +799,6 @@ settings_language = 言語
 
 settings_layout-options = レイアウト設定
 
-settings_log-size = ゲームログサイズ
-
 settings_pass-on-rez = アイスのレゾ時に優先権をパス
 
 settings_pin-base-art = 拡大したカードの基本アートを使用

--- a/resources/public/i18n/ko.ftl
+++ b/resources/public/i18n/ko.ftl
@@ -576,10 +576,6 @@ settings_ffg = FFG
 
 settings_game-stats = 게임 승/패 기록
 
-settings_get-log-top = 현재 로그 높이 입력
-
-settings_get-log-width = 현재 로그 너비 입력
-
 settings_high-res = 고해상도 카드 이미지 활성화
 
 settings_invalid-email = 이 이메일 주소로 등록된 계정이 없습니다

--- a/resources/public/i18n/la-pig.ftl
+++ b/resources/public/i18n/la-pig.ftl
@@ -808,10 +808,6 @@ settings_ffg = FFGYAY
 
 settings_game-stats = Amegay Inway/Oselay atisticsstay
 
-settings_get-log-top = Etgay urrentcay oglay optay
-
-settings_get-log-width = Etgay urrentcay oglay idthway
-
 settings_high-res = Enabley ighhay-esolutionray ardcay imagesyay
 
 settings_invalid-email = Onay accountyay ithway atthay emailyay addressyay existsyay

--- a/resources/public/i18n/pl.ftl
+++ b/resources/public/i18n/pl.ftl
@@ -622,10 +622,6 @@ settings_ffg = FFG
 
 settings_game-stats = Statystyki wygranych/przegranych
 
-settings_get-log-top = Pobierz aktualną wysokość dziennika
-
-settings_get-log-width = Pobierz aktualną szerokość dziennika
-
 settings_high-res = Użyj obrazów kart o wysokiej rozdzielczości
 
 settings_invalid-email = Brak konta z tym adresem e-mail

--- a/resources/public/i18n/pt.ftl
+++ b/resources/public/i18n/pt.ftl
@@ -669,10 +669,6 @@ settings_ffg = FFG
 
 settings_game-stats = Estatísticas de Vitória/Derrota em Jogo
 
-settings_get-log-top = Puxando topo do log atual
-
-settings_get-log-width = Puxando largura atual do log
-
 settings_high-res = Habilitar imagem das cartas em alta resolução
 
 settings_invalid-email = Nenhuma conta com esse email existe

--- a/resources/public/i18n/ru.ftl
+++ b/resources/public/i18n/ru.ftl
@@ -1737,10 +1737,6 @@ settings_game-stats = Учёт статистики побед/поражени�
 
 settings_gameplay-settings = Игровые настройки
 
-settings_get-log-top = Записать текущую высоту журнала
-
-settings_get-log-width = Записать текущую ширину журнала
-
 settings_ghost-trojans = Отображать бледные дубликаты программ-троянов, установленных на карты-носители
 
 settings_high-res = Включить загрузку изображений высокого разрешения
@@ -1766,8 +1762,6 @@ settings_log-player-highlight = Подсвечивать игроков в жу�
 settings_log-player-highlight-none = Не подсвечивать
 
 settings_log-player-highlight-red-blue = Корпорация: Синий / Бегущий: Красный
-
-settings_log-size = Размер журнала
 
 settings_log-timestamps = Временные метки в журнале
 

--- a/resources/public/i18n/zh-simp.ftl
+++ b/resources/public/i18n/zh-simp.ftl
@@ -1652,10 +1652,6 @@ settings_game-stats = 对战胜负统计
 
 settings_gameplay-settings = 游戏设置
 
-settings_get-log-top = 获取当前日志框顶部坐标
-
-settings_get-log-width = 获取当前日志框宽度
-
 settings_ghost-trojans = 对于被负载的程序显示鬼影
 
 settings_high-res = 启用高分辨率卡牌图像
@@ -1681,8 +1677,6 @@ settings_log-player-highlight = 日志玩家高亮
 settings_log-player-highlight-none = 无
 
 settings_log-player-highlight-red-blue = 公司：蓝色 / 潜袭者：红色
-
-settings_log-size = 日志栏尺寸
 
 settings_log-timestamps = 日志时间戳
 

--- a/resources/public/i18n/zh-trad.ftl
+++ b/resources/public/i18n/zh-trad.ftl
@@ -1559,10 +1559,6 @@ settings_game-stats = 遊戲勝負統計數據
 
 settings_gameplay-settings = 遊戲中設定
 
-settings_get-log-top = 使用目前行動紀錄高度
-
-settings_get-log-width = 使用目前行動紀錄寬度
-
 settings_ghost-trojans = 顯示附載程序的副本
 
 settings_high-res = 允許高解析度卡牌圖面
@@ -1588,8 +1584,6 @@ settings_log-player-highlight = 行動紀錄凸顯使用者名稱
 settings_log-player-highlight-none = 無
 
 settings_log-player-highlight-red-blue = 公司: 藍色 / 潛襲者: 紅色
-
-settings_log-size = 行動紀錄大小
 
 settings_log-timestamps = 行動紀錄標記時間
 

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -44,7 +44,6 @@
          [:source {:src "/sound/ting.mp3" :type "audio/mp3"}]
          [:source {:src "/sound/ting.ogg" :type "audio/ogg"}]]
         (hiccup/include-js "https://code.jquery.com/jquery-2.1.1.min.js")
-        (hiccup/include-js "https://code.jquery.com/ui/1.13.0/jquery-ui.min.js")
         (hiccup/include-js "https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js")
         (hiccup/include-js "/lib/js/toastr.min.js")
         [:script {:type "text/javascript"}

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -8,6 +8,11 @@
   #?(:clj (java.lang.Integer/parseInt (re-find #"^\d+" string))
      :cljs (js/parseInt string 10)))
 
+(defn clamp
+  "Limit n to the range [lo hi]."
+  [n lo hi]
+  (max lo (min hi n)))
+
 (defn side-from-str [side-str]
   (keyword (str/lower-case side-str)))
 

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -137,34 +137,6 @@
     (doseq [card (vals @all-cards)]
       (update-card-art card art lang res s))))
 
-(defn log-width-option [s]
-  (let [log-width (r/atom (:log-width @s))]
-    (fn []
-      [:div
-       [:input {:type "number"
-                :min 100 :max 2000
-                :on-change #(do (swap! s assoc :log-width (.. % -target -value))
-                                (reset! log-width (.. % -target -value)))
-                :value @log-width}]
-       [:button.update-log-width {:type "button"
-                                  :on-click #(do (swap! s assoc :log-width (get-in @app-state [:options :log-width]))
-                                                 (reset! log-width (get-in @app-state [:options :log-width])))}
-        [tr-span [:settings_get-log-width "Get current log width"]]]])))
-
-(defn log-top-option [s]
-  (let [log-top (r/atom (:log-top @s))]
-    (fn []
-      [:div
-       [:input {:type "number"
-                :min 100 :max 2000
-                :on-change #(do (swap! s assoc :log-top (.. % -target -value))
-                                (reset! log-top (.. % -target -value)))
-                :value @log-top}]
-       [:button.update-log-width {:type "button"
-                                  :on-click #(do (swap! s assoc :log-top (get-in @app-state [:options :log-top]))
-                                                 (reset! log-top (get-in @app-state [:options :log-top])))}
-        [tr-span [:settings_get-log-top "Get current log top"]]]])))
-
 (defn change-email [_]
   (let [email-state (r/atom {:flash-message ""
                              :email ""})]
@@ -822,11 +794,6 @@
                             :checked (:labeled-unrezzed-cards @s)
                             :on-change #(swap! s assoc :labeled-unrezzed-cards (.. % -target -checked))}]
             [tr-span [:settings_label-unrezzed-cards "Label unrezzed cards"]]]]
-
-          [tr-element :h4 [:settings_log-size "Log size"]]
-          [:div
-           [log-width-option s]
-           [log-top-option s]]
 
           [tr-element :h4 [:settings_card-images "Card images"]]
           [:div

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -20,6 +20,7 @@
    [nr.gameboard.card-preview :refer [card-highlight-mouse-out
                                       card-highlight-mouse-over card-preview-mouse-out
                                       card-preview-mouse-over put-game-card-in-channel zoom-channel]]
+   [nr.gameboard.log :as game-log :refer [find-matches reset-completions]]
    [nr.gameboard.player-stats :refer [stat-controls stats-view]]
    [nr.gameboard.replay :refer [replay-panel]]
    [nr.gameboard.right-pane :refer [content-pane]]
@@ -1806,6 +1807,64 @@
      [:button#trace-submit {:on-click #(send-command "choice" {:eid (prompt-eid (:side @game-state)) :choice (-> "#credit" js/$ .val str->int)})}
       [tr-span [:game_ok "OK"]]]]))
 
+(defn- card-title-prompt
+  [choices]
+  (let [state (r/atom {:value ""})
+        !input-ref (atom nil)
+        fill! (fn [match]
+                (swap! state assoc :value match)
+                (reset-completions state)
+                (when-let [input @!input-ref] (.focus input)))
+        submit! (fn []
+                  (send-command "choice" {:eid (prompt-eid (:side @game-state))
+                                          :choice (:value @state)}))]
+    (fn [choices]
+      (let [{:keys [value completions completion-highlight]} @state]
+        [:div
+         [:div.card-title-select
+          [:input#card-title
+           {:placeholder "Enter a card title"
+            :autoComplete "off"
+            :auto-focus true
+            :value value
+            :ref #(reset! !input-ref %)
+            :on-change #(let [input-value (.. % -target -value)
+                              matches (if (s/blank? input-value)
+                                        []
+                                        (find-matches (:autocomplete choices) input-value))]
+                          (swap! state assoc
+                                 :value input-value
+                                 :completion-highlight nil
+                                 :completions (mapv (fn [match]
+                                                      {:display-text match
+                                                       :on-select (fn [] (fill! match))})
+                                                    matches)))
+            :on-key-down
+            (fn [e]
+              (let [n (count completions)
+                    chosen (cond
+                             completion-highlight (nth completions completion-highlight)
+                             (= 1 n) (first completions))]
+                (case (.-key e)
+                  "ArrowDown" (when (pos? n)
+                                (.preventDefault e)
+                                (swap! state update :completion-highlight #(if % (mod (inc %) n) 0)))
+                  "ArrowUp" (when (pos? n)
+                              (.preventDefault e)
+                              (swap! state update :completion-highlight #(if % (mod (dec %) n) (dec n))))
+                  ("Tab" "ArrowRight") (when chosen
+                                         (.preventDefault e)
+                                         ((:on-select chosen)))
+                  "Enter" (do (.preventDefault e)
+                              (.stopPropagation e)
+                              (when chosen ((:on-select chosen)))
+                              (when-not completion-highlight (submit!)))
+                  "Escape" (reset-completions state)
+                  nil)))}]
+          [game-log/completions !input-ref state]]
+         [:button#card-submit {:on-click #(submit!)}
+          [tr-span [:game_ok "OK"]]]]))))
+
 (defn prompt-div
   [me {:keys [card msg prompt-type choices offer-bad-pub?] :as prompt-state}]
   (let [id (atom 0)]
@@ -1868,14 +1927,7 @@
 
        ;; auto-complete text box
        (:card-title choices)
-       [:div
-        [:div.credit-select
-         [:input#card-title {:placeholder "Enter a card title"
-                             :onKeyUp #(when (= "Enter" (.-key %))
-                                         (-> "#card-submit" js/$ .click)
-                                         (.stopPropagation %))}]]
-        [:button#card-submit {:on-click #(send-command "choice" {:eid (prompt-eid (:side @game-state)) :choice (-> "#card-title" js/$ .val)})}
-         [tr-span [:game_ok "OK"]]]]
+       [card-title-prompt choices]
 
        ;; choice of specified counters on card
        (:counter choices)
@@ -2004,8 +2056,7 @@
       #(send-command "credit")]]))
 
 (defn button-pane [{:keys [side prompt-state]}]
-  (let [autocomp (r/track (fn [] (get-in @prompt-state [:choices :autocomplete])))
-        show-discard? (r/track (fn [] (get-in @prompt-state [:show-discard])))
+  (let [show-discard? (r/track (fn [] (get-in @prompt-state [:show-discard])))
         prompt-type (r/track (fn [] (get-in @prompt-state [:prompt-type])))
         discard-opened-by-system (r/atom false)
         show-opponent-discard? (r/track (fn [] (get-in @prompt-state [:show-opponent-discard])))
@@ -2015,8 +2066,6 @@
 
        :component-did-update
        (fn []
-         (when (pos? (count @autocomp))
-           (-> "#card-title" js/$ (.autocomplete (clj->js {"source" @autocomp}))))
          (cond @show-discard? (do (-> ".me .discard-container .popup" js/$ .fadeIn)
                                   (reset! discard-opened-by-system true))
                @discard-opened-by-system (do (-> ".me .discard-container .popup" js/$ .fadeOut)
@@ -2028,9 +2077,7 @@
 
          (if (= "select" @prompt-type)
            (set! (.-cursor (.-style (.-body js/document))) "url('/img/gold_crosshair.png') 12 12, crosshair")
-           (set! (.-cursor (.-style (.-body js/document))) "default"))
-         (when (= "card-title" @prompt-type)
-           (-> "#card-title" js/$ .focus)))
+           (set! (.-cursor (.-style (.-body js/document))) "default")))
 
        :reagent-render
        (fn [{:keys [side run encounters prompt-state me] :as button-pane-args}]

--- a/src/cljs/nr/gameboard/pane_size.cljs
+++ b/src/cljs/nr/gameboard/pane_size.cljs
@@ -1,0 +1,36 @@
+(ns nr.gameboard.pane-size
+  (:require [jinteki.settings :as settings]
+            [nr.appstate :refer [app-state]]
+            [nr.local-storage :as ls]))
+
+(defn resize-card-zoom
+  "Resizes the card zoom based on the values in the app-state"
+  []
+  (let [width (get-in @app-state [:options :log-width])
+        top (get-in @app-state [:options :log-top])
+        max-card-width (- width 5)
+        max-card-height (- top 10)
+        card-ratio (/ 418 300)]
+    (if (> (/ max-card-height max-card-width) card-ratio)
+      (-> ".card-zoom" js/$
+        (.css "width" max-card-width)
+        (.css "height" (int (* max-card-width card-ratio))))
+      (-> ".card-zoom" js/$
+        (.css "width" (int (/ max-card-height card-ratio)))
+        (.css "height" max-card-height)))
+    (-> ".right-pane" js/$ (.css "width" width))
+    (-> ".content-pane" js/$
+      (.css "left" 0)
+      (.css "top" top)
+      (.css "height" "auto")
+      (.css "width" width))))
+
+(defn set-pane-size! [width top]
+  (swap! app-state update :options assoc :log-width width :log-top top)
+  (ls/save! "log-width" width)
+  (ls/save! "log-top" top)
+  (resize-card-zoom))
+
+(defn reset-pane-size! []
+  (let [{:keys [log-width log-top]} (settings/defaults)]
+    (set-pane-size! log-width log-top)))

--- a/src/cljs/nr/gameboard/right_pane.cljs
+++ b/src/cljs/nr/gameboard/right_pane.cljs
@@ -1,10 +1,11 @@
 (ns nr.gameboard.right-pane
   (:require [cljs.core.async :refer [put!]]
+            [jinteki.utils :refer [clamp]]
             [nr.appstate :refer [app-state]]
-            [nr.local-storage :as ls]
             [nr.gameboard.card-preview :refer [zoom-channel]]
             [nr.gameboard.diagrams :refer [run-timing-pane turn-timing-pane]]
             [nr.gameboard.log :refer [log-pane]]
+            [nr.gameboard.pane-size :refer [resize-card-zoom reset-pane-size! set-pane-size!]]
             [nr.gameboard.replay :refer [notes-pane notes-shared-pane]]
             [nr.gameboard.state :refer [game-state]]
             [nr.gameboard.settings :refer [settings-pane]]
@@ -37,47 +38,52 @@
    {:hiccup [settings-pane]
     :label [:log_settings "Settings"]}})
 
-(defn- resize-card-zoom
-  "Resizes the card zoom based on the values in the app-state"
-  []
-  (let [width (get-in @app-state [:options :log-width])
-        top (get-in @app-state [:options :log-top])
-        max-card-width (- width 5)
-        max-card-height (- top 10)
-        card-ratio (/ 418 300)]
-    (if (> (/ max-card-height max-card-width) card-ratio)
-      (-> ".card-zoom" js/$
-        (.css "width" max-card-width)
-        (.css "height" (int (* max-card-width card-ratio))))
-      (-> ".card-zoom" js/$
-        (.css "width" (int (/ max-card-height card-ratio)))
-        (.css "height" max-card-height)))
-    (-> ".right-pane" js/$ (.css "width" width))
-    (-> ".content-pane" js/$
-      (.css "left" 0)
-      (.css "top" top)
-      (.css "height" "auto")
-      (.css "width" width))))
+(defonce ^:private resize-state (atom nil))
 
-(defn- pane-resize
-  "Resize the card zoom to fit the available space"
-  [event ui]
-  (let [width (.. ui -size -width)
-        top (.. ui -position -top)]
-    (swap! app-state assoc-in [:options :log-width] width) ;;XXX: rename
-    (swap! app-state assoc-in [:options :log-top] top)
-    (ls/save! "log-width" width)
-    (ls/save! "log-top" top)
-    (resize-card-zoom)))
+(defonce ^:private last-resize-down (atom 0))
 
-(defn- pane-start-resize [event ui]
+(defn- pane-start-resize
   "Display a zoomed card when resizing so the user can visualize how the
-  resulting zoom will look."
-  (when-let [card (get-in @game-state [:runner :identity])]
-    (put! zoom-channel card)))
+  resulting zoom will look. A double press resets the pane to its default size."
+  [dir e]
+  (.preventDefault e)
+  (let [now (.-timeStamp e)
+        double-press? (< (- now @last-resize-down) 350)]
+    (reset! last-resize-down now)
+    (if double-press?
+      (reset-pane-size!)
+      (do (.setPointerCapture (.-currentTarget e) (.-pointerId e))
+          (reset! resize-state {:dir dir
+                                :start-x (.-clientX e)
+                                :start-y (.-clientY e)
+                                :start-width (get-in @app-state [:options :log-width])
+                                :start-top (get-in @app-state [:options :log-top])})
+          (when-let [card (get-in @game-state [:runner :identity])]
+            (put! zoom-channel card))))))
 
-(defn- pane-stop-resize [event ui]
-  (put! zoom-channel false))
+(defn- pane-resize [e]
+  (when-let [{:keys [dir start-x start-y start-width start-top]} @resize-state]
+    (let [width (if (#{:w :nw} dir)
+                  (clamp (- start-width (- (.-clientX e) start-x))
+                         100 (- (.-innerWidth js/window) 300))
+                  start-width)
+          top (if (#{:n :nw} dir)
+                (clamp (+ start-top (- (.-clientY e) start-y))
+                       0 (- (.-innerHeight js/window) 100))
+                start-top)]
+      (set-pane-size! width top))))
+
+(defn- pane-stop-resize [_e]
+  (when @resize-state
+    (reset! resize-state nil)
+    (put! zoom-channel false)))
+
+(defn- resize-handle [dir]
+  [:div {:class ["resize-handle" (str "resize-handle-" (name dir))]
+         :on-pointer-down #(pane-start-resize dir %)
+         :on-pointer-move pane-resize
+         :on-pointer-up pane-stop-resize
+         :on-pointer-cancel pane-stop-resize}])
 
 (defn- tab-selector [selected-tab]
   [:div.panel.panel-top.blue-shade.selector
@@ -109,16 +115,15 @@
       {:display-name "content-pane"
 
        :component-did-mount
-       (fn [this]
-         (-> ".content-pane" js/$ (.resizable #js {:handles "w, n, nw"
-                                                   :resize pane-resize
-                                                   :start pane-start-resize
-                                                   :stop pane-stop-resize}))
+       (fn [_this]
          (resize-card-zoom))
 
        :reagent-render
        (fn []
          [:div.content-pane
+          [resize-handle :w]
+          [resize-handle :n]
+          [resize-handle :nw]
           [tab-selector selected-tab]
           [:div.panel.blue-shade.panel-bottom.content
            (get-in @loaded-tabs [@selected-tab :hiccup] "nothing here")]])})))

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -2,12 +2,15 @@
   (:require
    [nr.account :refer [post-options]]
    [nr.appstate :refer [app-state]]
+   [nr.gameboard.pane-size :refer [reset-pane-size!]]
    [nr.translations :refer [tr-element tr-span]]))
 
 (defn settings-pane []
   (fn []
     [:div.settings
-     [:section [:button {:on-click #(post-options (constantly nil))} [tr-span [:ingame-settings_save "Save"]]]]
+     [:section
+      [:button {:on-click #(post-options (constantly nil))} [tr-span [:ingame-settings_save "Save"]]]
+      [:button {:on-click #(reset-pane-size!)} [tr-span [:ingame-settings_reset-log-size "Reset log size"]]]]
      [:section
       [tr-element :h4 [:ingame-settings_card-stacking "Card settings"]]
       [:div

--- a/src/cljs/nr/zoom.cljs
+++ b/src/cljs/nr/zoom.cljs
@@ -1,6 +1,7 @@
 (ns nr.zoom
   (:require
    [jinteki.settings :refer [zoom-default zoom-step zoom-min zoom-max]]
+   [jinteki.utils :refer [clamp]]
    [nr.appstate :refer [app-state]]
    [nr.local-storage :as ls]
    [nr.translations :refer [tr]]
@@ -9,7 +10,6 @@
 (def zoom-cursor (r/cursor app-state [:options :zoom]))
 
 (defn- round2 [n] (/ (js/Math.round (* n 100)) 100))
-(defn- clamp [n lo hi] (max lo (min hi n)))
 
 (defn apply-zoom!
   "Emulate browser zoom by setting CSS `zoom` on <html>, plus an `--app-zoom` custom

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -372,6 +372,26 @@ glow-spin(prop, pct)
             &:hover, &:focus
                 border-color: white-solid
 
+    .command-matches-container
+        position: absolute !important
+        z-index: 30
+
+        ::-webkit-scrollbar
+            width 0
+
+        ul.command-matches
+            list-style-type: none
+            overflow-x: clip
+            overflow-y: auto
+            max-height: 300px
+            white-space: nowrap
+            width: max-content
+            scrollbar-width: none
+
+            li.command-match.highlight span
+                color: gold-base
+                cursor: pointer
+
     .popup
         display: none
         position: absolute
@@ -707,10 +727,12 @@ glow-spin(prop, pct)
                 flex-direction(column)
                 row-gap: 5px
 
-                // scroll instead of letting other panels crowd out the prompt,
+                // Scroll instead of letting other panels crowd out the prompt,
                 // but only while a prompt is up, so the rfg popups and the run
-                // servers menu can still overlay the board the rest of the time
-                &:has(.prompt)
+                // servers menu can still overlay the board the rest of the time.
+                // Scrolling clips the card title autocomplete though, so don't
+                // add scrolling if there.
+                &:has(.prompt):not(:has(.card-title-select .command-matches-container))
                     overflow-y: auto
 
                 > div
@@ -806,6 +828,19 @@ glow-spin(prop, pct)
 
                         select
                             margin-right: 5px
+
+                    .card-title-select
+                        position: relative
+                        margin-bottom: 10px
+
+                        input
+                            width: 100%
+                            box-sizing: border-box
+
+                        .command-matches-container
+                            bottom: 0
+                            left: 100%
+                            margin-left: 14px
 
                     .encounter-info
                         width: 100%
@@ -1207,25 +1242,8 @@ glow-spin(prop, pct)
                             flex: 1
 
                     .command-matches-container
-                        position: absolute !important
                         bottom: 24px
                         right: 100%
-
-                        ::-webkit-scrollbar
-                            width 0
-
-                        ul.command-matches
-                            list-style-type: none
-                            overflow-x: clip
-                            overflow-y: auto
-                            max-height: 300px
-                            white-space: nowrap
-                            width: max-content
-                            scrollbar-width: none
-
-                            li.command-match.highlight span
-                                color: gold-base
-                                cursor: pointer
 
 .gameboard.card-unplayable-fade-out
 

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -1165,6 +1165,32 @@ glow-spin(prop, pct)
             position:absolute
             bottom: 0px
 
+            .resize-handle
+                position: absolute
+                z-index: 30
+                touch-action: none
+
+            .resize-handle-w
+                left: -4px
+                top: 0
+                bottom: 0
+                width: 8px
+                cursor: ew-resize
+
+            .resize-handle-n
+                top: -4px
+                left: 0
+                right: 0
+                height: 8px
+                cursor: ns-resize
+
+            .resize-handle-nw
+                top: -6px
+                left: -6px
+                width: 14px
+                height: 14px
+                cursor: nwse-resize
+
             .selector
                 position: absolute
                 top: 0px


### PR DESCRIPTION
https://github.com/mtgred/netrunner/commit/28daac9a0 removed the jquery-ui css that supported the card title lookup and chat log resize handlers, breaking that functionality. This was a few years ago too, so I wasn't very confident that adding it back was gonna just fix it, and it wasn't much code to implement both on the codebase anyway, so I opted to remove it instead.

So now `Targetted Marketing` shows an autocomplete a bit like the commands one:
<img width="722" height="742" alt="CleanShot 2026-08-15 at 22 03 15@2x" src="https://github.com/user-attachments/assets/440e0c26-1379-443a-bc0d-1b0b142a0fba" />

And you can resize the chat log again:
<img width="516" height="236" alt="CleanShot 2026-08-15 at 22 07 27@2x" src="https://github.com/user-attachments/assets/a7a44001-1c3b-4891-8dce-4087c3ef9e5d" />

I added a new button to reset the chat log size because I think that it's gonna be easy to resize it by accident, and you can also reset by double clicking the resize handlers:
<img width="454" height="330" alt="CleanShot 2026-08-15 at 22 08 31@2x" src="https://github.com/user-attachments/assets/bb52ae61-5c53-447e-b1a3-b54725c728b3" />

This led me to the account settings log top/width controls. They didn't seem to work properly for me, some values I put would just lead to a super short chat window. And when I was thinking of adding the reset button there too, I felt like it was better to remove it altogether. I don't think a user would want to edit the log size with the number boxes, at least now that you could responsively do it with the handlers and reset it on the game screen. So I removed it instead. Let me know if you prefer to have it.

Fix https://github.com/mtgred/netrunner/issues/8806
