### PR TITLE
feat: classique precons

### DIFF
--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -21,7 +21,7 @@
 ;; System Gateway preconstructed decks
 (def gateway-beginner-corp
   {:format "system-gateway"
-   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code 30077}
+   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code "30077"}
    :name "System Gateway Starter Corp"
    :cards [{:qty 3 :card "Offworld Office"}
            {:qty 2 :card "Send a Message"}
@@ -42,7 +42,7 @@
 
 (def gateway-intermediate-corp
   {:format "system-gateway"
-   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code 30077}
+   :identity {:title "The Syndicate: Profit over Principle" :side "Corp" :code "30077"}
    :name "System Gateway Starter Corp"
    :cards [{:qty 3 :card "Offworld Office"}
            {:qty 2 :card "Send a Message"}
@@ -69,7 +69,7 @@
 
 (def gateway-beginner-runner
   {:format "system-gateway"
-   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code 30076}
+   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code "30076"}
    :name "System Gateway Starter Runner"
    :cards [{:qty 2 :card "Creative Commission"}
            {:qty 3 :card "Jailbreak"}
@@ -90,7 +90,7 @@
 
 (def gateway-intermediate-runner
   {:format "system-gateway"
-   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code 30076}
+   :identity {:title "The Catalyst: Convention Breaker" :side "Runner" :code "30076"}
    :name "System Gateway Starter Runner"
    :cards [{:qty 2 :card "Creative Commission"}
            {:qty 3 :card "Jailbreak"}
@@ -142,7 +142,7 @@
     [:preconstructed.worlds-2012-info "Worlds 2012 was played with (up to 3 copies of) the Core Set as the only legal product. Jeremy Zwirn (Building a Better World, Gabriel Santiago) took first place against Ben Marsh (Engineering the Future, Gabriel Santiago) in the first ever Netrunner World Championship."]
     [:preconstructed.worlds-2012-a-ul "Worlds 2012: Weyland vs. Criminal"]
     (precon "Ben Marsh - 2012: ETF"
-            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
+            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code "01054"}
             [{:qty 3 :card "Enigma"}
              {:qty 2 :card "Heimdall 1.0"}
              {:qty 2 :card "Tollbooth"}
@@ -164,7 +164,7 @@
              {:qty 3 :card "Accelerated Beta Test"}
              {:qty 3 :card "Priority Requisition"}])
     (precon "Jeremy Z - 2012: Criminal"
-            {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code 1017}
+            {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code "01017"}
             [{:qty 2 :card "Corroder"}
              {:qty 1 :card "Yog.0"}
              {:qty 1 :card "Ninja"}
@@ -192,7 +192,7 @@
     [:preconstructed.worlds-2012-info "Worlds 2012 was played with (up to 3 copies of) the Core Set as the only legal product. Jeremy Zwirn (Building a Better World, Gabriel Santiago) took first place against Ben Marsh (Engineering the Future, Gabriel Santiago) in the first ever Netrunner World Championship."]
     [:preconstructed.worlds-2012-b-ul "Worlds 2012: Haas-Bioroid vs. Criminal"]
     (precon "Jeremy Z - 2012: Weyland"
-            {:title "Weyland Consortium: Building a Better World" :side "Corp" :code 1093}
+            {:title "Weyland Consortium: Building a Better World" :side "Corp" :code "01093"}
             [{:qty 3 :card "Priority Requisition"}
              {:qty 3 :card "Private Security Force"}
              {:qty 3 :card "Hostile Takeover"}
@@ -212,7 +212,7 @@
              {:qty 3 :card "Hedge Fund"}
              {:qty 3 :card "Scorched Earth"}])
     (precon "Ben Marsh - 2012: Gabe"
-            {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code 1017}
+            {:title "Gabriel Santiago: Consummate Professional" :side "Runner" :code "01017"}
             [{:qty 3 :card "Sneakdoor Beta"}
              {:qty 1 :card "Gordian Blade"}
              {:qty 2 :card "Corroder"}
@@ -243,7 +243,7 @@
     [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves. Jens Erickson (Andromeda, ETR) took first place against Andrew Veen (Kate, NBN: Making News)"]
     [:preconstructed.worlds-2013-a-ul "Worlds 2013: HB FastAdv vs. Shaper Katman"]
     (precon "Jens Erickson - 2013: Engineering the Future"
-            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
+            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code "01054"}
             [{:qty 3 :card "Accelerated Beta Test"}
              {:qty 3 :card "Project Vitruvius"}
              {:qty 3 :card "Efficiency Committee"}
@@ -269,7 +269,7 @@
              {:qty 1 :card "Ichi 1.0"}
              {:qty 1 :card "Grim"}])
     (precon "Andrew Veen - 2013: Kate McCaffrey"
-            {:title "Kate \"Mac\" McCaffrey: Digital Tinker" :side "Runner" :code 01033}
+            {:title "Kate \"Mac\" McCaffrey: Digital Tinker" :side "Runner" :code "01033"}
             [{:qty 3 :card "Modded"}
              {:qty 3 :card "Test Run"}
              {:qty 3 :card "Sure Gamble"}
@@ -295,7 +295,7 @@
     [:preconstructed.worlds-2013-info "166 players attended worlds in 2013. The tournament was held in Minneapolis, MN, USA, and consisted of 6 swiss rounds into a top 32 cut. The legal cardpool consisted of cards up to Opening Moves. Jens Erickson (Andromeda, ETR) took first place against Andrew Veen (Kate, NBN: Making News)"]
     [:preconstructed.worlds-2013-b-ul "Worlds 2013: NBN Fast Adv vs. Andy Sucker"]
     (precon "Andrew Veen - 2013: Making News"
-            {:title "NBN: Making News" :side "Corp" :code 25104}
+            {:title "NBN: Making News" :side "Corp" :code "25104"}
             [{:qty 3 :card "AstroScript Pilot Program"}
              {:qty 3 :card "Project Beale"}
              {:qty 3 :card "Breaking News"}
@@ -317,7 +317,7 @@
              {:qty 1 :card "Rototurret"}
              {:qty 3 :card "Caduceus"}])
     (precon "Jens Erickson - 2013: Andromeda"
-            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code 2083}
+            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code "02083"}
             [{:qty 3 :card "Account Siphon"}
              {:qty 3 :card "Inside Job"}
              {:qty 3 :card "Special Order"}
@@ -349,7 +349,7 @@
     [:preconstructed.worlds-2014-info "238 players attended worlds in 2014. The tournament was held in Minneapolis, MN, USA, and consisted of 7 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Up and Over."]
     [:preconstructed.worlds-2014-a-ul "Worlds 2014: Honor and Perfection vs. Andromedium"]
     (precon "Dan D'Argenio - 2014: Honor and Perfection"
-            {:title "Jinteki: Replicating Perfection" :side "Corp" :code 2031}
+            {:title "Jinteki: Replicating Perfection" :side "Corp" :code "02031"}
             [{:qty 3 :card "NAPD Contract"}
              {:qty 3 :card "Nisei MK II"}
              {:qty 3 :card "The Future Perfect"}
@@ -373,7 +373,7 @@
              {:qty 3 :card "Pup"}
              {:qty 3 :card "Tsurugi"}])
     (precon "Minh Tran - 2014: Andromedium"
-            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code 2083}
+            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code "02083"}
             [{:qty 3 :card "Account Siphon"}
              {:qty 2 :card "Inside Job"}
              {:qty 2 :card "Special Order"}
@@ -407,7 +407,7 @@
     [:preconstructed.worlds-2014-info "238 players attended worlds in 2014. The tournament was held in Minneapolis, MN, USA, and consisted of 7 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Up and Over."]
     [:preconstructed.worlds-2014-b-ul "Worlds 2014: Personal Evolution vs. Daily QT Andy"]
     (precon "Minh Tran - 2014: Personal Evolution"
-            {:title "Jinteki: Personal Evolution" :side "Corp" :code 1067}
+            {:title "Jinteki: Personal Evolution" :side "Corp" :code "01067"}
             [{:qty 3 :card "Fetal AI"}
              {:qty 3 :card "Gila Hands Arcology"}
              {:qty 3 :card "House of Knives"}
@@ -431,7 +431,7 @@
              {:qty 3 :card "Mushin No Shin"}
              {:qty 3 :card "Sweeps Week"}])
     (precon "Dan D'Argenio - 2014: Daily QT Andy"
-            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code 2083}
+            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code "02083"}
             [{:qty 3 :card "Account Siphon"}
              {:qty 1 :card "Inside Job"}
              {:qty 3 :card "Special Order"}
@@ -465,7 +465,7 @@
     [:preconstructed.worlds-2015-info "269 players attended worlds in 2015. The tournament was held in Minneapolis, MN, USA, and consisted of 8 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Data and Destiny."]
     [:preconstructed.worlds-2015-a-ul "Worlds 2015: Foodcoatshop vs. The Morning After"]
     (precon "Dan D'Argenio - 2015: Foodcoatshop"
-            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code 1054}
+            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code "01054"}
             [{:qty 3 :card "Accelerated Beta Test"}
              {:qty 1 :card "Project Vitruvius"}
              {:qty 3 :card "NAPD Contract"}
@@ -487,7 +487,7 @@
              {:qty 1 :card "Cyberdex Virus Suite"}
              {:qty 3 :card "Breaker Bay Grid"}])
     (precon "Timmy Wong - 2015: The Morning After"
-            {:title "Whizzard: Master Gamer" :side "Runner" :code 2001}
+            {:title "Whizzard: Master Gamer" :side "Runner" :code "02001"}
             [{:qty 2 :card "Stimhack"}
              {:qty 3 :card "Sure Gamble"}
              {:qty 1 :card "Test Run"}
@@ -518,7 +518,7 @@
     [:preconstructed.worlds-2015-info "269 players attended worlds in 2015. The tournament was held in Minneapolis, MN, USA, and consisted of 8 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Data and Destiny."]
     [:preconstructed.worlds-2015-b-ul "Worlds 2015: Yellow Shell vs. Radisson Cheese Plate"]
     (precon "Timmy Wong - 2015: Yellow Shell"
-            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code 6005}
+            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code "06005"}
             [{:qty 3 :card "AstroScript Pilot Program"}
              {:qty 3 :card "Breaking News"}
              {:qty 2 :card "Project Beale"}
@@ -546,7 +546,7 @@
              {:qty 1 :card "Cyberdex Virus Suite"}
              {:qty 3 :card "Product Placement"}])
     (precon "Dan D'Argenio - 2015: Radisson Cheese Plate"
-            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code 7030}
+            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code "07030"}
             [{:qty 2 :card "Account Siphon"}
              {:qty 3 :card "Blackmail"}
              {:qty 2 :card "Queen's Gambit"}
@@ -575,7 +575,7 @@
     [:preconstructed.worlds-2016-info "278 players attended worlds in 2016. The tournament was held in Minneapolis, MN, USA, and consisted of 9 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Escalation."]
     [:preconstructed.worlds-2016-a-ul "Worlds 2016: Snekbite vs. Minh MaxX++"]
     (precon "Chris Dyer - 2016: Snekbite"
-            {:title "NBN: Controlling the Message" :side "Corp" :code 11017}
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
             [{:qty 1 :card "AstroScript Pilot Program"}
              {:qty 3 :card "Breaking News"}
              {:qty 3 :card "Project Beale"}
@@ -600,7 +600,7 @@
              {:qty 2 :card "SanSan City Grid"}
              {:qty 2 :card "Mumbad Virtual Tour"}])
     (precon "Benjamin Ni - 2016: Minh MaxX++"
-            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code 7029}
+            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code "07029"}
             [{:qty 3 :card "Déjà Vu"}
              {:qty 2 :card "Account Siphon"}
              {:qty 3 :card "Sure Gamble"}
@@ -630,7 +630,7 @@
     [:preconstructed.worlds-2016-info "278 players attended worlds in 2016. The tournament was held in Minneapolis, MN, USA, and consisted of 9 swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Escalation."]
     [:preconstructed.worlds-2016-b-ul "Worlds 2016: Fiery Info vs. Papa Smurf"]
     (precon "Benjamin Ni - 2016: Fiery Info"
-            {:title "SYNC: Everything, Everywhere" :side "Corp" :code 9001}
+            {:title "SYNC: Everything, Everywhere" :side "Corp" :code "09001"}
             [{:qty 3 :card "Breaking News"}
              {:qty 1 :card "NAPD Contract"}
              {:qty 1 :card "15 Minutes"}
@@ -653,7 +653,7 @@
              {:qty 2 :card "Observe and Destroy"}
              {:qty 2 :card "BOOM!"}])
     (precon "Chris Dyer - 2016: Papa Smurf"
-            {:title "Whizzard: Master Gamer" :side "Runner" :code 2001}
+            {:title "Whizzard: Master Gamer" :side "Runner" :code "02001"}
             [{:qty 1 :card "Déjà Vu"}
              {:qty 3 :card "Sure Gamble"}
              {:qty 3 :card "Dirty Laundry"}
@@ -686,7 +686,7 @@
     [:preconstructed.worlds-2017-info "233 players attended worlds in 2017. The tournament was held in Minneapolis, MN, USA, and consisted of 8(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to the Revised Core set."]
     [:preconstructed.worlds-2017-a-ul "Worlds 2017: Stinson Reversed CI vs. Aesops Hayley"]
     (precon "ChaosJuggler - 2017: Sinson Reversed CI"
-            {:title "Cerebral Imaging: Infinite Frontiers" :side "Corp" :code 3001}
+            {:title "Cerebral Imaging: Infinite Frontiers" :side "Corp" :code "03001"}
             [{:qty 1 :card "Corporate Sales Team"}
              {:qty 3 :card "Efficiency Committee"}
              {:qty 2 :card "Elective Upgrade"}
@@ -711,7 +711,7 @@
              {:qty 2 :card "Architect"}
              {:qty 1 :card "Ichi 1.0"}])
     (precon "Grey Tongue - 2017: Aesops Hayley"
-            {:title "Hayley Kaplan: Universal Scholar" :side "Runner" :code 8025}
+            {:title "Hayley Kaplan: Universal Scholar" :side "Runner" :code "08025"}
             [{:qty 2 :card "Stimhack"}
              {:qty 3 :card "Sure Gamble"}
              {:qty 2 :card "Astrolabe"}
@@ -745,7 +745,7 @@
     [:preconstructed.worlds-2017-info "233 players attended worlds in 2017. The tournament was held in Minneapolis, MN, USA, and consisted of 8(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to the Revised Core set."]
     [:preconstructed.worlds-2017-b-ul "Worlds 2017: No-Show Rewiring CI vs. Laguna Lock Hayley"]
     (precon "Grey Tongue - 2017: No-Show Rewiring CI"
-            {:title "Cerebral Imaging: Infinite Frontiers" :side "Corp" :code 3001}
+            {:title "Cerebral Imaging: Infinite Frontiers" :side "Corp" :code "03001"}
             [{:qty 2 :card "Brain Rewiring"}
              {:qty 3 :card "Efficiency Committee"}
              {:qty 2 :card "Global Food Initiative"}
@@ -770,7 +770,7 @@
              {:qty 1 :card "Loki"}
              {:qty 2 :card "Mother Goddess"}])
     (precon "ChaosJuggler - 2017: Laguna Lock Hayley"
-            {:title "Hayley Kaplan: Universal Scholar" :side "Runner" :code 8025}
+            {:title "Hayley Kaplan: Universal Scholar" :side "Runner" :code "08025"}
             [{:qty 3 :card "Indexing"}
              {:qty 1 :card "Information Sifting"}
              {:qty 1 :card "Levy AR Lab Access"}
@@ -808,7 +808,7 @@
     [:preconstructed.worlds-2018-info "403(!) players attended worlds in 2018. This is the final worlds championship to be run by FFG. The tournament was held in Minneapolis, MN, USA, and consisted of 9(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Reign and Reverie"]
     [:preconstructed.worlds-2018-a-ul "Worlds 2018: AMERICA CtM vs. Gooseberry MaxX"]
     (precon "Joe Schupp - 2018: AMERICA CtM"
-            {:title "NBN: Controlling the Message" :side "Corp" :code 11017}
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
             [{:qty 1 :card "15 Minutes"}
              {:qty 3 :card "AR-Enhanced Security"}
              {:qty 3 :card "Global Food Initiative"}
@@ -832,7 +832,7 @@
              {:qty 1 :card "Tollbooth"}
              {:qty 1 :card "Turnpike"}])
     (precon "Chris Dyer - 2018: Gooseberry MaxX"
-            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code 7029}
+            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code "07029"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "Hacktivist Meeting"}
              {:qty 1 :card "Indexing"}
@@ -862,7 +862,7 @@
     [:preconstructed.worlds-2018-info "403(!) players attended worlds in 2018. This is the final worlds championship to be run by FFG. The tournament was held in Minneapolis, MN, USA, and consisted of 9(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to Reign and Reverie"]
     [:preconstructed.worlds-2018-b-ul "Worlds 2018: Trust the Process vs. Dan D'Argenio KoS Val"]
     (precon "Chris Dyer - 2018: Trust the Process"
-            {:title "NBN: Controlling the Message" :side "Corp" :code 11017}
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
             [{:qty 1 :card "15 Minutes"}
              {:qty 3 :card "AR-Enhanced Security"}
              {:qty 3 :card "Global Food Initiative"}
@@ -888,7 +888,7 @@
              {:qty 1 :card "Tollbooth"}
              {:qty 1 :card "Turnpike"}])
     (precon "Joe Schupp - 2018: Dan D'Argenio KoS Val"
-            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code 7030}
+            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code "07030"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "Employee Strike"}
              {:qty 3 :card "I've Had Worse"}
@@ -919,7 +919,7 @@
     [:preconstructed.worlds-2019-info "256 players played in the first even Project NISEI Netrunner World Championship in 2019. This tournament was held in Rotterdam, NL, and consisted of 8(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to the Uprising Booster Pack"]
     [:preconstructed.worlds-2019-a-ul "Worlds 2019: Fully dedicated to efficiency vs. Trash Panda"]
     (precon "Pinsel - 2019: Fully dedicated to efficiency"
-            {:title "Asa Group: Security Through Vigilance" :side "Corp" :code 21009}
+            {:title "Asa Group: Security Through Vigilance" :side "Corp" :code "21009"}
             [{:qty 3 :card "Efficiency Committee"}
              {:qty 3 :card "Global Food Initiative"}
              {:qty 3 :card "Project Vitruvius"}
@@ -941,7 +941,7 @@
              {:qty 3 :card "Gatekeeper"}
              {:qty 3 :card "Architect"}])
     (precon "Testrunning - 2019: Trash Panda"
-            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code 21081}
+            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code "21081"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "I've Had Worse"}
              {:qty 3 :card "Inject"}
@@ -971,7 +971,7 @@
     [:preconstructed.worlds-2019-info "256 players played in the first even Project NISEI Netrunner World Championship in 2019. This tournament was held in Rotterdam, NL, and consisted of 8(?) swiss rounds into a top 16 cut. The legal cardpool consisted of cards up to the Uprising Booster Pack"]
     [:preconstructed.worlds-2019-b-ul "Worlds 2019: 2 Grid for 2 Place vs. Trash Panda"]
     (precon "Testrunning - 2019: 2 Grid for 2 Place"
-            {:title "Pālanā Foods: Sustainable Growth" :side "Corp" :code 10030}
+            {:title "Pālanā Foods: Sustainable Growth" :side "Corp" :code "10030"}
             [{:qty 3 :card "Nisei MK II"}
              {:qty 3 :card "Obokata Protocol"}
              {:qty 1 :card "Philotic Entanglement"}
@@ -993,7 +993,7 @@
              {:qty 2 :card "Excalibur"}
              {:qty 3 :card "Anansi"}])
     (precon "Pinsel - 2019: Trash Panda"
-            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code 21081}
+            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code "21081"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "I've Had Worse"}
              {:qty 3 :card "Inject"}
@@ -1024,7 +1024,7 @@
     [:preconstructed.worlds-2020-info "294 players played in the first ever online world championship for Netrunner, run by Project NISEI 2020. Due to travel restrictions at the start of the COVID-19 pandemic, this tournament was held online via Jinteki.net, and consisted of 8 swiss rounds on two distinct day-ones, into a top 16 cut. The legal cardpool consisted of cards up to Uprising."]
     [:preconstructed.worlds-2020-a-ul "Worlds 2020: I don't like this deck vs. Engolo Freedom"]
     (precon "Limes - 2020: I don't like this deck"
-            {:title "Sportsmetal: Go Big or Go Home" :side "Corp" :code 22026}
+            {:title "Sportsmetal: Go Big or Go Home" :side "Corp" :code "22026"}
             [{:qty 2 :card "False Lead"}
              {:qty 3 :card "Hyperloop Extension"}
              {:qty 3 :card "Megaprix Qualifier"}
@@ -1045,7 +1045,7 @@
              {:qty 3 :card "Stock Buy-Back"}
              {:qty 3 :card "Meridian"}])
     (precon "tf34 - 2020: Engolo Freedom"
-            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code 21081}
+            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code "21081"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "I've Had Worse"}
              {:qty 1 :card "Rebirth"}
@@ -1074,7 +1074,7 @@
     [:preconstructed.worlds-2020-info "294 players played in the first ever online world championship for Netrunner, run by Project NISEI 2020. Due to travel restrictions at the start of the COVID-19 pandemic, this tournament was held online via Jinteki.net, and consisted of 8 swiss rounds on two distinct day-ones, into a top 16 cut. The legal cardpool consisted of cards up to Uprising."]
     [:preconstructed.worlds-2020-b-ul "Worlds 2020: Malia CTM vs. Imp-pressive Hoshiko"]
     (precon "tf34 - 2020: Malia CTM"
-            {:title "NBN: Controlling the Message" :side "Corp" :code 11017}
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
             [{:qty 3 :card "Bellona"}
              {:qty 1 :card "Degree Mill"}
              {:qty 3 :card "Project Beale"}
@@ -1098,7 +1098,7 @@
              {:qty 1 :card "Tollbooth"}
              {:qty 1 :card "F2P"}])
     (precon "Limes - 2020: Imp-pressive Hoshiko"
-            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code 26066}
+            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code "26066"}
             [{:qty 3 :card "Dirty Laundry"}
              {:qty 2 :card "I've Had Worse"}
              {:qty 2 :card "Labor Rights"}
@@ -1127,7 +1127,7 @@
     [:preconstructed.worlds-2021-info "201 players played in the second online world championship for Netrunner, run by Project NISEI in 2021. Due to the ongoing disruption caused by the COVID-19 pandemic, this tournament was held online via Jinteki.net, and consisted of 8 swiss rounds on two distinct day-ones, into a top 16 cut. The legal cardpool consisted of cards up to System Gateway."]
     [:preconstructed.worlds-2021-a-ul "Worlds 2021: 44 Card PD vs. Watch Me Drip, Watch Me Maemi"]
     (precon "Patrick Gower - 2021: 44 card PD"
-            {:title "Haas-Bioroid: Precision Design" :side "Corp" :code 30035}
+            {:title "Haas-Bioroid: Precision Design" :side "Corp" :code "30035"}
             [{:qty 3 :card "Cyberdex Sandbox"}
              {:qty 2 :card "Global Food Initiative"}
              {:qty 1 :card "Luminal Transubstantiation"}
@@ -1150,7 +1150,7 @@
              {:qty 2 :card "Ansel 1.0"}
              {:qty 3 :card "Drafter"}])
     (precon "Jonas - 2021: Watch Me Drip, Watch Me Maemi"
-            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code 7029}
+            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code "07029"}
             [{:qty 3 :card "Deuces Wild"}
              {:qty 3 :card "Dirty Laundry"}
              {:qty 1 :card "Falsified Credentials"}
@@ -1188,7 +1188,7 @@
     [:preconstructed.worlds-2021-info "201 players played in the second online world championship for Netrunner, run by Project NISEI in 2021. Due to the ongoing disruption caused by the COVID-19 pandemic, this tournament was held online via Jinteki.net, and consisted of 8 swiss rounds on two distinct day-ones, into a top 16 cut. The legal cardpool consisted of cards up to System Gateway."]
     [:preconstructed.worlds-2021-b-ul "Worlds 2021: Is Gagarin Good? vs. Medium to Large Maxx"]
     (precon "Jonas - 2021: Is Gagarin Good?"
-            {:title "Gagarin Deep Space: Expanding the Horizon" :side "Corp" :code 7002}
+            {:title "Gagarin Deep Space: Expanding the Horizon" :side "Corp" :code "07002"}
             [{:qty 1 :card "Above the Law"}
              {:qty 2 :card "Global Food Initiative"}
              {:qty 2 :card "Hostile Takeover"}
@@ -1212,7 +1212,7 @@
              {:qty 1 :card "Mausolus"}
              {:qty 1 :card "Rototurret"}])
     (precon "Patrick Gower - 2021: Medium to Large MaxX"
-            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code 7029}
+            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code "07029"}
             [{:qty 3 :card "Deuces Wild"}
              {:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "I've Had Worse"}
@@ -1247,7 +1247,7 @@
     [:preconstructed.worlds-2022-info "158 players played in the first world championship run by Null Signal Games (formerly Project NISEI), which was the first Netrunner world championship to be run in-person since the start of the COVID-19 pandemic. The tournament was held in Toronto, Canada, and consisted of 8(?) rounds into a top 16 cut. The legal cardpool consisted of cards up to Midnight Sun."]
     [:preconstructed.worlds-2022-a-ul "Worlds 2022: SNACS vs. Liberté, Égalité, Humidité"]
     (precon "William Huang - 2022: SNACS"
-            {:title "Sportsmetal: Go Big or Go Home" :side "Corp" :code 22026}
+            {:title "Sportsmetal: Go Big or Go Home" :side "Corp" :code "22026"}
             [{:qty 1 :card "Élivágar Bifurcation"}
              {:qty 2 :card "Global Food Initiative"}
              {:qty 1 :card "Luminal Transubstantiation"}
@@ -1271,7 +1271,7 @@
              {:qty 2 :card "Ansel 1.0"}
              {:qty 1 :card "Drafter"}])
     (precon "skry - 2022: Liberté, Égalité, Humidité"
-            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code 21081}
+            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code "21081"}
             [{:qty 3 :card "Deuces Wild"}
              {:qty 2 :card "Dirty Laundry"}
              {:qty 1 :card "Mad Dash"}
@@ -1303,7 +1303,7 @@
     [:preconstructed.worlds-2022-info "158 players played in the first world championship run by Null Signal Games (formerly Project NISEI), which was the first Netrunner world championship to be run in-person since the start of the COVID-19 pandemic. The tournament was held in Toronto, Canada, and consisted of 8(?) rounds into a top 16 cut. The legal cardpool consisted of cards up to Midnight Sun."]
     [:preconstructed.worlds-2022-b-ul "Worlds 2022: Dies to Doom Blade vs. ApocoLat"]
     (precon "skry - 2022: Dies to Doomblade"
-            {:title "AgInfusion: New Miracles for a New World" :side "Corp" :code 12052}
+            {:title "AgInfusion: New Miracles for a New World" :side "Corp" :code "12052"}
             [{:qty 1 :card "Longevity Serum"}
              {:qty 3 :card "Obokata Protocol"}
              {:qty 3 :card "Send a Message"}
@@ -1326,7 +1326,7 @@
              {:qty 3 :card "Anemone"}
              {:qty 3 :card "Mlinzi"}])
     (precon "William Huang - 2022: ApocoLat"
-            {:title "Lat: Ethical Freelancer" :side "Runner" :code 26019}
+            {:title "Lat: Ethical Freelancer" :side "Runner" :code "26019"}
             [{:qty 3 :card "Apocalypse"}
              {:qty 3 :card "Creative Commission"}
              {:qty 1 :card "Deuces Wild"}
@@ -1358,7 +1358,7 @@
     [:preconstructed.worlds-2023-info "254 players played in the second Netrunner world championship run by Null Signal Games. The tournament was held in Barcelona, Spain, and consisted of 8 rounds into a top 16 cut. The legal cardpool consisted of cards up to The Automata Initiative."]
     [:preconstructed.worlds-2023-a-ul "Worlds 2023: The Worlds Grid vs. sableCarnage"]
     (precon "William Huang - 2023: The Worlds Grind"
-            {:title "Weyland Consortium: Built to Last" :side "Corp" :code 30059}
+            {:title "Weyland Consortium: Built to Last" :side "Corp" :code "30059"}
             [{:qty 1 :card "Above the Law"}
              {:qty 3 :card "SDS Drone Deployment"}
              {:qty 3 :card "Send a Message"}
@@ -1382,7 +1382,7 @@
              {:qty 1 :card "Sadaka"}
              {:qty 3 :card "Winchester"}])
     (precon "cableCarnage - 2023: sableCarnage"
-            {:title "Nyusha \"Sable\" Sintashta: Symphonic Prodigy" :side "Runner" :code 33011}
+            {:title "Nyusha \"Sable\" Sintashta: Symphonic Prodigy" :side "Runner" :code "33011"}
             [{:qty 1 :card "Bahia Bands"}
              {:qty 3 :card "Bravado"}
              {:qty 3 :card "Dirty Laundry"}
@@ -1417,7 +1417,7 @@
     [:preconstructed.worlds-2023-info "254 players played in the second Netrunner world championship run by Null Signal Games. The tournament was held in Barcelona, Spain, and consisted of 8 rounds into a top 16 cut. The legal cardpool consisted of cards up to The Automata Initiative."]
     [:preconstructed.worlds-2023-b-ul "Worlds 2023: tableCarnage vs. You *do* always come back!"]
     (precon "cableCarnage - 2023: tableCarnage"
-            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code 6005}
+            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code "06005"}
             [{:qty 3 :card "Bellona"}
              {:qty 2 :card "Degree Mill"}
              {:qty 3 :card "False Lead"}
@@ -1443,7 +1443,7 @@
              {:qty 1 :card "Virtual Service Agent"}
              {:qty 1 :card "Unsmiling Tsarevna"}])
     (precon "William Huang - 2023: You *do* always come back!"
-            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code 26066}
+            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code "26066"}
             [{:qty 2 :card "Diesel"}
              {:qty 3 :card "Dirty Laundry"}
              {:qty 3 :card "Moshing"}
@@ -1473,7 +1473,7 @@
       [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
       [:preconstructed.worlds-2024-a-ul "Worlds 2024: Kill R+ vs. Good Stuff Lat"]
       (precon "Aruzan - 2024: Kill R+"
-            {:title "NBN: Reality Plus" :side "Corp" :code 30051}
+            {:title "NBN: Reality Plus" :side "Corp" :code "30051"}
             [{:qty 2 :card "Degree Mill"}
              {:qty 1 :card "Oracle Thinktank"}
              {:qty 3 :card "Project Beale"}
@@ -1499,7 +1499,7 @@
              {:qty 2 :card "AMAZE Amusements"}
              {:qty 2 :card "The Holo Man"}])
       (precon "DeeR - 2024: Deep Dive Lat"
-              {:title "Lat: Ethical Freelancer" :side "Runner" :code 26019}
+              {:title "Lat: Ethical Freelancer" :side "Runner" :code "26019"}
               [{:qty 3 :card "Creative Commission"}
                {:qty 2 :card "Deep Dive"}
                {:qty 2 :card "Diesel"}
@@ -1533,7 +1533,7 @@
     [:preconstructed.worlds-2024-info "204 players played in the third Netrunner world championship run by Null Signal Games. In this tournament, Alex Boyd AKA Aruzan (Arissana, Reality Plus) won the title of Netrunner World Champion in a final game Against Dee Ruttenberg AKA DeeR (Lat, PE), with Aruzan going entirely undefeated in the top cut. The tournament was held at the San Francisco Embarcadero Waterfront Hotel on 19th and 20th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Rebellion Without Rehearsal."]
     [:preconstructed.worlds-2024-b-ul "Worlds 2024: Loud PE vs. Deep Dive Arissana"]
     (precon "DeeR - 2024: Loud PE"
-            {:title "Jinteki: Personal Evolution" :side "Corp" :code 1067}
+            {:title "Jinteki: Personal Evolution" :side "Corp" :code "01067"}
             [{:qty 1 :card "Blood in the Water"}
              {:qty 3 :card "Fujii Asset Retrieval"}
              {:qty 2 :card "House of Knives"}
@@ -1559,7 +1559,7 @@
              {:qty 1 :card "The Holo Man"}
              {:qty 1 :card "Crisium Grid"}])
     (precon "Aruzan - 2024: Spree Arissana"
-            {:title "Arissana Rocha Nahu: Street Artist" :side "Runner" :code 34020}
+            {:title "Arissana Rocha Nahu: Street Artist" :side "Runner" :code "34020"}
             [{:qty 2 :card "Burner"}
              {:qty 3 :card "Creative Commission"}
              {:qty 3 :card "Deep Dive"}
@@ -1595,7 +1595,7 @@
     [:preconstructed.worlds-2025-info "361 players played in the fourth Netrunner world championship run by Null Signal Games. In this tournament, ZomZraft (Epiphany, Hoshiko) won the title of Netrunner World Champion in a final game Against davz131 (Au Co, Esa). The tournament was held at Dovecot Studios in Edenburg on the 18th and 19th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Elevation."]
     [:preconstructed.worlds-2025-a-ul "Worlds 2025: SBT Bytes vs. Vampire"]
     (precon "davz131 - 2025: SBT Bytes"
-            {:title "AU Co.: The Gold Standard in Clones" :side "Corp" :code 35046}
+            {:title "AU Co.: The Gold Standard in Clones" :side "Corp" :code "35046"}
             [{:qty 3 :card "Fujii Asset Retrieval"}
              {:qty 1 :card "Longevity Serum"}
              {:qty 3 :card "See How They Run"}
@@ -1618,7 +1618,7 @@
              {:qty 2 :card "Oppo Research"}
              {:qty 2 :card "End of the Line"}])
     (precon "ZomZraft - 2025: Vampire"
-            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code 26066}
+            {:title "Hoshiko Shiro: Untold Protagonist" :side "Runner" :code "26066"}
             [{:qty 3 :card "Steelskin Scarring"}
              {:qty 3 :card "Strike Fund"}
              {:qty 3 :card "The Price"}
@@ -1649,7 +1649,7 @@
     [:preconstructed.worlds-2025-info "361 players played in the fourth Netrunner world championship run by Null Signal Games. In this tournament, ZomZraft (Epiphany, Hoshiko) won the title of Netrunner World Champion in a final game Against davz131 (Au Co, Esa). The tournament was held at Dovecot Studios in Edenburg on the 18th and 19th of October, and consisted of 14 rounds of Single-Sided Swiss into a top 16 cut. The legal cardpool consisted of cards up to Elevation."]
     [:preconstructed.worlds-2025-b-ul "Worlds 2025: Constrictor vs. Esâ me, I'm back"]
     (precon "ZomZraft - 2025: Constrictor"
-            {:title "Epiphany Analytica: Nations Undivided" :side "Corp" :code 34048}
+            {:title "Epiphany Analytica: Nations Undivided" :side "Corp" :code "34048"}
             [{:qty 3 :card "Artificial Cryptocrash"}
              {:qty 2 :card "Freedom of Information"}
              {:qty 3 :card "Stoke the Embers"}
@@ -1676,7 +1676,7 @@
              {:qty 1 :card "Retribution"}
              {:qty 2 :card "The Holo Man"}])
     (precon "davz131 - 2025: Esâ me, I'm back"
-            {:title "Esâ Afontov: Eco-Insurrectionist" :side "Runner" :code 33001}
+            {:title "Esâ Afontov: Eco-Insurrectionist" :side "Runner" :code "33001"}
             [{:qty 2 :card "Chastushka"}
              {:qty 2 :card "Finality"}
              {:qty 1 :card "Katorga Breakout"}

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -1,11 +1,13 @@
 (ns jinteki.preconstructed)
 
 (defn precon
-  [name id deck]
-  {:identity id
-   :name name
-   :format "Preconstructed"
-   :cards deck})
+  ([name id deck] (precon name id deck nil))
+  ([name id deck decklist]
+   {:identity id
+    :name name
+    :format "Preconstructed"
+    :cards deck
+    :decklist decklist}))
 
 (defn matchup
   [tr-inner tr-tag tr-desc tr-underline corp runner]
@@ -1699,6 +1701,930 @@
              {:qty 1 :card "Mystic Maemi"}
              {:qty 3 :card "Dr. Nuka Vrolyck"}])))
 
+(def classique-blurb
+  "The classique format is a very accessible way for newer players to try some examples of classic netrunner decks.")
+
+;; Classique 2022
+(def classique-2022-foodcoats-vs-book-of-kate
+  (matchup
+    [:preconstructed.classique-2022-a "Classique 2022: Foodcoats (C) vs. Book of Kate (R)"]
+    [:preconstructed.classique-2022-a-tag "Foodcoats (C) vs. Book of Kate (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2022-a-ul "Classique 2022: Foodcoats vs. Book of Kate"]
+    (precon "Classique 2022: Foodcoats"
+            {:title "Haas-Bioroid: Engineering the Future" :side "Corp" :code "01054"}
+            [{:qty 3 :card "Accelerated Beta Test"}
+             {:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "NAPD Contract"}
+             {:qty 3 :card "Adonis Campaign"}
+             {:qty 3 :card "Eve Campaign"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 3 :card "Ash 2X3ZB9CY"}
+             {:qty 3 :card "Breaker Bay Grid"}
+             {:qty 2 :card "Caprice Nisei"}
+             {:qty 1 :card "Crisium Grid"}
+             {:qty 2 :card "Archived Memories"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "Architect"}
+             {:qty 3 :card "Eli 1.0"}
+             {:qty 2 :card "Enigma"}
+             {:qty 3 :card "Ichi 1.0"}
+             {:qty 2 :card "Ichi 2.0"}
+             {:qty 3 :card "Turing"}
+             {:qty 1 :card "Wall of Static"}]
+            "https://netrunnerdb.com/en/decklist/3f40bbd4-ac95-4afc-9a45-b6a623cc0049")
+    (precon "Classique 2022: Book of Kate"
+            {:title "Kate \"Mac\" McCaffrey: Digital Tinker" :side "Runner" :code "01033"}
+            [{:qty 3 :card "Diesel"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 1 :card "Legwork"}
+             {:qty 1 :card "Levy AR Lab Access"}
+             {:qty 3 :card "Lucky Find"}
+             {:qty 2 :card "Quality Time"}
+             {:qty 1 :card "Scavenge"}
+             {:qty 1 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "The Maker's Eye"}
+             {:qty 2 :card "Astrolabe"}
+             {:qty 2 :card "Clone Chip"}
+             {:qty 1 :card "Plascrete Carapace"}
+             {:qty 3 :card "Prepaid VoicePAD"}
+             {:qty 1 :card "R&D Interface"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 1 :card "Film Critic"}
+             {:qty 1 :card "Same Old Thing"}
+             {:qty 1 :card "Utopia Shard"}
+             {:qty 1 :card "Atman"}
+             {:qty 2 :card "Cerberus \"Lady\" H1"}
+             {:qty 1 :card "D4v1d"}
+             {:qty 1 :card "Gordian Blade"}
+             {:qty 1 :card "Mimic"}
+             {:qty 3 :card "Self-modifying Code"}]
+            "https://netrunnerdb.com/en/decklist/520c62fb-38f3-4a5f-91e4-1050689730fa")))
+
+(def classique-2022-grail-neh-vs-endless-waltz
+  (matchup
+    [:preconstructed.classique-2022-b "Classique 2022: Grail NEH (C) vs. Endless Waltz (R)"]
+    [:preconstructed.classique-2022-b-tag "Grail NEH (C) vs. Endless Waltz (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2022-b-ul "Classique 2022: Grail NEH vs. Endless Waltz"]
+    (precon "Classique 2022: Grail NEH"
+            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code "06005"}
+            [{:qty 1 :card "AstroScript Pilot Program"}
+             {:qty 2 :card "Breaking News"}
+             {:qty 3 :card "NAPD Contract"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 2 :card "Remastered Edition"}
+             {:qty 1 :card "Blacklist"}
+             {:qty 2 :card "Daily Business Show"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 3 :card "PAD Campaign"}
+             {:qty 1 :card "Cyberdex Virus Suite"}
+             {:qty 3 :card "SanSan City Grid"}
+             {:qty 2 :card "Biotic Labor"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 2 :card "Shipment from SanSan"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 3 :card "Galahad"}
+             {:qty 3 :card "Lancelot"}
+             {:qty 3 :card "Merlin"}
+             {:qty 3 :card "Pop-up Window"}
+             {:qty 3 :card "Wraparound"}]
+            "https://netrunnerdb.com/en/decklist/002dd16d-b350-4f67-80f4-6d5462fe184c")
+    (precon "Classique 2022: Endless Waltz"
+            {:title "Leela Patel: Trained Pragmatist" :side "Runner" :code "06095"}
+            [{:qty 3 :card "Account Siphon"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 1 :card "Emergency Shutdown"}
+             {:qty 2 :card "Inside Job"}
+             {:qty 1 :card "Legwork"}
+             {:qty 3 :card "Special Order"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "Desperado"}
+             {:qty 1 :card "Plascrete Carapace"}
+             {:qty 3 :card "R&D Interface"}
+             {:qty 3 :card "Bank Job"}
+             {:qty 2 :card "John Masanori"}
+             {:qty 1 :card "Kati Jones"}
+             {:qty 3 :card "Security Testing"}
+             {:qty 1 :card "Utopia Shard"}
+             {:qty 2 :card "Corroder"}
+             {:qty 3 :card "Faerie"}
+             {:qty 1 :card "Femme Fatale"}
+             {:qty 1 :card "Mimic"}
+             {:qty 1 :card "Passport"}
+             {:qty 2 :card "Sneakdoor Beta"}
+             {:qty 1 :card "Yog.0"}
+             {:qty 1 :card "ZU.13 Key Master"}]
+            "https://netrunnerdb.com/en/decklist/2cae2c77-333f-44ed-a964-46e968357feb")))
+
+(def classique-2022-ctm-vs-reg-whizz
+  (matchup
+    [:preconstructed.classique-2022-c "Classique 2022: CtM (C) vs. Reg Whizz (R)"]
+    [:preconstructed.classique-2022-c-tag "CtM (C) vs. Reg Whizz (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2022-c-ul "Classique 2022: CtM vs. Reg Whizz"]
+    (precon "Classique 2022: CtM"
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
+            [{:qty 1 :card "AstroScript Pilot Program"}
+             {:qty 3 :card "Breaking News"}
+             {:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 2 :card "Commercial Bankers Group"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 1 :card "PAD Campaign"}
+             {:qty 3 :card "Sensie Actors Union"}
+             {:qty 2 :card "Mumbad Virtual Tour"}
+             {:qty 2 :card "SanSan City Grid"}
+             {:qty 2 :card "Closed Accounts"}
+             {:qty 2 :card "Exchange of Information"}
+             {:qty 2 :card "Hard-Hitting News"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "Psychographics"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 2 :card "Archangel"}
+             {:qty 1 :card "Cobra"}
+             {:qty 1 :card "Enigma"}
+             {:qty 2 :card "Pop-up Window"}
+             {:qty 3 :card "Resistor"}
+             {:qty 2 :card "Tollbooth"}
+             {:qty 2 :card "Turnpike"}]
+            "https://netrunnerdb.com/en/decklist/bd4dd590-6191-4c29-a195-4473059bf63b")
+    (precon "Classique 2022: Reg Whizz"
+            {:title "Whizzard: Master Gamer" :side "Runner" :code "02001"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 2 :card "Déjà Vu"}
+             {:qty 2 :card "Employee Strike"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 2 :card "Inject"}
+             {:qty 1 :card "Retrieval Run"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 1 :card "Net-Ready Eyes"}
+             {:qty 2 :card "Obelus"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 1 :card "Earthrise Hotel"}
+             {:qty 1 :card "Ice Carver"}
+             {:qty 1 :card "Liberated Account"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 3 :card "Temüjin Contract"}
+             {:qty 2 :card "Datasucker"}
+             {:qty 2 :card "Medium"}
+             {:qty 2 :card "Mimic"}
+             {:qty 2 :card "Paperclip"}
+             {:qty 3 :card "Parasite"}
+             {:qty 1 :card "Progenitor"}
+             {:qty 2 :card "Yog.0"}]
+            "https://netrunnerdb.com/en/decklist/b14c2b27-ebca-4d88-9e84-569ef1e11e54")))
+
+(def classique-2022-supermodernism-argus-vs-crowdfunding-val
+  (matchup
+    [:preconstructed.classique-2022-d "Classique 2022: Supermodernism Argus (C) vs. Crowdfunding Val (R)"]
+    [:preconstructed.classique-2022-d-tag "Supermodernism Argus (C) vs. Crowdfunding Val (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2022-d-ul "Classique 2022: Supermodernism Argus vs. Crowdfunding Val"]
+    (precon "Classique 2022: Supermodernism Argus"
+            {:title "Argus Security: Protection Guaranteed" :side "Corp" :code "07001"}
+            [{:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Hostile Takeover"}
+             {:qty 1 :card "Oaktown Renovation"}
+             {:qty 3 :card "Project Atlas"}
+             {:qty 3 :card "NGO Front"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 3 :card "Prisec"}
+             {:qty 1 :card "Audacity"}
+             {:qty 1 :card "Consulting Visit"}
+             {:qty 2 :card "Economic Warfare"}
+             {:qty 1 :card "Fast Track"}
+             {:qty 3 :card "Hard-Hitting News"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 2 :card "High-Profile Target"}
+             {:qty 1 :card "IPO"}
+             {:qty 2 :card "Too Big to Fail"}
+             {:qty 2 :card "Archer"}
+             {:qty 3 :card "Border Control"}
+             {:qty 3 :card "Data Raven"}
+             {:qty 2 :card "Hortum"}
+             {:qty 1 :card "Ice Wall"}
+             {:qty 3 :card "Mausolus"}]
+            "https://netrunnerdb.com/en/decklist/fa0cb0ad-5d70-4e90-832a-c1101f9254b6")
+    (precon "Classique 2022: Crowdfunding Val"
+            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code "07030"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 3 :card "Hacktivist Meeting"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 3 :card "Inject"}
+             {:qty 2 :card "Mining Accident"}
+             {:qty 1 :card "Rebirth"}
+             {:qty 3 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "Hippo"}
+             {:qty 1 :card "Turntable"}
+             {:qty 3 :card "Crowdfunding"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 2 :card "Earthrise Hotel"}
+             {:qty 2 :card "Liberated Account"}
+             {:qty 3 :card "The Turning Wheel"}
+             {:qty 2 :card "Aumakua"}
+             {:qty 3 :card "Black Orchestra"}
+             {:qty 2 :card "Datasucker"}
+             {:qty 2 :card "MKUltra"}
+             {:qty 3 :card "Paperclip"}]
+            "https://netrunnerdb.com/en/decklist/2fa90df8-0d4e-435c-8556-5271ba5b1c8e")))
+
+;; Classique 2023
+(def classique-2023-panic-palana-vs-noise-shop
+  (matchup
+    [:preconstructed.classique-2023-a "Classique 2023: Panic Palana (C) vs. Noise Shop (R)"]
+    [:preconstructed.classique-2023-a-tag "Panic Palana (C) vs. Noise Shop (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2023-a-ul "Classique 2023: Panic Palana vs. Noise Shop"]
+    (precon "Classique 2023: Panic Palana"
+            {:title "Pālanā Foods: Sustainable Growth" :side "Corp" :code "10030"}
+            [{:qty 3 :card "Corporate Sales Team"}
+             {:qty 2 :card "Global Food Initiative"}
+             {:qty 3 :card "Nisei MK II"}
+             {:qty 1 :card "Philotic Entanglement"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 2 :card "Launch Campaign"}
+             {:qty 3 :card "Caprice Nisei"}
+             {:qty 1 :card "Cyberdex Virus Suite"}
+             {:qty 3 :card "Marcus Batty"}
+             {:qty 3 :card "Celebrity Gift"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "Interns"}
+             {:qty 3 :card "Restructure"}
+             {:qty 1 :card "Assassin"}
+             {:qty 1 :card "Cobra"}
+             {:qty 2 :card "Crick"}
+             {:qty 3 :card "Eli 1.0"}
+             {:qty 2 :card "Lotus Field"}
+             {:qty 3 :card "Pup"}
+             {:qty 2 :card "Swordsman"}
+             {:qty 3 :card "Viper"}
+             {:qty 1 :card "Wraparound"}]
+            "https://netrunnerdb.com/en/decklist/cb0de9b9-bd6a-4a2b-beab-2b2bd1586b43")
+    (precon "Classique 2023: Noise Shop"
+            {:title "Noise: Hacker Extraordinaire" :side "Runner" :code "01001"}
+            [{:qty 3 :card "Déjà Vu"}
+             {:qty 3 :card "Inject"}
+             {:qty 1 :card "Levy AR Lab Access"}
+             {:qty 2 :card "Grimoire"}
+             {:qty 2 :card "Adjusted Chronotype"}
+             {:qty 3 :card "Aesop's Pawnshop"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 3 :card "Wyldside"}
+             {:qty 3 :card "Cache"}
+             {:qty 2 :card "Clot"}
+             {:qty 2 :card "D4v1d"}
+             {:qty 3 :card "Datasucker"}
+             {:qty 2 :card "Faust"}
+             {:qty 3 :card "Imp"}
+             {:qty 3 :card "Lamprey"}
+             {:qty 2 :card "Medium"}
+             {:qty 1 :card "Mimic"}
+             {:qty 3 :card "Parasite"}
+             {:qty 1 :card "Scheherazade"}]
+            "https://netrunnerdb.com/en/decklist/9feb53a6-d470-46fe-ad58-68b54e431b77")))
+
+(def classique-2023-tablet-asa-vs-core-set-waltz
+  (matchup
+    [:preconstructed.classique-2023-b "Classique 2023: Tablet Asa (C) vs. Core Set Waltz (R)"]
+    [:preconstructed.classique-2023-b-tag "Tablet Asa (C) vs. Core Set Waltz (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2023-b-ul "Classique 2023: Tablet Asa vs. Core Set Waltz"]
+    (precon "Classique 2023: Tablet Asa"
+            {:title "Asa Group: Security Through Vigilance" :side "Corp" :code "21009"}
+            [{:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Project Vitruvius"}
+             {:qty 3 :card "Successful Field Test"}
+             {:qty 3 :card "Cybernetics Court"}
+             {:qty 2 :card "Daily Quest"}
+             {:qty 3 :card "Jeeves Model Bioroids"}
+             {:qty 2 :card "Lakshmi Smartfabrics"}
+             {:qty 2 :card "MCA Austerity Policy"}
+             {:qty 3 :card "Marilyn Campaign"}
+             {:qty 3 :card "Mumba Temple"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 1 :card "Cyberdex Virus Suite"}
+             {:qty 1 :card "Biotic Labor"}
+             {:qty 3 :card "Fully Operational"}
+             {:qty 3 :card "Violet Level Clearance"}
+             {:qty 1 :card "Drafter"}
+             {:qty 1 :card "Fairchild 3.0"}
+             {:qty 3 :card "Gatekeeper"}
+             {:qty 3 :card "Hagen"}
+             {:qty 3 :card "Tour Guide"}]
+            "https://netrunnerdb.com/en/decklist/7cec66ed-30f5-45bd-90ab-c9aee62742e7")
+    (precon "Classique 2023: Core Set Waltz"
+            {:title "Leela Patel: Trained Pragmatist" :side "Runner" :code "06095"}
+            [{:qty 3 :card "Bravado"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 3 :card "Diversion of Funds"}
+             {:qty 2 :card "Embezzle"}
+             {:qty 2 :card "Inside Job"}
+             {:qty 1 :card "Legwork"}
+             {:qty 1 :card "Special Order"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 1 :card "The Maker's Eye"}
+             {:qty 2 :card "Aniccam"}
+             {:qty 3 :card "Boomerang"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 3 :card "PAD Tap"}
+             {:qty 1 :card "Political Operative"}
+             {:qty 2 :card "The Class Act"}
+             {:qty 2 :card "The Turning Wheel"}
+             {:qty 2 :card "Amina"}
+             {:qty 2 :card "Bukhgalter"}
+             {:qty 1 :card "Paperclip"}
+             {:qty 2 :card "Rezeki"}
+             {:qty 1 :card "Sneakdoor Beta"}
+             {:qty 2 :card "Tapwrm"}]
+            "https://netrunnerdb.com/en/decklist/5da194aa-0647-4e38-9597-86c47da4f9a9")))
+
+(def classique-2023-fastrobiotics-vs-ppvp-kate
+  (matchup
+    [:preconstructed.classique-2023-c "Classique 2023: Fastrobiotics (C) vs. PPVP Kate (R)"]
+    [:preconstructed.classique-2023-c-tag "Fastrobiotics (C) vs. PPVP Kate (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2023-c-ul "Classique 2023: Fastrobiotics vs. PPVP Kate"]
+    (precon "Classique 2023: Fastrobiotics"
+            {:title "Near-Earth Hub: Broadcast Center" :side "Corp" :code "06005"}
+            [{:qty 1 :card "AstroScript Pilot Program"}
+             {:qty 2 :card "Breaking News"}
+             {:qty 2 :card "Evidence Collection"}
+             {:qty 3 :card "NAPD Contract"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 1 :card "Daily Business Show"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 3 :card "PAD Campaign"}
+             {:qty 2 :card "Cyberdex Virus Suite"}
+             {:qty 3 :card "SanSan City Grid"}
+             {:qty 2 :card "Biotic Labor"}
+             {:qty 1 :card "Fast Track"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 2 :card "Shipment from SanSan"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 2 :card "Architect"}
+             {:qty 3 :card "Eli 1.0"}
+             {:qty 2 :card "Enigma"}
+             {:qty 1 :card "Ichi 1.0"}
+             {:qty 3 :card "Pop-up Window"}
+             {:qty 2 :card "Tollbooth"}
+             {:qty 2 :card "Wraparound"}]
+            "https://netrunnerdb.com/en/decklist/66db5f78-2158-48a8-ad9a-840d802f4227")
+    (precon "Classique 2023: PPVP Kate"
+            {:title "Kate \"Mac\" McCaffrey: Digital Tinker" :side "Runner" :code "01033"}
+            [{:qty 3 :card "Diesel"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 1 :card "Legwork"}
+             {:qty 1 :card "Levy AR Lab Access"}
+             {:qty 3 :card "Lucky Find"}
+             {:qty 2 :card "Quality Time"}
+             {:qty 1 :card "Scavenge"}
+             {:qty 1 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "The Maker's Eye"}
+             {:qty 2 :card "Astrolabe"}
+             {:qty 3 :card "Clone Chip"}
+             {:qty 1 :card "Plascrete Carapace"}
+             {:qty 3 :card "Prepaid VoicePAD"}
+             {:qty 1 :card "R&D Interface"}
+             {:qty 1 :card "Same Old Thing"}
+             {:qty 1 :card "Atman"}
+             {:qty 2 :card "Cerberus \"Lady\" H1"}
+             {:qty 1 :card "Clot"}
+             {:qty 1 :card "Cyber-Cypher"}
+             {:qty 1 :card "Datasucker"}
+             {:qty 1 :card "Mimic"}
+             {:qty 1 :card "Parasite"}
+             {:qty 3 :card "Self-modifying Code"}
+             {:qty 1 :card "Sharpshooter"}
+             {:qty 1 :card "ZU.13 Key Master"}]
+            "https://netrunnerdb.com/en/decklist/2ecb0879-e262-4f08-a77f-ccfbde83c090")))
+
+(def classique-2023-supermodernism-argus-vs-crowdfunding-val
+  (matchup
+    [:preconstructed.classique-2023-d "Classique 2023: Supermodernism Argus (C) vs. Crowdfunding Val (R)"]
+    [:preconstructed.classique-2023-d-tag "Supermodernism Argus (C) vs. Crowdfunding Val (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2023-d-ul "Classique 2023: Supermodernism Argus vs. Crowdfunding Val"]
+    (precon "Classique 2023: Supermodernism Argus"
+            {:title "Argus Security: Protection Guaranteed" :side "Corp" :code "07001"}
+            [{:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Hostile Takeover"}
+             {:qty 1 :card "Oaktown Renovation"}
+             {:qty 3 :card "Project Atlas"}
+             {:qty 3 :card "NGO Front"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 3 :card "Prisec"}
+             {:qty 1 :card "Audacity"}
+             {:qty 1 :card "Consulting Visit"}
+             {:qty 2 :card "Economic Warfare"}
+             {:qty 1 :card "Fast Track"}
+             {:qty 3 :card "Hard-Hitting News"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 2 :card "High-Profile Target"}
+             {:qty 1 :card "IPO"}
+             {:qty 2 :card "Too Big to Fail"}
+             {:qty 2 :card "Archer"}
+             {:qty 3 :card "Border Control"}
+             {:qty 3 :card "Data Raven"}
+             {:qty 2 :card "Hortum"}
+             {:qty 1 :card "Ice Wall"}
+             {:qty 3 :card "Mausolus"}]
+            "https://netrunnerdb.com/en/decklist/a23906a9-d08a-4739-a123-8d18a4145f52")
+    (precon "Classique 2023: Crowdfunding Val"
+            {:title "Valencia Estevez: The Angel of Cayambe" :side "Runner" :code "07030"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 3 :card "Hacktivist Meeting"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 3 :card "Inject"}
+             {:qty 2 :card "Mining Accident"}
+             {:qty 1 :card "Rebirth"}
+             {:qty 3 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "Hippo"}
+             {:qty 1 :card "Turntable"}
+             {:qty 3 :card "Crowdfunding"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 2 :card "Earthrise Hotel"}
+             {:qty 2 :card "Liberated Account"}
+             {:qty 3 :card "The Turning Wheel"}
+             {:qty 2 :card "Aumakua"}
+             {:qty 3 :card "Black Orchestra"}
+             {:qty 2 :card "Datasucker"}
+             {:qty 2 :card "MKUltra"}
+             {:qty 3 :card "Paperclip"}]
+            "https://netrunnerdb.com/en/decklist/54af876d-89f1-4dc9-a6d8-6d1e5a6e40a5")))
+
+;; Classique 2025
+(def classique-2025-cambridge-pe-vs-classic-andy
+  (matchup
+    [:preconstructed.classique-2025-a "Classique 2025: Cambridge PE (C) vs. Classic Andy (R)"]
+    [:preconstructed.classique-2025-a-tag "Cambridge PE (C) vs. Classic Andy (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2025-a-ul "Classique 2025: Cambridge PE vs. Classic Andy"]
+    (precon "Classique 2025: Cambridge PE"
+            {:title "Jinteki: Personal Evolution" :side "Corp" :code "01067"}
+            [{:qty 3 :card "Fetal AI"}
+             {:qty 3 :card "Gila Hands Arcology"}
+             {:qty 3 :card "House of Knives"}
+             {:qty 1 :card "Philotic Entanglement"}
+             {:qty 2 :card "The Future Perfect"}
+             {:qty 2 :card "Jackson Howard"}
+             {:qty 1 :card "Project Junebug"}
+             {:qty 3 :card "Psychic Field"}
+             {:qty 3 :card "Ronin"}
+             {:qty 1 :card "Shattered Remains"}
+             {:qty 3 :card "Snare!"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "Mushin No Shin"}
+             {:qty 3 :card "Neural EMP"}
+             {:qty 1 :card "Scorched Earth"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 3 :card "Eli 1.0"}
+             {:qty 2 :card "Enigma"}
+             {:qty 2 :card "Komainu"}
+             {:qty 1 :card "Neural Katana"}
+             {:qty 2 :card "Pup"}
+             {:qty 1 :card "Yagura"}]
+            "https://netrunnerdb.com/en/decklist/cbe92073-0b92-4365-87b5-a237a5298654")
+    (precon "Classique 2025: Classic Andy"
+            {:title "Andromeda: Dispossessed Ristie" :side "Runner" :code "02083"}
+            [{:qty 3 :card "Account Siphon"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 1 :card "Emergency Shutdown"}
+             {:qty 1 :card "Express Delivery"}
+             {:qty 1 :card "Infiltration"}
+             {:qty 1 :card "Inside Job"}
+             {:qty 2 :card "Legwork"}
+             {:qty 2 :card "Quality Time"}
+             {:qty 3 :card "Special Order"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 3 :card "Desperado"}
+             {:qty 1 :card "Plascrete Carapace"}
+             {:qty 2 :card "R&D Interface"}
+             {:qty 1 :card "Daily Casts"}
+             {:qty 2 :card "Kati Jones"}
+             {:qty 1 :card "Same Old Thing"}
+             {:qty 3 :card "Security Testing"}
+             {:qty 2 :card "Corroder"}
+             {:qty 3 :card "Datasucker"}
+             {:qty 3 :card "Faerie"}
+             {:qty 1 :card "Femme Fatale"}
+             {:qty 1 :card "Mimic"}
+             {:qty 1 :card "Passport"}
+             {:qty 1 :card "Yog.0"}]
+            "https://netrunnerdb.com/en/decklist/dfe43bba-b1ef-46a7-8094-8a755bd99525")))
+
+(def classique-2025-ctm-vs-reg-whizz
+  (matchup
+    [:preconstructed.classique-2025-b "Classique 2025: CtM (C) vs. Reg Whizz (R)"]
+    [:preconstructed.classique-2025-b-tag "CtM (C) vs. Reg Whizz (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2025-b-ul "Classique 2025: CtM vs. Reg Whizz"]
+    (precon "Classique 2025: CtM"
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
+            [{:qty 1 :card "AstroScript Pilot Program"}
+             {:qty 3 :card "Breaking News"}
+             {:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 2 :card "Commercial Bankers Group"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 1 :card "PAD Campaign"}
+             {:qty 3 :card "Sensie Actors Union"}
+             {:qty 2 :card "Mumbad Virtual Tour"}
+             {:qty 2 :card "SanSan City Grid"}
+             {:qty 2 :card "Closed Accounts"}
+             {:qty 2 :card "Exchange of Information"}
+             {:qty 2 :card "Hard-Hitting News"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "Psychographics"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 2 :card "Archangel"}
+             {:qty 1 :card "Cobra"}
+             {:qty 1 :card "Enigma"}
+             {:qty 2 :card "Pop-up Window"}
+             {:qty 3 :card "Resistor"}
+             {:qty 2 :card "Tollbooth"}
+             {:qty 2 :card "Turnpike"}]
+            "https://netrunnerdb.com/en/decklist/55b1c17a-58d5-4cc7-bf06-ab5783e8f19d")
+    (precon "Classique 2025: Reg Whizz"
+            {:title "Whizzard: Master Gamer" :side "Runner" :code "02001"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 2 :card "Déjà Vu"}
+             {:qty 2 :card "Employee Strike"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 2 :card "Inject"}
+             {:qty 1 :card "Retrieval Run"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 1 :card "Net-Ready Eyes"}
+             {:qty 2 :card "Obelus"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 1 :card "Earthrise Hotel"}
+             {:qty 1 :card "Ice Carver"}
+             {:qty 1 :card "Liberated Account"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 3 :card "Temüjin Contract"}
+             {:qty 2 :card "Datasucker"}
+             {:qty 2 :card "Medium"}
+             {:qty 2 :card "Mimic"}
+             {:qty 2 :card "Paperclip"}
+             {:qty 3 :card "Parasite"}
+             {:qty 1 :card "Progenitor"}
+             {:qty 2 :card "Yog.0"}]
+            "https://netrunnerdb.com/en/decklist/21a89387-2395-4022-9b97-64b6b0a97309")))
+
+(def classique-2025-reversed-stinson-ci-vs-german-geist
+  (matchup
+    [:preconstructed.classique-2025-c "Classique 2025: Reversed Stinson CI (C) vs. German Geist (R)"]
+    [:preconstructed.classique-2025-c-tag "Reversed Stinson CI (C) vs. German Geist (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2025-c-ul "Classique 2025: Reversed Stinson CI vs. German Geist"]
+    (precon "Classique 2025: Reversed Stinson CI"
+            {:title "Cerebral Imaging: Infinite Frontiers" :side "Corp" :code "03001"}
+            [{:qty 1 :card "Corporate Sales Team"}
+             {:qty 3 :card "Efficiency Committee"}
+             {:qty 2 :card "Elective Upgrade"}
+             {:qty 3 :card "Project Vitruvius"}
+             {:qty 3 :card "Jeeves Model Bioroids"}
+             {:qty 3 :card "MCA Austerity Policy"}
+             {:qty 3 :card "Reversed Accounts"}
+             {:qty 2 :card "Bryan Stinson"}
+             {:qty 1 :card "Cyberdex Virus Suite"}
+             {:qty 3 :card "Biotic Labor"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "IPO"}
+             {:qty 2 :card "Shipment from Tennin"}
+             {:qty 3 :card "Ultraviolet Clearance"}
+             {:qty 3 :card "Violet Level Clearance"}
+             {:qty 2 :card "Architect"}
+             {:qty 1 :card "Bastion"}
+             {:qty 1 :card "Enigma"}
+             {:qty 1 :card "Fairchild 2.0"}
+             {:qty 3 :card "Fairchild 3.0"}
+             {:qty 1 :card "Ichi 1.0"}
+             {:qty 2 :card "Vanilla"}]
+            "https://netrunnerdb.com/en/decklist/37fe16e0-0035-4bfe-9c1c-04cf72f305af")
+    (precon "Classique 2025: German Geist"
+            {:title "Armand \"Geist\" Walker: Tech Lord" :side "Runner" :code "08063"}
+            [{:qty 1 :card "\"Freedom Through Equality\""}
+             {:qty 3 :card "Calling in Favors"}
+             {:qty 1 :card "Information Sifting"}
+             {:qty 1 :card "Legwork"}
+             {:qty 2 :card "Levy AR Lab Access"}
+             {:qty 1 :card "On the Lam"}
+             {:qty 1 :card "Forger"}
+             {:qty 3 :card "Sports Hopper"}
+             {:qty 5 :card "Spy Camera"}
+             {:qty 2 :card "Dean Lister"}
+             {:qty 1 :card "Drug Dealer"}
+             {:qty 3 :card "Fall Guy"}
+             {:qty 2 :card "Maxwell James"}
+             {:qty 3 :card "Off-Campus Apartment"}
+             {:qty 1 :card "Political Operative"}
+             {:qty 1 :card "Same Old Thing"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 3 :card "Tech Trader"}
+             {:qty 3 :card "Underworld Contact"}
+             {:qty 1 :card "Abagnale"}
+             {:qty 2 :card "Aumakua"}
+             {:qty 1 :card "Mongoose"}
+             {:qty 1 :card "Paperclip"}]
+            "https://netrunnerdb.com/en/decklist/bd685b50-492e-4a77-97c4-1ae7d757f416")))
+
+(def classique-2025-seamusmodernism-vs-pitchfork-hayley
+  (matchup
+    [:preconstructed.classique-2025-d "Classique 2025: Seamusmodernism (C) vs. Pitchfork Hayley (R)"]
+    [:preconstructed.classique-2025-d-tag "Seamusmodernism (C) vs. Pitchfork Hayley (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2025-d-ul "Classique 2025: Seamusmodernism vs. Pitchfork Hayley"]
+    (precon "Classique 2025: Seamusmodernism"
+            {:title "Argus Security: Protection Guaranteed" :side "Corp" :code "07001"}
+            [{:qty 2 :card "Geothermal Fracking"}
+             {:qty 3 :card "Hostile Takeover"}
+             {:qty 3 :card "Oaktown Renovation"}
+             {:qty 1 :card "Posted Bounty"}
+             {:qty 3 :card "Project Atlas"}
+             {:qty 2 :card "Jackson Howard"}
+             {:qty 1 :card "Shattered Remains"}
+             {:qty 3 :card "Snare!"}
+             {:qty 1 :card "Crisium Grid"}
+             {:qty 1 :card "Cyberdex Virus Suite"}
+             {:qty 3 :card "Beanstalk Royalties"}
+             {:qty 1 :card "Casting Call"}
+             {:qty 1 :card "Fast Track"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "Restructure"}
+             {:qty 1 :card "SEA Source"}
+             {:qty 3 :card "Scorched Earth"}
+             {:qty 2 :card "Archer"}
+             {:qty 1 :card "Changeling"}
+             {:qty 1 :card "Cobra"}
+             {:qty 3 :card "Enigma"}
+             {:qty 1 :card "Grim"}
+             {:qty 1 :card "Ice Wall"}
+             {:qty 1 :card "Meru Mati"}
+             {:qty 1 :card "Mother Goddess"}
+             {:qty 2 :card "Spiderweb"}
+             {:qty 2 :card "Swordsman"}
+             {:qty 1 :card "Wraparound"}]
+            "https://netrunnerdb.com/en/decklist/f80137ab-1027-4937-8270-6addf7d5c6ce")
+    (precon "Classique 2025: Pitchfork Hayley"
+            {:title "Hayley Kaplan: Universal Scholar" :side "Runner" :code "08025"}
+            [{:qty 1 :card "Levy AR Lab Access"}
+             {:qty 3 :card "Scavenge"}
+             {:qty 1 :card "Stimhack"}
+             {:qty 2 :card "Astrolabe"}
+             {:qty 3 :card "Clone Chip"}
+             {:qty 1 :card "Plascrete Carapace"}
+             {:qty 3 :card "R&D Interface"}
+             {:qty 2 :card "Aesop's Pawnshop"}
+             {:qty 2 :card "Artist Colony"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 3 :card "Fan Site"}
+             {:qty 1 :card "Film Critic"}
+             {:qty 1 :card "Hunting Grounds"}
+             {:qty 3 :card "Professional Contacts"}
+             {:qty 1 :card "Same Old Thing"}
+             {:qty 3 :card "Technical Writer"}
+             {:qty 1 :card "Atman"}
+             {:qty 3 :card "Cache"}
+             {:qty 1 :card "Cerberus \"Lady\" H1"}
+             {:qty 1 :card "Chameleon"}
+             {:qty 1 :card "Clot"}
+             {:qty 2 :card "Cyber-Cypher"}
+             {:qty 1 :card "D4v1d"}
+             {:qty 2 :card "Self-modifying Code"}]
+            "https://netrunnerdb.com/en/decklist/4028e1eb-5da2-4e32-9278-c0235cd5926a")))
+
+;; Classique 2026
+(def classique-2026-come-on-and-slam-vs-clanaxx
+  (matchup
+    [:preconstructed.classique-2026-a "Classique 2026: Come On And Slam (C) vs. ClanaxX (R)"]
+    [:preconstructed.classique-2026-a-tag "Come On And Slam (C) vs. ClanaxX (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2026-a-ul "Classique 2026: Come On And Slam vs. ClanaxX"]
+    (precon "Classique 2026: Come On And Slam"
+            {:title "Sportsmetal: Go Big or Go Home" :side "Corp" :code "22026"}
+            [{:qty 1 :card "Corporate Sales Team"}
+             {:qty 3 :card "Hyperloop Extension"}
+             {:qty 1 :card "Ikawah Project"}
+             {:qty 3 :card "Project Vitruvius"}
+             {:qty 3 :card "Remote Enforcement"}
+             {:qty 3 :card "Jeeves Model Bioroids"}
+             {:qty 3 :card "NGO Front"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 3 :card "Arella Salvatore"}
+             {:qty 1 :card "Ark Lockdown"}
+             {:qty 3 :card "Biotic Labor"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "IPO"}
+             {:qty 2 :card "Ultraviolet Clearance"}
+             {:qty 3 :card "Architect"}
+             {:qty 1 :card "Enigma"}
+             {:qty 3 :card "Fairchild 3.0"}
+             {:qty 3 :card "Gatekeeper"}
+             {:qty 2 :card "IP Block"}
+             {:qty 1 :card "Surveyor"}
+             {:qty 1 :card "Tollbooth"}
+             {:qty 2 :card "Vanilla"}]
+            "https://netrunnerdb.com/en/decklist/f04d44e1-573b-4d54-9969-2ff5cc38e87b")
+    (precon "Classique 2026: ClanaxX"
+            {:title "MaxX: Maximum Punk Rock" :side "Runner" :code "07029"}
+            [{:qty 3 :card "Fisk Investment Seminar"}
+             {:qty 3 :card "Hacktivist Meeting"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 2 :card "Levy AR Lab Access"}
+             {:qty 1 :card "Mad Dash"}
+             {:qty 2 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 2 :card "Patchwork"}
+             {:qty 1 :card "Titanium Ribs"}
+             {:qty 3 :card "Zer0"}
+             {:qty 3 :card "Clan Vengeance"}
+             {:qty 2 :card "DDoS"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 3 :card "Liberated Account"}
+             {:qty 3 :card "Same Old Thing"}
+             {:qty 2 :card "Black Orchestra"}
+             {:qty 2 :card "D4v1d"}
+             {:qty 2 :card "MKUltra"}
+             {:qty 2 :card "Paperclip"}]
+            "https://netrunnerdb.com/en/decklist/0ea9b4a4-b18f-44e0-a666-170ae9856b28")))
+
+(def classique-2026-battyshop-blue-sun-vs-trash-panda-freedom
+  (matchup
+    [:preconstructed.classique-2026-b "Classique 2026: Battyshop Blue Sun (C) vs. Trash Panda Freedom (R)"]
+    [:preconstructed.classique-2026-b-tag "Battyshop Blue Sun (C) vs. Trash Panda Freedom (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2026-b-ul "Classique 2026: Battyshop Blue Sun vs. Trash Panda Freedom"]
+    (precon "Classique 2026: Battyshop Blue Sun"
+            {:title "Blue Sun: Powering the Future" :side "Corp" :code "25123"}
+            [{:qty 2 :card "Hostile Takeover"}
+             {:qty 3 :card "SDS Drone Deployment"}
+             {:qty 3 :card "SSL Endorsement"}
+             {:qty 3 :card "NGO Front"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 1 :card "Crisium Grid"}
+             {:qty 3 :card "Marcus Batty"}
+             {:qty 3 :card "Building Blocks"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "IPO"}
+             {:qty 1 :card "Preemptive Action"}
+             {:qty 3 :card "Punitive Counterstrike"}
+             {:qty 2 :card "Afshar"}
+             {:qty 3 :card "Border Control"}
+             {:qty 3 :card "Chiyashi"}
+             {:qty 1 :card "Hortum"}
+             {:qty 2 :card "Mausolus"}
+             {:qty 1 :card "Orion"}
+             {:qty 2 :card "Sapper"}
+             {:qty 3 :card "Surveyor"}
+             {:qty 1 :card "Tithonium"}]
+            "https://netrunnerdb.com/en/decklist/cbde6e9e-1139-4b3e-bbd3-61973573ee80")
+    (precon "Classique 2026: Trash Panda Freedom"
+            {:title "Freedom Khumalo: Crypto-Anarchist" :side "Runner" :code "21081"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 3 :card "I've Had Worse"}
+             {:qty 3 :card "Inject"}
+             {:qty 3 :card "Stimhack"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 2 :card "Clone Chip"}
+             {:qty 3 :card "Hippo"}
+             {:qty 2 :card "Knobkierie"}
+             {:qty 3 :card "Daily Casts"}
+             {:qty 3 :card "Liberated Account"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 2 :card "Black Orchestra"}
+             {:qty 1 :card "Consume"}
+             {:qty 2 :card "D4v1d"}
+             {:qty 1 :card "Imp"}
+             {:qty 1 :card "MKUltra"}
+             {:qty 2 :card "Paperclip"}
+             {:qty 1 :card "Pelangi"}
+             {:qty 1 :card "Self-modifying Code"}
+             {:qty 1 :card "Stargate"}
+             {:qty 2 :card "Yusuf"}]
+            "https://netrunnerdb.com/en/decklist/4097ef38-8ae0-4dae-a53e-0a5974f53c7a")))
+
+(def classique-2026-post-scarcity-palana-vs-whiteblade-liza
+  (matchup
+    [:preconstructed.classique-2026-c "Classique 2026: Post-Scarcity Palana (C) vs. Whiteblade Liza (R)"]
+    [:preconstructed.classique-2026-c-tag "Post-Scarcity Palana (C) vs. Whiteblade Liza (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2026-c-ul "Classique 2026: Post-Scarcity Palana vs. Whiteblade Liza"]
+    (precon "Classique 2026: Post-Scarcity Palana"
+            {:title "Pālanā Foods: Sustainable Growth" :side "Corp" :code "10030"}
+            [{:qty 3 :card "Nisei MK II"}
+             {:qty 3 :card "Obokata Protocol"}
+             {:qty 1 :card "SSL Endorsement"}
+             {:qty 1 :card "Timely Public Release"}
+             {:qty 3 :card "NGO Front"}
+             {:qty 3 :card "Rashida Jaheem"}
+             {:qty 2 :card "Snare!"}
+             {:qty 2 :card "Bio Vault"}
+             {:qty 2 :card "Crisium Grid"}
+             {:qty 3 :card "La Costa Grid"}
+             {:qty 1 :card "Archived Memories"}
+             {:qty 1 :card "Celebrity Gift"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 3 :card "IPO"}
+             {:qty 2 :card "Aiki"}
+             {:qty 3 :card "Anansi"}
+             {:qty 3 :card "Border Control"}
+             {:qty 2 :card "Excalibur"}
+             {:qty 2 :card "IP Block"}
+             {:qty 3 :card "Kakugo"}
+             {:qty 1 :card "Macrophage"}
+             {:qty 2 :card "Thimblerig"}]
+            "https://netrunnerdb.com/en/decklist/05aa8a53-d7ad-43c5-8b11-34e6beffcfcb")
+    (precon "Classique 2026: Whiteblade Liza"
+            {:title "Liza Talking Thunder: Prominent Legislator" :side "Runner" :code "22008"}
+            [{:qty 3 :card "Dirty Laundry"}
+             {:qty 3 :card "Diversion of Funds"}
+             {:qty 3 :card "Hot Pursuit"}
+             {:qty 2 :card "Legwork"}
+             {:qty 1 :card "Special Order"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 1 :card "Lucky Charm"}
+             {:qty 3 :card "Paragon"}
+             {:qty 1 :card "\"Baklan\" Bochkin"}
+             {:qty 2 :card "Counter Surveillance"}
+             {:qty 1 :card "Drug Dealer"}
+             {:qty 3 :card "Dummy Box"}
+             {:qty 3 :card "PAD Tap"}
+             {:qty 3 :card "Paparazzi"}
+             {:qty 3 :card "Rogue Trading"}
+             {:qty 3 :card "Street Peddler"}
+             {:qty 3 :card "The Class Act"}
+             {:qty 3 :card "Wireless Net Pavilion"}
+             {:qty 3 :card "Aumakua"}
+             {:qty 3 :card "Femme Fatale"}]
+            "https://netrunnerdb.com/en/decklist/5efe66b5-a80d-489b-818e-7ebd6d783153")))
+
+(def classique-2026-death-rattle-ctm-vs-internet-famous-smoke
+  (matchup
+    [:preconstructed.classique-2026-d "Classique 2026: Death Rattle CtM (C) vs. Internet Famous Smoke (R)"]
+    [:preconstructed.classique-2026-d-tag "Death Rattle CtM (C) vs. Internet Famous Smoke (R)"]
+    [:preconstructed.classique-info classique-blurb]
+    [:preconstructed.classique-2026-d-ul "Classique 2026: Death Rattle CtM vs. Internet Famous Smoke"]
+    (precon "Classique 2026: Death Rattle CtM"
+            {:title "NBN: Controlling the Message" :side "Corp" :code "11017"}
+            [{:qty 1 :card "AstroScript Pilot Program"}
+             {:qty 3 :card "Breaking News"}
+             {:qty 3 :card "Global Food Initiative"}
+             {:qty 3 :card "Project Beale"}
+             {:qty 3 :card "Jackson Howard"}
+             {:qty 2 :card "PAD Campaign"}
+             {:qty 3 :card "Sensie Actors Union"}
+             {:qty 2 :card "Mumbad Virtual Tour"}
+             {:qty 2 :card "SanSan City Grid"}
+             {:qty 1 :card "Biotic Labor"}
+             {:qty 2 :card "Closed Accounts"}
+             {:qty 2 :card "Exchange of Information"}
+             {:qty 2 :card "Hard-Hitting News"}
+             {:qty 3 :card "Hedge Fund"}
+             {:qty 1 :card "Psychographics"}
+             {:qty 3 :card "Sweeps Week"}
+             {:qty 2 :card "Archangel"}
+             {:qty 1 :card "Cobra"}
+             {:qty 1 :card "Data Ward"}
+             {:qty 1 :card "IP Block"}
+             {:qty 2 :card "Pop-up Window"}
+             {:qty 1 :card "Quandary"}
+             {:qty 2 :card "Resistor"}
+             {:qty 1 :card "Tollbooth"}
+             {:qty 1 :card "Turnpike"}
+             {:qty 1 :card "Wraparound"}]
+            "https://netrunnerdb.com/en/decklist/ae53c577-1b0b-4360-a6ab-1b310bdc3ae3")
+    (precon "Classique 2026: Internet Famous Smoke"
+            {:title "Ele \"Smoke\" Scovak: Cynosure of the Net" :side "Runner" :code "11066"}
+            [{:qty 1 :card "\"Freedom Through Equality\""}
+             {:qty 3 :card "Diesel"}
+             {:qty 3 :card "Dirty Laundry"}
+             {:qty 2 :card "Indexing"}
+             {:qty 3 :card "Sure Gamble"}
+             {:qty 2 :card "Astrolabe"}
+             {:qty 2 :card "Clone Chip"}
+             {:qty 1 :card "R&D Interface"}
+             {:qty 1 :card "Beth Kilrain-Chang"}
+             {:qty 2 :card "Daily Casts"}
+             {:qty 1 :card "Film Critic"}
+             {:qty 1 :card "Ghost Runner"}
+             {:qty 1 :card "Hunting Grounds"}
+             {:qty 2 :card "Net Mercur"}
+             {:qty 2 :card "New Angeles City Hall"}
+             {:qty 1 :card "Patron"}
+             {:qty 3 :card "Temüjin Contract"}
+             {:qty 2 :card "Cloak"}
+             {:qty 1 :card "Clot"}
+             {:qty 1 :card "Corroder"}
+             {:qty 1 :card "Houdini"}
+             {:qty 3 :card "Self-modifying Code"}
+             {:qty 1 :card "Switchblade"}]
+            "https://netrunnerdb.com/en/decklist/1c7ffb1d-f12e-4b4f-bb7e-22d972683cf1")))
+
 ;; Utility
 
 (defn matchup-by-key
@@ -1735,7 +2661,23 @@
     :worlds-2024-a worlds-2024-deer-runs
     :worlds-2024-b worlds-2024-deer-corps
     :worlds-2025-a worlds-2025-zomzraft-runs
-    :worlds-2025-b worlds-2025-zomzraft-corps))
+    :worlds-2025-b worlds-2025-zomzraft-corps
+    :classique-2022-a classique-2022-foodcoats-vs-book-of-kate
+    :classique-2022-b classique-2022-grail-neh-vs-endless-waltz
+    :classique-2022-c classique-2022-ctm-vs-reg-whizz
+    :classique-2022-d classique-2022-supermodernism-argus-vs-crowdfunding-val
+    :classique-2023-a classique-2023-panic-palana-vs-noise-shop
+    :classique-2023-b classique-2023-tablet-asa-vs-core-set-waltz
+    :classique-2023-c classique-2023-fastrobiotics-vs-ppvp-kate
+    :classique-2023-d classique-2023-supermodernism-argus-vs-crowdfunding-val
+    :classique-2025-a classique-2025-cambridge-pe-vs-classic-andy
+    :classique-2025-b classique-2025-ctm-vs-reg-whizz
+    :classique-2025-c classique-2025-reversed-stinson-ci-vs-german-geist
+    :classique-2025-d classique-2025-seamusmodernism-vs-pitchfork-hayley
+    :classique-2026-a classique-2026-come-on-and-slam-vs-clanaxx
+    :classique-2026-b classique-2026-battyshop-blue-sun-vs-trash-panda-freedom
+    :classique-2026-c classique-2026-post-scarcity-palana-vs-whiteblade-liza
+    :classique-2026-d classique-2026-death-rattle-ctm-vs-internet-famous-smoke))
 
 (def all-matchups
   "A set of all preconstructed matchups (by key).
@@ -1753,4 +2695,12 @@
     :worlds-2022-a :worlds-2022-b
     :worlds-2023-a :worlds-2023-b
     :worlds-2024-a :worlds-2024-b
-    :worlds-2025-a :worlds-2025-b})
+    :worlds-2025-a :worlds-2025-b
+    :classique-2022-a :classique-2022-b
+    :classique-2022-c :classique-2022-d
+    :classique-2023-a :classique-2023-b
+    :classique-2023-c :classique-2023-d
+    :classique-2025-a :classique-2025-b
+    :classique-2025-c :classique-2025-d
+    :classique-2026-a :classique-2026-b
+    :classique-2026-c :classique-2026-d})

--- a/src/cljc/jinteki/preconstructed.cljc
+++ b/src/cljc/jinteki/preconstructed.cljc
@@ -233,7 +233,7 @@
              {:qty 2 :card "Desperado"}
              {:qty 2 :card "Lemuria Codecracker"}
              {:qty 2 :card "Decoy"}
-             {:qty 1 :card "Crashspace"}
+             {:qty 1 :card "Crash Space"}
              {:qty 3 :card "Armitage Codebusting"}
              {:qty 2 :card "Bank Job"}])))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -11,6 +11,7 @@
                            get-counters get-title has-subtype? ice? program? rezzed?
                            same-card? operation? condition-counter?]]
    [jinteki.cards :refer [all-cards]]
+   [jinteki.preconstructed :refer [matchup-by-key]]
    [jinteki.utils :refer [add-cost-to-label is-tagged? select-non-nil-keys
                           str->int] :as utils]
    [nr.appstate :refer [app-state current-gameid]]
@@ -28,7 +29,8 @@
    [nr.translations :refer [tr tr-data tr-game-prompt tr-side tr-element tr-span]]
    [nr.utils :refer [banned-span card-colors-class card-colors-custom-style
                      checkbox-button cond-button get-image-path
-                     image-or-face map-longest render-icons render-message]]
+                     image-or-face map-longest precon-decklist-links
+                     render-icons render-message]]
    [nr.ws :as ws]
    [jinteki.card-backs :as card-backs]
    [reagent.core :as r]))
@@ -1452,9 +1454,12 @@
       (when (and @show-decklists
                  (get-in @game-state [:decklists]))
         (let [corp-list (or (get-in @game-state [:decklists :corp]) {:- 1})
-              runner-list (or (get-in @game-state [:decklists :runner]) {:- 1})]
+              runner-list (or (get-in @game-state [:decklists :runner]) {:- 1})
+              precon (get-in @app-state [:current-game :precon])]
           [:div.decklists.blue-shade
            [:br]
+           (when precon
+             [precon-decklist-links (matchup-by-key precon)])
            [build-in-game-decklists corp-list runner-list]])))))
 
 (defn build-start-box

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1458,8 +1458,8 @@
               precon (get-in @app-state [:current-game :precon])]
           [:div.decklists.blue-shade
            [:br]
-           (when precon
-             [precon-decklist-links (matchup-by-key precon)])
+           (when-let [links (when precon (precon-decklist-links (matchup-by-key precon)))]
+             [:p links])
            [build-in-game-decklists corp-list runner-list]])))))
 
 (defn build-start-box

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -5,7 +5,7 @@
     [nr.appstate :refer [app-state]]
     [nr.auth :refer [authenticated] :as auth]
     [nr.translations :refer [tr tr-format tr-side tr-element tr-span]]
-    [nr.utils :refer [cond-button focus-on-mount slug->format]]
+    [nr.utils :refer [cond-button focus-on-mount precon-decklist-links slug->format]]
     [nr.ws :as ws]
     [reagent.core :as r]))
 
@@ -109,7 +109,9 @@
 (defn precon-choice [fmt-state precon]
   [:div
    {:style {:display (if (= @fmt-state "preconstructed") "block" "none")}}
-   [:span (str "Decks:     " (tr (:tr-underline (matchup-by-key (keyword @precon)))))]
+   (let [matchup (matchup-by-key (keyword @precon))]
+     [:span "Decks:     " (or (precon-decklist-links matchup)
+                              (tr (:tr-underline matchup)))])
    [:div
     [:label "Match:    "]
     [:select.precon

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -11,7 +11,7 @@
     [nr.player-view :refer [player-view]]
     [nr.translations :refer [tr tr-element tr-element-with-embedded-content tr-span tr-side]]
     [nr.utils :refer [cond-button format-date-time mdy-formatter
-                      tr-non-game-toast non-game-toast]]
+                      precon-decklist-links tr-non-game-toast non-game-toast]]
     [nr.ws :as ws]
     [reagent-modals.modals :as reagent-modals]
     [reagent.core :as r]
@@ -102,8 +102,10 @@
 
 (defn precon-info-box [current-game]
   (when-let [precon (:precon @current-game)]
-    [:div.infobox.blue-shade
-     [tr-element :p (:tr-desc (matchup-by-key precon))]]))
+    (let [matchup (matchup-by-key precon)]
+      [:div.infobox.blue-shade
+       [tr-element :p (:tr-desc matchup)]
+       [precon-decklist-links matchup]])))
 
 (defn chimera-info-box [current-game]
   (when (= "chimera" (:format @current-game))

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -105,7 +105,8 @@
     (let [matchup (matchup-by-key precon)]
       [:div.infobox.blue-shade
        [tr-element :p (:tr-desc matchup)]
-       [precon-decklist-links matchup]])))
+       (when-let [links (precon-decklist-links matchup)]
+         [:p links])])))
 
 (defn chimera-info-box [current-game]
   (when (= "chimera" (:format @current-game))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -414,7 +414,7 @@
   "Links to the published decklists of a precon matchup, when it has them"
   [{:keys [corp runner]}]
   (when (and (:decklist corp) (:decklist runner))
-    [:p
+    [:span
      [:a {:href (:decklist corp) :target "_blank"} (:name corp)]
      " vs. "
      [:a {:href (:decklist runner) :target "_blank"} (:name runner)]]))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -410,6 +410,15 @@
      [:button (merge {:on-click f :key text} attrs) text]
      [:button.disabled (merge {:key text} attrs) text])))
 
