### PR TITLE
Keep usernames literal in system messages

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -714,11 +714,13 @@
    indicate-action
    make-message
    make-system-message
+   make-system-message-parts
    play-sfx
    say
    system-msg
    implementation-msg
-   system-say])
+   system-say
+   system-say-parts])
 
 (expose-vars
   [game.core.servers

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -16,7 +16,7 @@
    [game.core.rezzing :refer [derez rez]]
    [game.core.runs :refer [check-for-empty-server continue handle-end-run
                            jack-out start-next-phase toggle-auto-no-action]]
-   [game.core.say :refer [indicate-action say system-msg system-say]]
+   [game.core.say :refer [indicate-action say system-msg system-say-parts]]
    [game.core.set-up :refer [keep-hand mulligan]]
    [game.core.shuffling :refer [shuffle-deck]]
    [game.core.toasts :refer [ack-toast]]
@@ -61,7 +61,9 @@
     (if-let [command (parse-command state text)]
       (when (and (not= side nil) (not= side :spectator) (should-process-command? state side text))
         (command state side)
-        (system-say state side (str "[!]" (:username author) " uses a command: " text)))
+        (system-say-parts
+          state side
+          ["[!]" {:username (:username author)} " uses a command: " text]))
       (say state side args))))
 
 (def commands

--- a/src/clj/game/core/say.clj
+++ b/src/clj/game/core/say.clj
@@ -17,6 +17,20 @@
   [text]
   (make-message {:user "__system__" :text text}))
 
+(defn make-system-message-parts
+  "Creates a system message whose username parts are kept separate from
+  renderable text. The complete text is retained for backwards compatibility."
+  [parts]
+  (assoc
+    (make-system-message
+      (apply str (map #(if (string? %) % (:username %)) parts)))
+    :parts parts))
+
+(defn- username-message-parts [username text]
+  (if username
+    [{:username username} (str " " text)]
+    [text]))
+
 (defn- select-pronoun
   "Selects an appropriate plurular pronoun
   'their' is neuter, so it's appropriate to everyone as a fallback"
@@ -57,6 +71,12 @@
         (str/replace #"\[corp-pronoun\]" corp-pronoun)
         (str/replace #"\[runner-pronoun\]" runner-pronoun))))
 
+(defn- insert-pronouns-in-parts [state side parts]
+  (mapv #(if (string? %)
+           (insert-pronouns state side %)
+           %)
+        parts))
+
 (defn- log
   [state message]
   (swap! state update :log conj message))
@@ -70,16 +90,21 @@
      (let [log-sides (flatten [log-side])]
        (log state (zipmap log-sides (repeat message)))))))
 
-(defn- multi-say
-  [state side message-map]
-  (let [message (update-vals message-map #(make-system-message  (insert-pronouns state side %)))]
-    (log state message)))
-
 (defn system-say
   "Prints a system message to log (`say` from user __system__)"
   ([state side text] (system-say state side text nil))
   ([state side text {:keys [hr log-side]}]
    (say state side (make-system-message (str text (when hr "[hr]"))) (or log-side :public))))
+
+(defn system-say-parts
+  "Prints a structured system message to the log."
+  ([state side parts] (system-say-parts state side parts nil))
+  ([state side parts {:keys [hr log-side]}]
+   (let [parts (cond-> (insert-pronouns-in-parts state side parts)
+                 hr (conj "[hr]"))
+         message (make-system-message-parts parts)
+         log-sides (flatten [(or log-side :public)])]
+     (log state (zipmap log-sides (repeat message))))))
 
 (defn unsafe-say
   "Prints a reagent hiccup directly to the log. Do not use for any user-generated content!"
@@ -92,13 +117,21 @@
   ([state side text] (system-msg state side text nil))
   ([state side text args]
    (let [username (get-in @state [side :user :username])]
-     (system-say state side (str username " " text ".") args))))
+     (system-say-parts
+       state side
+       (username-message-parts username (str text "."))
+       args))))
 
 (defn multi-msg
   [state side message-map]
   (let [username (get-in @state [side :user :username])
-        message-map (update-vals message-map #(str username " " % "."))]
-    (multi-say state side message-map)))
+        messages (update-vals
+                   message-map
+                   #(make-system-message-parts
+                      (insert-pronouns-in-parts
+                        state side
+                        (username-message-parts username (str % ".")))))]
+    (log state messages)))
 
 (defn enforce-msg
   "Prints a message related to a rules enforcement on a given card.

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -2,7 +2,7 @@
   (:require
    [cheshire.generate :refer [add-encoder encode-str]]
    [game.core.process-actions :refer [command-parser process-action]]
-   [game.core.say :refer [system-say]]
+   [game.core.say :refer [system-say system-say-parts]]
    [game.core.toasts :refer [toast]]
    [game.core.winning :refer [concede]]))
 
