### PR TITLE
fix: default sound to 50%

### DIFF
--- a/src/cljc/jinteki/settings.cljc
+++ b/src/cljc/jinteki/settings.cljc
@@ -375,7 +375,7 @@
     :validate-fn boolean?
     :doc "Enable in-game sound effects on this device"}
    {:key :sounds-volume
-    :default 100
+    :default 50
     :sync? false  ; device-specific
     :validate-fn number?
     :doc "Sound effects volume level (0-100) on this device"}

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -351,7 +351,7 @@
                                  :on-change #(let [checked (.. % -target -checked)]
                                                (when checked
                                                  (play-sfx [(select-random-from-grouping grouping)]
-                                                           {:volume (or (:sounds-volume @s) 50)
+                                                           {:volume (:sounds-volume @s)
                                                             :force true}))
                                                (swap! s assoc-in [:bespoke-sounds grouping] checked))}]
                  [tr-span [:settings_bespoke-sounds group-name] {:sound group-name}]]]))]
@@ -765,7 +765,7 @@
                     :min 1 :max 100 :step 1
                     :on-mouse-up #(play-sfx [(random-sound)] {:volume (int (.. % -target -value))})
                     :on-change #(swap! s assoc :sounds-volume (.. % -target -value))
-                    :value (or (:sounds-volume @s) 50)
+                    :value (:sounds-volume @s)
                     :disabled (not (or (:sounds @s) (:lobby-sounds @s)))}]]
 
           [tr-element :h4 [:settings_layout-device "Device Layout"]]


### PR DESCRIPTION
Some users mentioned it was too loud by default, and code already had a fallback to 50 that was never used.