+(defn precon-decklist-links
+  "Links to the published decklists of a precon matchup, when it has them"
+  [{:keys [corp runner]}]
+  (when (and (:decklist corp) (:decklist runner))
+    [:p
+     [:a {:href (:decklist corp) :target "_blank"} (:name corp)]
+     " vs. "
+     [:a {:href (:decklist runner) :target "_blank"} (:name runner)]]))
+
 (defn checkbox-button [on-text off-text on-cond f]
   (if on-cond
     [:button.on {:on-click f :key on-text} on-text]

--- a/test/clj/jinteki/preconstructed_test.clj
+++ b/test/clj/jinteki/preconstructed_test.clj
@@ -1,0 +1,27 @@
+(ns jinteki.preconstructed-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.test :refer [deftest is]]
+   [jinteki.preconstructed :refer [all-matchups matchup-by-key
+                                   gateway-beginner-corp gateway-beginner-runner
+                                   gateway-intermediate-corp gateway-intermediate-runner]]))
+
+(def card-titles
+  (->> (slurp "data/cards.edn")
+       (edn/read-string)
+       (map :title)
+       (set)))
+
+(def all-decks
+  (concat [gateway-beginner-corp gateway-beginner-runner
+           gateway-intermediate-corp gateway-intermediate-runner]
+          (mapcat #(let [{:keys [corp runner]} (matchup-by-key %)] [corp runner])
+                  (sort all-matchups))))
+
+(deftest precon-cards-exist
+  (doseq [{:keys [cards] deck-name :name id :identity} all-decks]
+    (is (contains? card-titles (:title id))
+        (str deck-name ": unknown identity " (:title id)))
+    (doseq [{:keys [card]} cards]
+      (is (contains? card-titles card)
+          (str deck-name ": unknown card " card)))))