@@ -36,7 +36,9 @@
 (defn handle-notification
   ([state text]
    (when state
-     (system-say state nil text)))
+     (if (vector? text)
+       (system-say-parts state nil text)
+       (system-say state nil text))))
   ([state _ text] (handle-notification state text))
   ([state _ _ text] (handle-notification state text)))
 
@@ -53,4 +55,6 @@
                     (= _id (get-in @state [:runner :user :_id])) :runner
                     :else nil)]
     (swap! state assoc-in [side :user] user)
-    (handle-notification state (str username " rejoined the game."))))
+    (handle-notification
+      state
+      [{:username username} " rejoined the game."])))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -7,7 +7,7 @@
    [game.core.commands :as commands :refer [parse-command]]
    [game.core.diffs :as diffs]
    [game.core.finding :refer [find-latest]]
-   [game.core.say :refer [make-system-message]]
+   [game.core.say :refer [make-system-message make-system-message-parts]]
    [game.core.set-up :refer [init-game]]
    [game.main :as main]
    [jinteki.chimera :as chimera]
@@ -65,7 +65,10 @@
   Otherwise, adds the message to the log and only diffs the `:log`."
   [{state :state :as lobby} side user message]
   (when (and state @state)
-    (let [message (if (= (str/trim message) "null") " null" message)]
+    (let [message (if (and (string? message)
+                          (= (str/trim message) "null"))
+                    " null"
+                    message)]
       (if (and side user (parse-command state message))
         (update-and-send-diffs! main/handle-say lobby side user message)
         ;; if side is nil, then it's a notification
@@ -236,7 +239,8 @@
        ;; The game will not exist if this is the last player to leave.
        (when-let [lobby? (lobby/leave-lobby! db user uid nil lobby)]
          (handle-message-and-send-diffs!
-          lobby? nil nil (str (:username user) " has left the game.")))
+          lobby? nil nil
+          [(lobby/lobby-username-part lobby uid user) " has left the game."]))
        (lobby/send-lobby-list uid)
        (lobby/broadcast-lobby-list)
        (when ?reply-fn (?reply-fn true))))
@@ -363,8 +367,10 @@
    (let [lobby (app-state/get-lobby gameid)]
      (when (and lobby (lobby/allowed-in-lobby user lobby))
        (let [correct-password? (lobby/check-password lobby user password)
-             watch-str (str (:username user) " joined the game as a spectator" (when request-side (str " (" request-side " perspective)")) ".")
-             watch-message (make-system-message watch-str)
+             watch-parts [{:username (:username user) :spectator true}
+                          (str " joined the game as a spectator"
+                               (when request-side (str " (" request-side " perspective)")) ".")]
+             watch-message (make-system-message-parts watch-parts)
              new-app-state (swap! app-state/app-state
                                   update :lobbies
                                   lobby/handle-watch-lobby gameid uid user correct-password? watch-message request-side)
@@ -376,7 +382,7 @@
              (lobby/send-lobby-state lobby?)
              (lobby/send-lobby-ting lobby?)
              (lobby/broadcast-lobby-list)
-             (main/handle-notification (:state lobby?) watch-str)
+             (main/handle-notification (:state lobby?) watch-parts)
              (send-state-to-uid! uid :game/start lobby? (diffs/public-states (:state lobby?)))
              (when ?reply-fn (?reply-fn 200)))
            (false? correct-password?)
@@ -400,7 +406,9 @@
       (app-state/set-last-update gameid)
       (lobby/game-thread
        lobby?
-       (handle-message-and-send-diffs! lobby? nil nil (str (:username user) " " message " spectators."))
+       (handle-message-and-send-diffs!
+         lobby? nil nil
+         [{:username (:username user)} (str " " message " spectators.")])
        ;; needed to update the status bar
        (lobby/send-lobby-state lobby?)
        (lobby/log-delay! timestamp id)))))
