### PR TITLE
Move :last-update to a standalone ConcurrentHashMap

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  :init-ns web.dev
                  :init (go)}
 
-  :dependencies [[org.clojure/clojure "1.12.4"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/clojurescript "1.11.132"
                   :exclusions [org.clojure/google-closure-library
                                org.clojure/data.json
@@ -29,13 +29,13 @@
                  [org.clojure/core.async "1.7.701"]
                  [com.taoensso/sente "1.22.0"]
                  [com.taoensso/timbre "6.8.0"]
-                 [ring/ring-core "1.9.4"]
-                 [ring/ring-devel "1.9.4" :exclusions [org.clojure/java.classpath]]
-                 [ring/ring-anti-forgery "1.3.0"]
+                 [com.taoensso/tufte "3.1.0"]
+                 [ring/ring-core "1.15.5"]
+                 [ring/ring-devel "1.15.5"]
+                 [ring/ring-anti-forgery "1.4.0"]
                  [ring/ring-json "0.5.1"]
                  [ring-cors "0.1.13"]
-                 [compojure "1.6.2"]
-                 [hiccup "1.0.5"]
+                 [hiccup "2.0.0"]
                  [aero "1.1.6"]
                  [cheshire/cheshire "5.10.1"]
                  [stylefruits/gniazdo "1.2.0"]
@@ -49,7 +49,6 @@
                  [http-kit "2.7.0"]
                  [com.draines/postal "2.0.5"]
                  [throttler "1.0.1"]
-                 [clj-http "3.12.3"]
                  [reagent "1.3.0"]
                  [org.clojure/tools.analyzer "1.1.0"]
                  [org.clojure/tools.analyzer.jvm "1.2.1"]
@@ -57,7 +56,7 @@
                  [org.clojure/tools.cli "1.0.206"]
                  [danlentz/clj-uuid "0.1.9"]
                  [potemkin "0.4.5"]
-                 [cond-plus "1.1.1"]
+                 [com.noahbogart/cond-plus "1.4.0"]
                  [org.clojure/data.csv "1.0.0"]
                  [dev.weavejester/medley "1.8.0"]
                  [org.clj-commons/claypoole "1.2.2"]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1,7 +1,7 @@
 (ns game.cards.upgrades
   (:require
    [clojure.string :as str]
-   [cond-plus.core :refer [cond+]]
+   [com.noahbogart.cond-plus :refer [cond+]]
    [game.core.access :refer [access-bonus set-only-card-to-access
                              installed-access-trigger
                              steal-cost-bonus]]

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -1,6 +1,6 @@
 (ns game.core.diffs
   (:require
-   [cond-plus.core :refer [cond+]]
+   [com.noahbogart.cond-plus :refer [cond+]]
    [differ.core :as differ]
    [game.core.board :refer [installable-servers]]
    [game.core.card :refer :all]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1,9 +1,8 @@
 (ns game.core.engine
   (:require
     [clj-uuid :as uuid]
-    [clojure.stacktrace :refer [print-stack-trace]]
     [clojure.string :as string]
-    [cond-plus.core :refer [cond+]]
+    [com.noahbogart.cond-plus :refer [cond+]]
     [game.core.board :refer [clear-empty-remotes get-all-cards all-installed all-installed-runner
                              all-installed-runner-type all-active-installed]]
     [game.core.card :refer [active? facedown? faceup? get-card get-cid get-title ice? in-discard? in-hand? in-rfg? in-set-aside? installed? rezzed? program? console? unique?]]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -1,6 +1,6 @@
 (ns game.core.installing
   (:require
-    [cond-plus.core :refer [cond+]]
+    [com.noahbogart.cond-plus :refer [cond+]]
     [clojure.string :as string]
     [game.core.agendas :refer [update-advancement-requirement]]
     [game.core.board :refer [all-installed get-remotes installable-servers server->zone all-installed-runner-type]]

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -1,6 +1,6 @@
 (ns game.core.memory
   (:require
-   [cond-plus.core :refer [cond+]]
+   [com.noahbogart.cond-plus :refer [cond+]]
    [game.core.card :refer [has-subtype? virus-program? program?]]
    [game.core.card-defs :refer [card-def]]
    [game.core.eid :refer [make-eid]]

--- a/src/clj/game/core/winning.clj
+++ b/src/clj/game/core/winning.clj
@@ -2,7 +2,7 @@
   (:require
    [cljc.java-time.duration :as duration]
    [cljc.java-time.instant :as inst]
-   [cond-plus.core :refer [cond+]]
+   [com.noahbogart.cond-plus :refer [cond+]]
    [game.core.effects :refer [any-effects sum-effects]]
    [game.core.say :refer [play-sfx system-msg system-say]]
    [game.utils :refer [dissoc-in]]

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -27,6 +27,9 @@
 (defn set-last-update [gameid]
   (ConcurrentHashMap/.put last-updates gameid (inst/now)))
 
+(defn remove-last-update [gameid]
+  (ConcurrentHashMap/.remove last-updates gameid))
+
 (defonce lobby-subs-timeout-hours 1)
 
 (defn register-user

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -1,10 +1,16 @@
 (ns web.app-state
   (:require
-   [clojure.core.async :refer [<! go timeout]]
-   [cljc.java-time.temporal.chrono-unit :as chrono]
    [cljc.java-time.instant :as inst]
-   [taoensso.encore :as enc]
-   [medley.core :refer [dissoc-in find-first]]))
+   [cljc.java-time.temporal.chrono-unit :as chrono]
+   [clojure.core.async :refer [<! go timeout]]
+   [differ.core :as differ]
+   [medley.core :refer [dissoc-in find-first]]
+   [taoensso.encore :as enc])
+  (:import
+   [java.time Instant]
+   [java.util.concurrent ConcurrentHashMap]))
+
+(set! *warn-on-reflection* true)
 
 (defonce app-state
   (atom {:lobbies {}
@@ -12,6 +18,14 @@
          :tournament nil
          :block-game-creation false
          :users {}}))
+
+(defonce last-updates (ConcurrentHashMap/new))
+
+(defn get-last-update [gameid]
+  (ConcurrentHashMap/.get last-updates gameid))
+
+(defn set-last-update [gameid]
+  (ConcurrentHashMap/.put last-updates gameid (inst/now)))
 
 (defonce lobby-subs-timeout-hours 1)
 
@@ -73,7 +87,7 @@
   "checks if a user receives lobby updates, and updates the state if they've timed out to amortize subsequent checks. Mutates"
   [uid]
   (if-let [last-ping (get-in @app-state [:lobby-updates uid])]
-    (if (.isBefore (inst/now) (inst/plus last-ping lobby-subs-timeout-hours chrono/hours))
+    (if (Instant/.isBefore (inst/now) (inst/plus last-ping lobby-subs-timeout-hours chrono/hours))
       true
       (do (pause-lobby-updates uid) nil))
     (do (pause-lobby-updates uid) nil)))

--- a/src/clj/web/diffs.clj
+++ b/src/clj/web/diffs.clj
@@ -37,7 +37,7 @@
   "Strips private server information from a game map, preparing to send the game to clients."
   [full-game game-update]
   (-> game-update
-    (dissoc :state :last-update :on-close)
+    (dissoc :state :on-close)
     (update-if-contains :password (fn [_] true))
     (update-if-contains :players #(map (partial user-public-view full-game) %))
     (update-if-contains :original-players #(map (partial user-public-view full-game) %))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -3,7 +3,7 @@
    [cheshire.core :as json]
    [cljc.java-time.instant :as inst]
    [clojure.string :as str]
-   [cond-plus.core :refer [cond+]]
+   [com.noahbogart.cond-plus :refer [cond+]]
    [game.core.commands :as commands :refer [parse-command]]
    [game.core.diffs :as diffs]
    [game.core.finding :refer [find-latest]]
@@ -172,7 +172,6 @@
                   :original-players players
                   :ending-players players
                   :start-date now
-                  :last-update now
                   :state (init-game g)})
         (if (not (empty? replay-record))
           (replay-restore/handle-replay-state g replay-record replay-timestamp)
@@ -181,19 +180,13 @@
         (update g :players #(mapv strip-deck %))
         (assoc lobbies gameid g))
       (catch Exception e
-        (if (not (empty? replay-record))
-          (let [message (make-message {:user {:username "ERROR DURING REPLAY RESTORATION" :uid "ERROR DURING REPLAY RESTORATION"}
-                                       :text (str (.getMessage e))})]
-            (timbre/info (str "Error during replay restoration: " (.getMessage e) "\n" (str/join "\n" (map str (.getStackTrace e)))))
-            (-> lobbies
-                (lobby/handle-send-message gameid message)
-                (lobby/handle-set-last-update gameid "ERROR DURING REPLAY RESTORATION")))
-          (let [message (make-message {:user {:username "ERROR STARTING A GAME" :uid "ERROR STARTING A GAME"}
-                                           :text (str (.getMessage e))})]
+        (if (empty? replay-record)
+          (let [message (make-system-message (str "ERROR STARTING A GAME: " (ex-message e)))]
             (timbre/info e "Error starting a game")
-            (-> lobbies
-                (lobby/handle-send-message gameid message)
-                (lobby/handle-set-last-update gameid "ERROR STARTING A GAME"))))))
+            (lobby/handle-send-message lobbies gameid message))
+          (let [message (make-system-message (str "ERROR DURING REPLAY RESTORATION:" (ex-message e)))]
+            (timbre/info e "Error during replay restoration")
+            (lobby/handle-send-message lobbies gameid message)))))
     lobbies))
 
 (defn try-start-game
@@ -208,6 +201,7 @@
                    update :lobbies handle-start-game gameid players now replay-record replay-timestamp)
             lobby? (get-in new-app-state [:lobbies gameid])]
         (when lobby?
+          (app-state/set-last-update gameid)
           (stats/game-started db lobby?)
           (lobby/send-lobby-state lobby?)
           (lobby/broadcast-lobby-list)
@@ -305,8 +299,7 @@
            (let [old-state @state
                  side (side-from-str (:side player))]
              (try
-               (swap! app-state/app-state
-                      update :lobbies lobby/handle-set-last-update gameid uid)
+               (app-state/set-last-update gameid)
                (update-and-send-diffs! main/handle-action lobby side command args)
                (catch Exception e
                  (reset! state old-state)
@@ -373,13 +366,12 @@
              watch-message (make-system-message watch-str)
              new-app-state (swap! app-state/app-state
                                   update :lobbies
-                                  #(-> %
-                                       (lobby/handle-watch-lobby gameid uid user correct-password? watch-message request-side)
-                                       (lobby/handle-set-last-update gameid uid)))
+                                  lobby/handle-watch-lobby gameid uid user correct-password? watch-message request-side)
              lobby? (get-in new-app-state [:lobbies gameid])]
          (cond
            (and lobby? (lobby/spectator? uid lobby?) (lobby/allowed-in-lobby user lobby?))
            (do
+             (app-state/set-last-update gameid)
              (lobby/send-lobby-state lobby?)
              (lobby/send-lobby-ting lobby?)
              (lobby/broadcast-lobby-list)
@@ -399,13 +391,12 @@
     {gameid :gameid} :?data
     id :id
     timestamp :timestamp}]
-  (let [new-app-state (swap! app-state/app-state update :lobbies #(-> %
-                                                                      (lobby/handle-toggle-spectator-mute gameid uid)
-                                                                      (lobby/handle-set-last-update gameid uid)))
+  (let [new-app-state (swap! app-state/app-state update :lobbies lobby/handle-toggle-spectator-mute gameid uid)
         {:keys [state mute-spectators] :as lobby?} (get-in new-app-state [:lobbies gameid])
         message (if mute-spectators "muted" "unmuted")]
     ;; assert thread pool works like I think
     (when (and lobby? state (lobby/player? uid lobby?))
+      (app-state/set-last-update gameid)
       (lobby/game-thread
        lobby?
        (handle-message-and-send-diffs! lobby? nil nil (str (:username user) " " message " spectators."))
@@ -420,12 +411,13 @@
     {:keys [gameid msg]} :?data
     id :id
     timestamp :timestamp}]
-  (let [new-app-state (swap! app-state/app-state update :lobbies lobby/handle-set-last-update gameid uid)
+  (let [new-app-state (app-state/get-lobby gameid)
         {:keys [state mute-spectators] :as lobby?} (get-in new-app-state [:lobbies gameid])
         side (cond+
               [(lobby/player? uid lobby?) :> #(side-from-str (:side %))]
               [(and (not mute-spectators) (lobby/spectator? uid lobby?)) :spectator])]
     (when (and lobby? state side)
+      (app-state/set-last-update gameid)
       (lobby/game-thread
        lobby?
        (handle-message-and-send-diffs! lobby? side user msg)
@@ -479,10 +471,7 @@
     (swap! state assoc-in [:corp :user] old-runner)
     (swap! state assoc-in [:corp :options] old-runner-options)
     (lobby/lobby-thread
-     (let [new-app-state (swap! app-state/app-state
-                                update :lobbies
-                                #(-> %
-                                     (handle-swap-sides-in-prog gameid)))
+     (let [new-app-state (swap! app-state/app-state update :lobbies handle-swap-sides-in-prog gameid)
            lobby? (get-in new-app-state [:lobbies gameid])]
        (lobby/send-lobby-state lobby?)
        (lobby/broadcast-lobby-list)))))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -19,8 +19,7 @@
    [web.lobby :as lobby]
    [web.replay-restore :as replay-restore]
    [web.stats :as stats]
-   [web.ws :as ws]
-   [game.core :refer [make-message]]))
+   [web.ws :as ws]))
 
 (defn game-diff-json
   "Converts the appropriate diff to json"
@@ -411,8 +410,7 @@
     {:keys [gameid msg]} :?data
     id :id
     timestamp :timestamp}]
-  (let [new-app-state (app-state/get-lobby gameid)
-        {:keys [state mute-spectators] :as lobby?} (get-in new-app-state [:lobbies gameid])
+  (let [{:keys [state mute-spectators] :as lobby?} (app-state/get-lobby gameid)
         side (cond+
               [(lobby/player? uid lobby?) :> #(side-from-str (:side %))]
               [(and (not mute-spectators) (lobby/spectator? uid lobby?)) :spectator])]
@@ -452,13 +450,12 @@
 
 (defn handle-swap-sides-in-prog [lobbies gameid]
   (if-let [lobby (get lobbies gameid)]
-    (do
-      (-> lobby
-          ;; note - original-players needs to be updated so that you rejoin the game
-          ;; on the correct side if you leave/rejoin
-          (update :original-players #(mapv switch-side %))
-          (update :players #(mapv switch-side %))
-          (->> (assoc lobbies gameid))))
+    (-> lobby
+        ;; note - original-players needs to be updated so that you rejoin the game
+        ;; on the correct side if you leave/rejoin
+        (update :original-players #(mapv switch-side %))
+        (update :players #(mapv switch-side %))
+        (->> (assoc lobbies gameid)))
     lobbies))
 
 (defn switch-side-for-lobby

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -118,7 +118,6 @@
                 :side side}]
     {:gameid gameid
      :date now
-     :last-update now
      :players [player]
      :spectators []
      :corp-spectators []
@@ -367,6 +366,7 @@
                              register-lobby lobby uid)
         lobby? (get-in new-app-state [:lobbies (:gameid lobby)])]
     (when lobby?
+      (app-state/set-last-update (:gameid lobby?))
       (assign-tournament-properties lobby?)
       (send-lobby-state lobby?)
       (broadcast-lobby-list))))
@@ -437,12 +437,6 @@
   [uid lobby]
   (or (player? uid lobby)
       (spectator? uid lobby)))
-
-(defn handle-set-last-update [lobbies gameid uid]
-  (let [lobby (get lobbies gameid)]
-    (if (and lobby (in-lobby? uid lobby))
-      (assoc-in lobbies [gameid :last-update] (inst/now))
-      lobbies)))
 
 (defn handle-leave-lobby [lobbies uid leave-message]
   (if-let [lobby (app-state/uid->lobby lobbies uid)]
@@ -590,10 +584,10 @@
               processed-deck (process-deck raw-deck)
               new-app-state
               (swap! app-state/app-state
-                     update :lobbies #(-> %
-                                          (handle-select-deck uid processed-deck)
-                                          (handle-set-last-update (:gameid lobby) uid)))
+                     update :lobbies handle-select-deck uid processed-deck)
               lobby? (get-in new-app-state [:lobbies (:gameid lobby)])]
+          (when lobby?
+            (app-state/set-last-update gameid))
           (send-lobby-state lobby?)
           ;;(broadcast-lobby-list)
           (?reply-fn (some #(= processed-deck (:deck %)) (:players lobby?))))
@@ -620,10 +614,10 @@
       (when (and lobby (in-lobby? uid lobby))
         (let [message (core/make-message {:user user :text text})
               new-app-state (swap! app-state/app-state
-                                   update :lobbies #(-> %
-                                                        (handle-send-message gameid message)
-                                                        (handle-set-last-update gameid uid)))
+                                   update :lobbies handle-send-message gameid message)
               lobby? (get-in new-app-state [:lobbies gameid])]
+          (when lobby?
+            (app-state/set-last-update (:gameid lobby?)))
           (send-lobby-state lobby?))))
     (log-delay! timestamp id)))
 
@@ -773,9 +767,10 @@
                                                :text (swap-text (:players lobby) side)})
               new-app-state (swap! app-state/app-state
                                    update :lobbies
-                                   #(-> (handle-swap-sides db % gameid uid side swap-message)
-                                        (handle-set-last-update gameid uid)))
+                                   #(handle-swap-sides db % gameid uid side swap-message))
               lobby? (get-in new-app-state [:lobbies gameid])]
+          (when lobby?
+            (app-state/set-last-update (:gameid lobby?)))
           (send-lobby-state lobby?)
           (broadcast-lobby-list))))
     (log-delay! timestamp id)))
@@ -853,7 +848,8 @@
   "Called by a background thread to close lobbies that are inactive for some number of seconds."
   [db time-inactive]
   (let [changed? (volatile! false)]
-    (doseq [{:keys [gameid last-update started] :as lobby} (app-state/get-lobbies)]
+    (doseq [{:keys [gameid started] :as lobby} (app-state/get-lobbies)
+            :let [last-update (app-state/get-last-update gameid)]]
       (when (and gameid
                  (inst/is-after (inst/now) (inst/plus-seconds last-update (- time-inactive 30)))
                  (not (inst/is-after (inst/now) (inst/plus-seconds last-update (- time-inactive 29)))))
@@ -909,13 +905,12 @@
         (let [correct-password? (check-password lobby user password)
               watch-message (core/make-system-message (str (:username user) " joined the game as a spectator" (when request-side (str " (" request-side " perspective)")) "."))
               new-app-state (swap! app-state/app-state
-                                   update :lobbies #(-> %
-                                                        (handle-watch-lobby gameid uid user correct-password? watch-message request-side)
-                                                        (handle-set-last-update gameid uid)))
+                                   update :lobbies handle-watch-lobby gameid uid user correct-password? watch-message request-side)
               lobby? (get-in new-app-state [:lobbies gameid])]
           (cond
             (and lobby? correct-password? (allowed-in-lobby user lobby?))
-            (do (send-lobby-state lobby?)
+            (do (app-state/set-last-update gameid)
+                (send-lobby-state lobby?)
                 (send-lobby-ting lobby?)
                 (broadcast-lobby-list)
                 (when ?reply-fn (?reply-fn 200)))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -465,6 +465,7 @@
      (stats/update-game-stats db lobby)
      (stats/push-stats-update db lobby))
    (swap! app-state/app-state update :lobbies dissoc gameid)
+   (app-state/remove-last-update gameid)
    (doseq [uid (keep :uid (get-players-and-spectators lobby))]
      (clear-lobby-state uid))
    (leave-pool! pool gameid)

--- a/src/clj/web/tournament.clj
+++ b/src/clj/web/tournament.clj
@@ -100,10 +100,10 @@
           (let [timestamp (inst/now)
                 message (core/make-message {:user {:username "TOURNAMENT SCHEDULER" :uid "TOURNAMENT SCHEDULER"} :text msg})
                 new-app-state (swap! app-state/app-state
-                                     update :lobbies #(-> %
-                                                          (lobby/handle-send-message gameid message)
-                                                          (lobby/handle-set-last-update gameid "TOURNAMENT SCHEDULER")))
+                                     update :lobbies lobby/handle-send-message gameid message)
                 lobby? (get-in new-app-state [:lobbies gameid])]
+            (when lobby?
+              (app-state/set-last-update gameid))
             (lobby/send-lobby-state lobby?)
             (lobby/log-delay! timestamp :tournament-alert-lobby)))))))
 

