### PR TITLE
Optimize end-of-game queries

### DIFF
--- a/src/clj/tasks/index.clj
+++ b/src/clj/tasks/index.clj
@@ -15,6 +15,12 @@
      ["game-logs" (array-map :gameid 1)]
      ["game-logs" (array-map "corp.player.username" 1 :start-date -1)]
      ["game-logs" (array-map "runner.player.username" 1 :start-date -1)]
+     ["game-logs" (array-map "corp.player.username" 1 :start-date -1)
+      {:name "corp_username_unshared_replay"
+       :partialFilterExpression {:has-replay true :replay-shared false}}]
+     ["game-logs" (array-map "runner.player.username" 1 :start-date -1)
+      {:name "runner_username_unshared_replay"
+       :partialFilterExpression {:has-replay true :replay-shared false}}]
      ["messages" (array-map :channel 1 :date -1)]
      ["messages" (array-map :username 1 :date -1)]
      ["news" (array-map :date -1)]

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -197,10 +197,14 @@
 (defn delete-old-replay
   [db {:keys [username]}]
   (let [games (mq/with-collection db game-log-coll
-                (mq/find {$and [{$or [{:corp.player.username username}
-                                      {:runner.player.username username}]}
-                                {:replay {$exists true}}
-                                {:replay-shared false}]})
+                ;; :has-replay and :replay-shared are repeated in each $or branch
+                ;; so both branches match the partial indexes on game-logs
+                (mq/find {$or [{:corp.player.username username
+                                :has-replay true
+                                :replay-shared false}
+                               {:runner.player.username username
+                                :has-replay true
+                                :replay-shared false}]})
                 (mq/fields [:gameid])
                 (mq/sort (array-map :start-date -1))
                 (mq/skip 15))]

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -32,8 +32,7 @@
 
 (defmethod ws/event-msg-handler :stats/update [{{:keys [userstats deck-id deckstats]} :?data}]
   (swap! app-state assoc :stats userstats)
-  (update-deck-stats deck-id deckstats)
-  (fetch-game-history))
+  (update-deck-stats deck-id deckstats))
 
 (defn- set-replay-shared [state gameid shared?]
   (swap! state (fn [s]


### PR DESCRIPTION
There's two things that happen at the end of a game that can be pretty heavy on mongo.

First is deleting old replays. There's no index for fields, so if a user has a lot of games the query will scan them all. I added indexes to this query to make fetch less docs.

Second is the game history. This is also a pretty heavy, since mongo will still read the documents from disk even though the query has `{:replay 0 :log 0}`. This isn't a big problem since the stats page isn't that common to visit. But it's also fetched at the game end, for no real purpose since going to the stats page fetches it again. I removed the game end fetch. 

Note that deployments will need to call `lein create-indexes` to create the new indexes.