@@ -438,7 +446,8 @@
        ;; The game will not exist if this is the last player to leave.
        (when-let [lobby? (lobby/leave-lobby! db user uid nil lobby)]
          (handle-message-and-send-diffs!
-          lobby? nil nil (str (:username user) " has left the game.")))))
+          lobby? nil nil
+          [(lobby/lobby-username-part lobby uid user) " has left the game."]))))
    (lobby/broadcast-lobby-list)
    (when ?reply-fn (?reply-fn true))
    (lobby/log-delay! timestamp id)))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -362,7 +362,8 @@
   (let [lobby (-> (create-new-lobby {:uid uid :user user :options ?data})
                   (->> (auto-select-decks db))
                   (send-message
-                    (core/make-system-message (str (:username user) " has created the game."))))
+                    (core/make-system-message-parts
+                      [{:username (:username user)} " has created the game."])))
         new-app-state (swap! app-state/app-state update :lobbies
                              register-lobby lobby uid)
         lobby? (get-in new-app-state [:lobbies (:gameid lobby)])]
@@ -473,8 +474,15 @@
    (when (and (not skip-on-close) on-close)
      (on-close lobby))))
 
+(defn lobby-username-part
+  "Captures the user's role from the lobby before departure."
+  [lobby uid user]
+  (cond-> {:username (:username user)}
+    (spectator? uid lobby) (assoc :spectator true)))
+
 (defn leave-lobby! [db user uid ?reply-fn lobby]
-  (let [leave-message (core/make-system-message (str (:username user) " left the game."))
+  (let [leave-message (core/make-system-message-parts
+                        [(lobby-username-part lobby uid user) " left the game."])
         new-app-state (swap! app-state/app-state update :lobbies
                              #(handle-leave-lobby % uid leave-message))
         lobby? (get-in new-app-state [:lobbies (:gameid lobby)])]
@@ -676,7 +684,8 @@
 
 (defn join-lobby! [db user uid ?data ?reply-fn lobby]
   (let [correct-password? (check-password lobby user (:password ?data))
-        join-message (core/make-system-message (str (:username user) " joined the game."))
+        join-message (core/make-system-message-parts
+                       [{:username (:username user)} " joined the game."])
         new-app-state (swap! app-state/app-state update :lobbies
                              #(handle-join-lobby db % ?data uid user correct-password? join-message))
         lobby? (get-in new-app-state [:lobbies (:gameid ?data)])]
@@ -739,8 +748,8 @@
         (->> (assoc lobbies gameid)))
     lobbies))
 
-(defn swap-text
-  "Returns an appropriate message indicating that the players have swapped sides, 
+(defn swap-parts
+  "Returns structured message parts indicating that the players have swapped sides,
   where `player1-side` is the side that host is switching to"
   [players player1-side]
   (let [[player1 player2] (if (> (count players) 1)
@@ -748,12 +757,16 @@
                             (list (change-side (first players) player1-side)))
         player1-username (-> player1 :user :username)
         player2-username (-> player2 :user :username)]
-    (str player1-username " has swapped sides. "
-         (if (= player1-side "Any Side")
-           "Waiting for opponent."
-           (str player1-username " is now " (:side player1) ". "))
-         (when player2
-           (str player2-username " is now " (:side player2) ".")))))
+    (vec
+      (concat
+        [{:username player1-username} " has swapped sides. "]
+        (if (= player1-side "Any Side")
+          ["Waiting for opponent."]
+          [{:username player1-username}
+           (str " is now " (:side player1) ". ")])
+        (when player2
+          [{:username player2-username}
+           (str " is now " (:side player2) ".")])))))
 
 (defmethod ws/-msg-handler :lobby/swap
   lobby--swap
@@ -765,8 +778,8 @@
   (lobby-thread
     (let [lobby (app-state/get-lobby gameid)]
       (when (and lobby (first-player? uid lobby))
-        (let [swap-message (core/make-message {:user user
-                                               :text (swap-text (:players lobby) side)})
+        (let [swap-message (core/make-system-message-parts
+                             (swap-parts (:players lobby) side))
               new-app-state (swap! app-state/app-state
                                    update :lobbies
                                    #(handle-swap-sides db % gameid uid side swap-message))
@@ -911,7 +924,10 @@
     (let [lobby (app-state/get-lobby gameid)]
       (when (and lobby (allowed-in-lobby user lobby))
         (let [correct-password? (check-password lobby user password)
-              watch-message (core/make-system-message (str (:username user) " joined the game as a spectator" (when request-side (str " (" request-side " perspective)")) "."))
+              watch-message (core/make-system-message-parts
+                              [{:username (:username user) :spectator true}
+                               (str " joined the game as a spectator"
+                                    (when request-side (str " (" request-side " perspective)")) ".")])
               new-app-state (swap! app-state/app-state
                                    update :lobbies handle-watch-lobby gameid uid user correct-password? watch-message request-side)
               lobby? (get-in new-app-state [:lobbies gameid])]

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -11,7 +11,7 @@
    [nr.gameboard.state :refer [game-state not-spectator?]]
    [nr.translations :refer [tr tr-span]]
    [nr.utils :refer [player-highlight-option-class render-message
-                     render-player-highlight scroll-to-bottom!]]
+                     render-system-message scroll-to-bottom!]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [reagent.dom :as rdom]))
@@ -289,12 +289,13 @@
          [show-decklists]
          [completions !input-ref state]]))))
 
-(defn format-system-timestamp [timestamp text corp runner]
-  (if (get-in @app-state [:options :log-timestamps])
-    (render-message (render-player-highlight text corp runner (str "[" (string/replace (.toLocaleTimeString (js/Date. timestamp)) #"\s\w*" "") "]")))
-    (render-message (render-player-highlight text corp runner))
-    )
-  )
+(defn format-system-timestamp [timestamp message corp runner]
+  (render-system-message
+    message corp runner
+    (when (get-in @app-state [:options :log-timestamps])
+      (str "["
+           (string/replace (.toLocaleTimeString (js/Date. timestamp)) #"\s\w*" "")
+           "]"))))
 
 (defn format-user-timestamp [timestamp user]
   (if (get-in @app-state [:options :log-timestamps])
@@ -341,11 +342,11 @@
                                 :on-mouse-out #(card-preview-mouse-out % zoom-channel)
                                 :aria-live "polite"}]
                 (map
-                  (fn [{:keys [user text timestamp]}]
+                  (fn [{:keys [user text timestamp] :as message}]
                     ^{:key timestamp}
                     (if (= user "__system__")
                        [:div.system
-                         [format-system-timestamp timestamp text @corp @runner]]
+                         [format-system-timestamp timestamp message @corp @runner]]
                        [:div.message
                         [avatar user {:opts {:size 38}}]
                         [:div.content

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -12,7 +12,7 @@
    [nr.translations :refer [tr tr-format tr-room-type tr-side]]
    [nr.utils :refer [day-word-with-time-formatter faction-icon format-date-time
                      notnum->zero safe-divide player-highlight-option-class
-                     render-message render-player-highlight set-scroll-top store-scroll-top]]
+                     render-message render-system-message set-scroll-top store-scroll-top]]
    [nr.ws :as ws]
    [reagent.core :as r]))
 
@@ -156,7 +156,8 @@
                       (fn [i msg]
                         (when-not (typing-log? msg)
                           (if (= (:user msg) "__system__")
-                            [:div.system {:key i} (render-message (render-player-highlight (:text msg) corp runner))]
+                            [:div.system {:key i}
+                             (render-system-message msg corp runner nil)]
                             [:div.message {:key i}
                              [avatar (:user msg) {:opts {:size 38}}]
                              [:div.content

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -391,6 +391,42 @@
   ([message corp runner timestamp]
   (render-input message (player-highlight-patterns corp runner timestamp))))
 
+(defn- render-username [username corp runner]
+  [:span
+   {:class (cond
+             (= username corp) "corp-username"
+             (= username runner) "runner-username"
+             :else "username")}
+   username])
+
+(defn render-message-parts [parts corp runner timestamp]
+  (let [timestamp-index
+        (first
+          (keep-indexed
+            (fn [i part]
+              (when (map? part) i))
+            parts))]
+    (into
+      [:<>]
+      (map-indexed
+        (fn [i part]
+          (set-react-key
+            i
+            (cond
+              (string? part) (render-message part)
+              (:spectator part) [:span (:username part)]
+              :else
+              (wrap-timestamp
+                (render-username (:username part) corp runner)
+                (when (= i timestamp-index) timestamp)))))
+        parts))))
+
+(defn render-system-message [message corp runner timestamp]
+  (if-let [parts (:parts message)]
+    (render-message-parts parts corp runner timestamp)
+    (render-message
+      (render-player-highlight (:text message) corp runner timestamp))))
+
 (defn player-highlight-option-class []
   (when (= "blue-red" (get-in @app-state [:options :log-player-highlight]))
     "log-player-highlight-red-blue"))

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -1,13 +1,69 @@
 (ns game.core.say-test
   (:require
-   [clojure.test :refer :all]
+   [cheshire.core :as json]
    [clojure.repl :as repl]
+   [clojure.test :refer :all]
    [game.core :as core]
    [game.core.card :refer :all]
    [game.core.commands :refer [parse-command]]
    [game.core.mark :refer :all]
+   [game.core.say :as say]
+   [game.main :as main]
    [game.test-framework :refer :all]
    [jinteki.utils :refer [command-info]]))
+
+(deftest structured-system-message-test
+  (testing "retains flattened text for backwards compatibility"
+    (let [parts [{:username "MirrorCubeSquare"} " uses Mirror."]
+          message (core/make-system-message-parts parts)]
+      (is (= "__system__" (:user message)))
+      (is (= "MirrorCubeSquare uses Mirror." (:text message)))
+      (is (= parts (:parts message)))))
+
+  (testing "system-msg keeps the acting username separate"
+    (do-game
+      (new-game)
+      (swap! state assoc-in [:corp :user :username] "MirrorCubeSquare")
+      (core/system-msg state :corp "uses Mirror")
+      (let [message (-> @state :log last :public)]
+        (is (= "__system__" (:user message)))
+        (is (= "MirrorCubeSquare uses Mirror." (:text message)))
+        (is (= [{:username "MirrorCubeSquare"} " uses Mirror."]
+               (:parts message)))))))
+
+(deftest structured-message-routing-test
+  (let [state (atom {:corp {:user {:username "Mirror[pronoun]"
+                                  :options {:pronouns "she"}}}
+                     :log []})]
+    (say/system-msg state :corp "uses [pronoun] Mirror"
+                    {:hr true :log-side [:corp :runner]})
+    (let [entry (last (:log @state))
+          message (:corp entry)]
+      (is (= #{:corp :runner} (set (keys entry))))
+      (is (= message (:runner entry)))
+      (is (= "Mirror[pronoun] uses her Mirror.[hr]" (:text message)))
+      (is (= [{:username "Mirror[pronoun]"} " uses her Mirror." "[hr]"]
+             (:parts message)))
+      (is (= (:parts message)
+             (:parts (json/parse-string (json/generate-string message) true)))))
+    (say/multi-msg state :corp {:public "uses a card" :corp "uses Mirror"})
+    (let [entry (last (:log @state))]
+      (is (= "Mirror[pronoun] uses a card." (get-in entry [:public :text])))
+      (is (= "Mirror[pronoun] uses Mirror." (get-in entry [:corp :text])))
+      (is (= [{:username "Mirror[pronoun]"} " uses a card."]
+             (get-in entry [:public :parts])))
+      (is (nil? (:runner entry))))))
+
+(deftest notification-parts-test
+  (let [state (atom {:log []})
+        parts [{:username "Mirror"} " has left the game."]]
+    (main/handle-notification state parts)
+    (main/handle-notification state nil parts)
+    (main/handle-notification state nil nil parts)
+    (is (= (repeat 3 parts) (map #(get-in % [:public :parts]) (:log @state))))
+    (main/handle-notification state "Server notification.")
+    (is (= "Server notification." (get-in @state [:log 3 :public :text])))
+    (is (nil? (get-in @state [:log 3 :public :parts])))))
 
 (deftest trash-button-logs-in-chat
   (do-game

--- a/test/clj/web/game_test.clj
+++ b/test/clj/web/game_test.clj
@@ -1,0 +1,17 @@
+(ns web.game-test
+  (:require
+   [clojure.test :refer :all]
+   [game.core.diffs :as diffs]
+   [web.game :as game]))
+
+(deftest structured-notification-diff-test
+  (let [state (atom {:log [] :history []})
+        parts [{:username "Mirror"} " has left the game."]
+        sent (atom nil)]
+    (with-redefs [game/send-state-diffs (fn [_ result] (reset! sent result))]
+      (game/handle-message-and-send-diffs! {:state state} nil nil parts))
+    (is (= parts (get-in @state [:log 0 :public :parts])))
+    (is (= "Mirror has left the game." (get-in @state [:log 0 :public :text])))
+    (is (= 1 (count (:history @state))))
+    (is (= (diffs/message-diffs {:log []} state) @sent))
+    (is (= (:hist-diff @sent) (first (:history @state))))))

--- a/test/clj/web/lobby_test.clj
+++ b/test/clj/web/lobby_test.clj
@@ -40,6 +40,40 @@
    (cond-> {:uid side :side side :user {:username side}}
      deck (assoc :deck deck))))
 
+(deftest swap-parts-test
+  (is (= [{:username "Corp"}
+          " has swapped sides. "
+          {:username "Corp"}
+          " is now Runner. "
+          {:username "Runner"}
+          " is now Corp."]
+         (lobby/swap-parts
+           [(player "Corp") (player "Runner")]
+           nil))))
+
+(deftest single-player-swap-parts-test
+  (is (= [{:username "Corp"} " has swapped sides. " "Waiting for opponent."]
+         (lobby/swap-parts [(player "Corp")] "Any Side")))
+  (is (= [{:username "Corp"} " has swapped sides. "
+          {:username "Corp"} " is now Runner. "]
+         (lobby/swap-parts [(player "Corp")] "Runner"))))
+
+(deftest departure-username-role-test
+  (let [user {:username "Mirror"}
+        room {:players [{:uid "player" :user user}]
+              :spectators [{:uid "watcher" :user user}]}
+        spectator-part (lobby/lobby-username-part room "watcher" user)
+        player-part (lobby/lobby-username-part room "player" user)]
+    (is (= {:username "Mirror" :spectator true} spectator-part))
+    (is (= {:username "Mirror"} player-part))
+    (testing "the captured role survives removal from the room"
+      (let [room-after (assoc room :spectators [])]
+        (is (nil? (lobby/spectator? "watcher" room-after)))
+        (is (true? (:spectator spectator-part)))))
+    (testing "a player no longer in the room retains the generic username part"
+      (is (= {:username "Mirror"}
+             (lobby/lobby-username-part {:players [] :spectators []} "player" user))))))
+
 (defn- auto-select
   [lobby & {:keys [options deck-found?] :or {options auto-opts deck-found? true}}]
   (with-redefs [lobby/find-deck-for-user (fn [_db deck-id _user] (when deck-found? {:_id deck-id}))

--- a/test/cljs/nr/utils_test.cljs
+++ b/test/cljs/nr/utils_test.cljs
@@ -1,0 +1,65 @@
+(ns nr.utils-test
+  (:require
+   [cljs.test :refer-macros [deftest is testing]]
+   [nr.utils :as utils]
+   [reagent.dom.server :as dom]))
+
+(defn- render-log [message corp runner timestamp]
+  (dom/render-to-static-markup
+    (utils/render-system-message message corp runner timestamp)))
+
+(deftest username-parts-test
+  (doseq [translation ["Mirror" "镜子"]
+          username ["Mirror" "MirrorCubeSquare" "Mirror[credit][!]" "<Mirror>"]]
+    (testing (str username " with card translation " translation)
+      (with-redefs [utils/card-patterns
+                    (fn [] [["Mirror" [:span {:data-card-title "Mirror"} translation]]])]
+        (let [message {:parts [{:username username} " uses Mirror and gains 1[credit].[hr]"
+                               {:username username} " joined."]}
+              html (render-log message username "Runner" "[12:00]")]
+          (is (= 1 (count (re-seq #"data-card-title=" html))))
+          (is (= 2 (count (re-seq #"corp-username" html))))
+          (is (= 1 (count (re-seq #"timestamp-wrapper-system" html))))
+          (is (= 1 (count (re-seq #"anr-icon credit" html))))
+          (is (= 1 (count (re-seq #"<hr" html))))
+          (is (= -1 (.indexOf html "smallwarning")))
+          (is (<= 0 (.indexOf html (if (= username "<Mirror>")
+                                    "&lt;Mirror&gt;" username))))
+          (is (<= 0 (.indexOf html (str ">" translation "</span>")))))))))
+
+(deftest other-username-and-warning-test
+  (with-redefs [utils/card-patterns (constantly [])]
+    (let [html (render-log {:parts ["[!]" {:username "Spectator[credit]"} " uses a command."]}
+                           "Corp" "Runner" "[12:00]")]
+      (is (<= 0 (.indexOf html "Spectator[credit]")))
+      (is (<= 0 (.indexOf html "smallwarning")))
+      (is (= -1 (.indexOf html "anr-icon")))
+      (is (<= 0 (.indexOf html "timestamp-wrapper-system"))))))
+
+(deftest spectator-plain-style-test
+  (with-redefs [utils/card-patterns
+                (fn [] [["Mirror" [:span {:data-card-title "Mirror"} "镜子"]]])]
+    (doseq [text [" joined the game as a spectator." " left the game." " has left the game."]
+            corp ["Corp" "Mirror[credit]"]]
+      (let [html (render-log {:parts [{:username "Mirror[credit]" :spectator true} text]}
+                             corp "Runner" "[12:00]")]
+        (is (<= 0 (.indexOf html "Mirror[credit]")))
+        (doseq [absent ["username" "timestamp" "[12:00]" "data-card-title" "anr-icon" "镜子"]]
+          (is (= -1 (.indexOf html absent))))))))
+
+(deftest unmarked-username-style-test
+  (with-redefs [utils/card-patterns (constantly [])]
+    (doseq [[username css-class] [["Corp" "corp-username"]
+                                ["Runner" "runner-username"]
+                                ["DepartedPlayer" "username"]]]
+      (let [html (render-log {:parts [{:username username} " has left the game."]}
+                             "Corp" "Runner" "[12:00]")]
+        (is (<= 0 (.indexOf html (str "class=\"" css-class "\""))))
+        (is (<= 0 (.indexOf html "timestamp-wrapper-system")))))))
+
+(deftest legacy-message-test
+  (with-redefs [utils/card-patterns (constantly [])]
+    (let [text "Corp gains 1[credit]."]
+      (is (= (dom/render-to-static-markup
+               (utils/render-message (utils/render-player-highlight text "Corp" "Runner" nil)))
+             (render-log {:text text} "Corp" "Runner" nil))))))


### PR DESCRIPTION
Usernames containing card names can be parsed as card links or translated card text in system messages. For example, `MirrorCubeSquare` can have its `Mirror` prefix replaced in spectator notifications or repeated names in side-swap messages. Icon and special-message tokens inside a username can also be interpreted as formatting.

Keep usernames separate from renderable text using structured system-message parts. Only message text goes through card, icon, special-code, and pronoun processing. Apply this to lobby events, side swaps, commands, game notifications, and saved game logs. Retain the flattened `:text` field and the existing rendering fallback for older messages and replays.

Preserve player highlighting and timestamps, including after a player leaves. Explicitly mark spectator names before removing them from the lobby so their join/leave messages remain plain and have no player timestamp.

Validation on current `master` (`d94d18cdc`):
- Backend: `game.core.say-test`, `web.lobby-test`, and `web.game-test` — 13 tests, 279 assertions, no failures or errors.
- Browser: `nr.utils-test` — 5 tests, 117 assertions, all passing in Chromium. Covers translated card names, icon/special tokens, HTML escaping, timestamps, spectator styling, departed players, and legacy messages.
- Shadow CLJS `release` of `:app` — successful, zero compiler warnings.
- `git diff --check` — clean.