--- a/src/cljs/nr/about.cljs
+++ b/src/cljs/nr/about.cljs
@@ -78,7 +78,7 @@
           [tr-element :h4 [:about_tech-stack "Tech Stack"]]
           [:ul.list.compact
            [:li [tr-element :b [:about_game-engine "Game engine:"]] " Clojure. Card data from " [:a {:href "https://netrunnerdb.com/" :target "_blank"} "NetrunnerDB"] " API."]
-           [:li [tr-element :b [:about_server "Server:"]] " Clojure. Ring and Compojure running on http-kit. Sente for websocket communications."]
+           [:li [tr-element :b [:about_server "Server:"]] " Clojure. Ring and Reitit running on http-kit. Sente for websocket communications."]
            [:li [tr-element :b [:about_front-end-client "Front-end client:"]] " ClojureScript. Reagent (React). "]]
 
           (let [link [:a {:href "https://github.com/mtgred/netrunner/issues" :target "_blank"} [tr-span [:about_url-github "Github"]]]]


### PR DESCRIPTION
We've been updating the `app-state` atom every single time _anyone_ touches anything in a lobby or game. I think this has been driving contention on the atom, so this is the first step towards pulling out some of the more contentious pieces into separate, better pieces that we can update or check without fighting everyone else. ConcurrentHashMap is fast and built to handle loads like this, so it's ideal.