### PR TITLE
type guard instant

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -26,7 +26,7 @@
    [nr.gameboard.state :refer [game-state not-spectator? replay-side]]
    [nr.sounds :refer [update-audio]]
    [nr.translations :refer [tr tr-data tr-game-prompt tr-side tr-element tr-span]]
-   [nr.utils :refer [banned-span card-colors-class card-colors-custom-style
+   [nr.utils :refer [banned-span card-colors-class card-colors-custom-style ->instant
                      checkbox-button cond-button get-image-path
                      image-or-face map-longest render-icons render-message]]
    [nr.ws :as ws]
@@ -2037,7 +2037,8 @@
 (defn- time-until
   "Helper method for timer. Computes how much time is left until `end`"
   [end]
-  (let [now (inst/now)
+  (let [end (->instant end)
+        now (inst/now)
         diff (duration/between now end)
         total-seconds (duration/get diff chrono/seconds)
         minutes (abs (quot total-seconds 60))

--- a/src/cljs/nr/tournament.cljs
+++ b/src/cljs/nr/tournament.cljs
@@ -8,7 +8,7 @@
    [cljc.java-time.instant :as inst]
    [cljc.java-time.duration :as duration]
    [cljc.java-time.temporal.chrono-unit :as chrono]
-   [nr.utils :refer [cond-button non-game-toast]]
+   [nr.utils :refer [cond-button non-game-toast ->instant]]
    ["react" :as react]
    [reagent.core :as r]
    [clojure.string :as str]))
@@ -180,7 +180,8 @@
 (defn- time-until
   "Helper method for game-time. Computes how many minutes since game start"
   [end]
-  (let [now (inst/now)
+  (let [end (->instant end)
+        now (inst/now)
         diff (duration/between now end)
         total-seconds (duration/get diff chrono/seconds)
         minutes (quot total-seconds 60)

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -4,6 +4,7 @@
    [cljc.java-time.format.date-time-formatter :as formatter]
    [cljc.java-time.zoned-date-time :as zdt]
    [cljc.java-time.zone-id :as zone]
+   [cljc.java-time.instant :as inst]
    [clojure.string :refer [join] :as s]
    [goog.object :as gobject]
    [goog.string :as gstring]
@@ -531,3 +532,14 @@
           local-time (zdt/with-zone-same-instant parsed default-zone)]
       (formatter/format formatter local-time))
     (catch js/Object e "dunno")))
+
+(defn ->instant
+  "Coerce a value to a js-joda Instant.
+   Accepts Instant, JS Date, or anything with a millisecond epoch."
+  [x]
+  (cond
+    (instance? js/java.time.Instant x) x
+    (instance? js/Date x) (inst/of-epoch-milli (.getTime x))
+    (number? x) (inst/of-epoch-milli x)
+    :else (do (prn "cannot convert to instant: " {:value x :type (type x)})
+              (inst/of-epoch-milli 1787702400000))))


### PR DESCRIPTION
Currently, you cannot play tournament games on our live instance. This means our tournament functionality also does not work.
Somewhere along the way, without any code changes, or instants stopped working and it's causing a blackscreen.

I can't reproduce this locally, so I'm trying to add some defensive type coercion to hopefully protect against this for now.