### PR DESCRIPTION
Adds the classique precons to the preconstructed decklists. It shows up like this:

<img width="1206" height="1988" alt="CleanShot 2026-08-16 at 19 09 01@2x" src="https://github.com/user-attachments/assets/0dfb5328-81d5-478d-a221-c598c5f909b6" />

On the new lobby, lobby, and when showing decklists you'll see a link the the nrdb decklist, so you can read up on deck strategy (e.g. for [Whiteblade Liza](https://netrunnerdb.com/en/decklist/5efe66b5-a80d-489b-818e-7ebd6d783153/-classique-2026-whiteblade-liza)):

<img width="1044" height="300" alt="CleanShot 2026-08-16 at 19 37 55@2x" src="https://github.com/user-attachments/assets/0c70dbf3-afc7-4f85-a42c-e75acd3be239" />

<img width="1226" height="926" alt="CleanShot 2026-08-16 at 19 13 34@2x" src="https://github.com/user-attachments/assets/ef274f5f-3fd8-4354-a858-6f5c437e57a9" />

<img width="846" height="1396" alt="CleanShot 2026-08-16 at 19 15 06@2x" src="https://github.com/user-attachments/assets/7b8a08ca-720e-4d33-a5ba-ec77f83649a9" />

Fix https://github.com/mtgred/netrunner/issues/8825